### PR TITLE
Standard postfix access for footer-data

### DIFF
--- a/pages/_data/langFiles.json
+++ b/pages/_data/langFiles.json
@@ -1,34 +1,26 @@
 {
   "en-US" : {
-    "Footer" : "footer-data-english.json",
     "HomeLinks": "homepage-links-english.json"
   },
   "es-ES" : {
-    "Footer" : "footer-data-spanish.json",
     "HomeLinks": "homepage-links-spanish.json"
   },
   "ar" : {
-    "Footer" : "footerdata-arabic.json",
     "HomeLinks": "home-page-links-arabic.json"
   },
   "vi" : {
-    "Footer" : "footer-data-vi.json",
     "HomeLinks": "home-page-links-vi.json"
   },
   "tl" : {
-    "Footer" : "footer-data-tl.json",
     "HomeLinks": "homepage-links-tl.json"
   },
   "ko" : {
-    "Footer" : "footer-data-ko.json",
     "HomeLinks": "homepage-links-ko.json"
   },
   "zh-Hans" : {
-    "Footer" : "footer-data-zh-hans.json",
     "HomeLinks": "homepage-links-zh-hans.json"
   },
   "zh-Hant" : {
-    "Footer" : "footer-data-zh-hant.json",
     "HomeLinks": "homepage-links-zh-hant.json"
   }
 }

--- a/pages/_includes/footer.njk
+++ b/pages/_includes/footer.njk
@@ -8,7 +8,7 @@
   gtag('config','UA-21974567-38');
 </script>
 
-{% set JSONraw %}{% include "../wordpress-posts/" + langFiles[tags | lang].Footer %}{% endset %}
+{% set JSONraw %}{% include "../wordpress-posts/footer-data" + tags | langFilePostfix + ".json" %}{% endset %}
 {% set JSON = JSONraw | jsonparse %}
 {% set FooterLinks1 = JSON.Table1 %}
 {% set FooterLinks2 = JSON.Table2 %}

--- a/pages/_includes/header.njk
+++ b/pages/_includes/header.njk
@@ -1,4 +1,4 @@
-{% set JSONraw %}{% include "../wordpress-posts/" + langFiles[tags | lang].Footer %}{% endset %}
+{% set JSONraw %}{% include "../wordpress-posts/footer-data" + tags | langFilePostfix + ".json" %}{% endset %}
 {% set JSON = JSONraw | jsonparse %}
 {% set Terms = JSON.Table3 %}
 <header>

--- a/pages/_includes/page.njk
+++ b/pages/_includes/page.njk
@@ -46,7 +46,7 @@
 </head>
 <body>
 {% include "header.njk" %}
-{% set JSONraw %}{% include "../wordpress-posts/" + langFiles[tags | lang].Footer %}{% endset %}
+{% set JSONraw %}{% include "../wordpress-posts/footer-data" + tags | langFilePostfix + ".json" %}{% endset %}
 {% set JSON = JSONraw | jsonparse %}
 {% set Terms = JSON.Table3 %}
 <main id="main">

--- a/pages/wordpress-posts/footer-data-ar.json
+++ b/pages/wordpress-posts/footer-data-ar.json
@@ -1,0 +1,63 @@
+{
+  "Table1": [
+    {
+      "Name": "قسم الصحة العامة",
+      "URL": "https://www.cdph.ca.gov/Programs/CID/DCDC/Pages/Immunization/ncov2019.aspx"
+    },
+    {
+      "Name": "غرفة أخبار المحافظ",
+      "URL": "https://www.gov.ca.gov/newsroom/"
+    },
+    {
+      "Name": "الخط الساخن COVID19 على مستوى الولاية",
+      "URL": "/hotline-ar/"
+    },
+    {
+      "Name": "إمكانية الوصول",
+      "URL": "https://www.ca.gov/accessibility/"
+    },
+    {
+      "Name": "سياسة الخصوصية",
+      "URL": "https://www.ca.gov/privacy-policy/"
+    },
+    {
+      "Name": "ردود الفعل",
+      "URL": "https://www.surveymonkey.com/r/COVID19CAGOV"
+    }
+  ],
+  "Table2": [
+    {
+      "Name": "الصفحة الرئيسية",
+      "URL": "/"
+    },
+    {
+      "Name": "بحث",
+      "URL": "/search/#top"
+    },
+    {
+      "Name": "عد إلى الأعلى",
+      "URL": "#top"
+    },
+    {
+      "Name": "قائمة طعام",
+      "URL": "#side-nav"
+    }
+  ],
+  "Table3": [
+    {
+      "Text": "الموقع الرسمي لحكومة ولاية كاليفورنيا"
+    },
+    {
+      "Text": "تخطى إلى المحتوى الرئيسي"
+    },
+    {
+      "Text": "استجابة كاليفورنيا لفيروس كورونا (COVID-19)"
+    },
+    {
+      "Text": "بحث"
+    },
+    {
+      "Text": "اختار اللغة"
+    }
+  ]
+}

