### PR TITLE
Adding "noindex" to "do not crawl" pages

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -215,6 +215,7 @@ module.exports = function(eleventyConfig) {
 
 
   eleventyConfig.addFilter('jsonparse', json => JSON.parse(json));
+  eleventyConfig.addFilter('includes', (items,value) => (items || []).includes(value));
 
   const getLangRecord = tags => 
     langData.languages.filter(x=>x.enabled&&(tags || []).includes(x.wptag)).concat(langData.languages[0])[0];

--- a/pages/_includes/page.njk
+++ b/pages/_includes/page.njk
@@ -6,6 +6,9 @@
   <meta name="description" content="{{ meta | safe }}">
   <meta name="author" content="{{ author | safe }}">
   <meta name="keywords" content="covid19, coronavirus, covid19, covid-19, california">
+  {%- if tags | includes("do-not-crawl") %}
+  <meta name="robots" content="noindex">
+  {%- endif %}
   <title>{{ title | safe }} - Coronavirus COVID-19 Response</title>
   
   <meta content="{{ title | safe }}" property="og:title">


### PR DESCRIPTION
pages marked "do not crawl" are already hidden from the sitemap, but they should have the "noindex" meta just in case they are found.