### PR TITLE
fixing canonical links for translated main

### DIFF
--- a/pages/_includes/main.njk
+++ b/pages/_includes/main.njk
@@ -30,7 +30,7 @@
     <meta content="https://covid19.ca.gov/" property="og:url"/>
     <meta name="twitter:card" content="summary_large_image"/>
     <link rel="preconnect" href="https://www.google-analytics.com/">
-    <link href="https://covid19.ca.gov/" rel="canonical"/>
+    <link href="https://covid19.ca.gov{{ page.url }}" rel="canonical">
 
     {% include "favicons.njk" %}
     <link rel="manifest" href="/img/manifest.json"/>


### PR DESCRIPTION
Looks like the /lang/ root pages are incorrectly reporting the english page as a canonical.

https://search.google.com/search-console/inspect?resource_id=https%3A%2F%2Fcovid19.ca.gov%2F&id=73KBAITSYX7oO0a9vMMY_Q&hl=en