### PR TITLE
changed toolkit link to go directly to toolkit site.

### DIFF
--- a/pages/_includes/page.njk
+++ b/pages/_includes/page.njk
@@ -122,7 +122,7 @@
 				<a href="/healthcare/#top" class="list-group-item list-group-item-action guide {{page | pageActive('healthcare')}}"><span class="ca-gov-icon-arrow-next"></span> Health care </a>
 				<a href="/safety-in-public-places/#top" class="list-group-item list-group-item-action guide {{page | pageActive('safety-in-public-places')}}"><span class="ca-gov-icon-arrow-next"></span> Public places</a>
         <a href="/state-local-resources/#top" class="list-group-item list-group-item-action guide {{page | pageActive('state-local-resources')}}"><span class="ca-gov-icon-arrow-next"></span> Get local information</a>
-        <a href="/toolkit/#top" class="list-group-item list-group-item-action guide {{page | pageActive('toolkit')}}"><span class="ca-gov-icon-arrow-next"></span> Your Actions Save Lives</a>
+        <a href="https://toolkit.covid19.ca.gov/" class="list-group-item list-group-item-action guide"><span class="ca-gov-icon-arrow-next"></span> Your Actions Save Lives</a>
 			</div>
 			</div>
 		</div>


### PR DESCRIPTION
Changed toolkit link to point directly to the toolkit site...https://toolkit.covid19.ca.gov/