### PR TITLE
redirecting wordpressposts

### DIFF
--- a/pages/manual-content/web.config.njk
+++ b/pages/manual-content/web.config.njk
@@ -32,6 +32,10 @@ eleventyExcludeFromCollections: true
         </rewriteMap>
       </rewriteMaps>
       <rules>
+        <rule name="FolderRemoval1" stopProcessing="true">
+          <match url="wordpress-posts/(.*)" />
+          <action type="Redirect" url="/{R:1}" />
+        </rule>
         <rule name="AddTrailingSlash BeforeStaticRewrites" stopProcessing="true">
           <match url="(^[^.]*[^/]$)" />
           <action type="Redirect" url="{UrlEncode:{R:1}}/" />
@@ -81,12 +85,7 @@ eleventyExcludeFromCollections: true
         <remove name="X-Powered-By" />
       </customHeaders>
     </httpProtocol>
-    <httpErrors errorMode="Custom" defaultResponseMode="File" >
-      <remove statusCode="404" />
-      <remove statusCode="500" />
-      <error statusCode="404" path="404\index.html" />
-      <error statusCode="500" path="500\index.html" />
-    </httpErrors>
+
   </system.webServer>
   <location path="img">
     <system.webServer>


### PR DESCRIPTION
Removing "/wordpressposts/" from all urls
https://github.com/cagov/covid19/issues/587