### PR TITLE
non roman path support

### DIFF
--- a/pages/rootcopy/web.config
+++ b/pages/rootcopy/web.config
@@ -36,7 +36,7 @@
       <rules>
         <rule name="AddTrailingSlash BeforeStaticRewrites" stopProcessing="true">
           <match url="(^[^.]*[^/]$)" />
-          <action type="Redirect" url="{R:1}/" />
+          <action type="Redirect" url="{UrlEncode:{R:1}}/" />
         </rule>
         <rule name="Static Rewrite Rule" stopProcessing="true">
           <match url=".*" />


### PR DESCRIPTION
support for arabic or non-roman paths.  The config for adding the trailing slash was decoding the url.