--- a/pages/wordpress-posts/footer-data-es.json
+++ b/pages/wordpress-posts/footer-data-es.json
@@ -1,0 +1,66 @@
+{
+  "Table1": [
+    {
+      "Name": "Departamento de Salud Pública",
+      "URL": "https://www.cdph.ca.gov/Programs/CID/DCDC/Pages/Immunization/ncov2019.aspx"
+    },
+    {
+      "Name": "Sala de redacción del Gobernador",
+      "URL": "https://www.gov.ca.gov/newsroom/"
+    },
+    {
+      "Name": "Línea directa de COVID-19 Estatal",
+      "URL": "/hotline-es/"
+    },
+    {
+      "Name": "Accesibilidad",
+      "URL": "https://www.ca.gov/accessibility/"
+    },
+    {
+      "Name": "Política de Privacidad",
+      "URL": "https://www.ca.gov/privacy-policy/"
+    },
+    {
+      "Name": "Comentarios",
+      "URL": "https://www.surveymonkey.com/r/COVID19CAGOV"
+    }
+  ],
+  "Table2": [
+    {
+      "Name": "Inicio",
+      "URL": "/"
+    },
+    {
+      "Name": "Buscar",
+      "URL": "/search/#top"
+    },
+    {
+      "Name": "Volver al principio",
+      "URL": "#top"
+    },
+    {
+      "Name": "Menú",
+      "URL": "#side-nav"
+    }
+  ],
+  "Table3": [
+    {
+      "Text": "Sitio Web Oficial del Gobierno del Estado de California"
+    },
+    {
+      "Text": "Saltar al contenido principal"
+    },
+    {
+      "Text": "Respuesta del coronavirus de California (COVID-19)"
+    },
+    {
+      "Text": "Buscar"
+    },
+    {
+      "Text": "Seleccione el idioma"
+    },
+    {
+      "Text": "Última actualización"
+    }
+  ]
+}

--- a/pages/wordpress-posts/footer-data.json
+++ b/pages/wordpress-posts/footer-data.json
@@ -1,0 +1,66 @@
+{
+  "Table1": [
+    {
+      "Name": "Department of Public Health",
+      "URL": "https://www.cdph.ca.gov/Programs/CID/DCDC/Pages/Immunization/ncov2019.aspx"
+    },
+    {
+      "Name": "Governor’s Newsroom",
+      "URL": "https://www.gov.ca.gov/newsroom/"
+    },
+    {
+      "Name": "Statewide COVID19 Hotline",
+      "URL": "/hotline/"
+    },
+    {
+      "Name": "Accessibility",
+      "URL": "https://www.ca.gov/accessibility/"
+    },
+    {
+      "Name": "Privacy Policy",
+      "URL": "https://www.ca.gov/privacy-policy/"
+    },
+    {
+      "Name": "Feedback",
+      "URL": "https://www.surveymonkey.com/r/COVID19CAGOV"
+    }
+  ],
+  "Table2": [
+    {
+      "Name": "Home",
+      "URL": "/"
+    },
+    {
+      "Name": "Search",
+      "URL": "/search/"
+    },
+    {
+      "Name": "Back to top",
+      "URL": "#top"
+    },
+    {
+      "Name": "Menu",
+      "URL": "#side-nav"
+    }
+  ],
+  "Table3": [
+    {
+      "Text": "Official California State Government Website"
+    },
+    {
+      "Text": "Skip to main content"
+    },
+    {
+      "Text": "California Coronavirus (COVID-19) Response"
+    },
+    {
+      "Text": "Search"
+    },
+    {
+      "Text": "Select language"
+    },
+    {
+      "Text": "Last updated"
+    }
+  ]
+}


### PR DESCRIPTION
Using postfix naming to assume footer data file.

Requires slug renames in WP to complete.

footer-data-english -> footer-data
footer-data-spanish -> footer-data-es
footerdata-arabic -> footer-data-ar