### PR TITLE
Fixing Immigrant guide pagenav

### DIFF
--- a/pages/_data/pageNav.json
+++ b/pages/_data/pageNav.json
@@ -527,8 +527,8 @@
       },
       "lang-es": {
         "title": "Guía para los Californianos inmigrantes",
-        "slug": "guia-californianos-inmigrantes",
-        "url": "/guia-californianos-inmigrantes/"
+        "slug": "guide-immigrant-californians-es",
+        "url": "/guide-immigrant-californians-es/"
       },
       "lang-ar": {
         "url": "/guide-immigrant-californians-ar/",


### PR DESCRIPTION
using the -es link for Spanish page, which was already redirecting anyway