### PR TITLE
Trailing slashes on sitemap URLS

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -61,9 +61,6 @@ module.exports = function(eleventyConfig) {
   eleventyConfig.addFilter('contentfilter', code => code);
       //.replace(/COVID-19/g,'COVID&#8288;-&#8288;19'));
 
-  
-  eleventyConfig.addFilter('removetrailingslash', code => code.replace(/\/$/,''));
-
   eleventyConfig.addFilter('lang', metatags => metatags.toString().includes('lang-es') ? 'es-ES' : 'en-US');
 
   eleventyConfig.addFilter('publishdateorfiledate', page => page.data.publishdate || page.date.toISOString());

--- a/pages/sitemap/sitemap.njk
+++ b/pages/sitemap/sitemap.njk
@@ -6,7 +6,7 @@ eleventyExcludeFromCollections: true
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 {% for page in collections.all %}{% if page.data.addtositemap %}
     <url>
-        <loc>https://covid19.ca.gov{{ page.url | url | removetrailingslash }}</loc>
+        <loc>https://covid19.ca.gov{{ page.url | url }}</loc>
         <lastmod>{{ page | publishdateorfiledate }}</lastmod>
     </url>
 {% endif %}{% endfor %}


### PR DESCRIPTION
Our URLs have trailing slashes.  Updating Sitemap to match so search results don't contain dupes.