### PR TITLE
turning off sitemap for search translated pages

### DIFF
--- a/pages/translated-posts/search-ar.html
+++ b/pages/translated-posts/search-ar.html
@@ -5,7 +5,7 @@ meta: "بحث في موقع Covid19 الإلكتروني."
 author: "State of California"
 publishdate: "2020-06-16T23:43:04.000Z"
 tags: ["lang-ar"]
-addtositemap: true
+addtositemap: false
 ---
  <h2>ابحث في هذا الموقع الإلكتروني</h2>    <label id="SearchInput" for="q"> أدخل نص البحث </label> <form class="form-inline"> 	<input type="search" class="form-control col-md-6" id="q" name="q" aria-labelledby="SearchInput" autofocus="" required=""> <button type="submit" class="btn btn-primary"> بحث </button>	   </form>
 

--- a/pages/translated-posts/search-es.html
+++ b/pages/translated-posts/search-es.html
@@ -5,7 +5,7 @@ meta: "Busque en el sitio web de COVID-19."
 author: "State of California"
 publishdate: "2020-06-16T23:43:04.000Z"
 tags: ["lang-es"]
-addtositemap: true
+addtositemap: false
 ---
  <h2>Busque en este sitio web</h2>    <label id="SearchInput" for="q"> Escriba el texto que desea buscar </label> <form class="form-inline"> 	<input type="search" class="form-control col-md-6" id="q" name="q" aria-labelledby="SearchInput" autofocus="" required=""> <button type="submit" class="btn btn-primary"> Buscar </button>	   </form>
 

--- a/pages/translated-posts/search-ko.html
+++ b/pages/translated-posts/search-ko.html
@@ -5,7 +5,7 @@ meta: "Covid19 웹사이트를 검색하십시오."
 author: "State of California"
 publishdate: "2020-06-16T23:43:04.000Z"
 tags: ["lang-ko"]
-addtositemap: true
+addtositemap: false
 ---
  <h2>이 웹사이트를 검색하십시오</h2>    <label id="SearchInput" for="q"> 검색 항목을 입력하십시오 </label> <form class="form-inline"> 	<input type="search" class="form-control col-md-6" id="q" name="q" aria-labelledby="SearchInput" autofocus="" required=""> <button type="submit" class="btn btn-primary"> 검색하십시오 </button>	   </form>
 

--- a/pages/translated-posts/search-tl.html
+++ b/pages/translated-posts/search-tl.html
@@ -5,7 +5,7 @@ meta: "Maghanap sa website ng Covid19."
 author: "State of California"
 publishdate: "2020-06-16T23:43:04.000Z"
 tags: ["lang-tl"]
-addtositemap: true
+addtositemap: false
 ---
  <h2>Maghanap sa website na ito</h2>    <label id="SearchInput" for="q"> Ilagay ang text ng iyong paghahanap </label> <form class="form-inline"> 	<input type="search" class="form-control col-md-6" id="q" name="q" aria-labelledby="SearchInput" autofocus="" required=""> <button type="submit" class="btn btn-primary"> Paghahanap </button>	   </form>
 

--- a/pages/translated-posts/search-vi.html
+++ b/pages/translated-posts/search-vi.html
@@ -5,7 +5,7 @@ meta: "Tìm kiếm trang web về Covid19."
 author: "State of California"
 publishdate: "2020-06-16T23:43:04.000Z"
 tags: ["lang-vi"]
-addtositemap: true
+addtositemap: false
 ---
  <h2>Tìm kiếm trang web này</h2>    <label id="SearchInput" for="q"> Nhập văn bản tìm kiếm </label> <form class="form-inline"> 	<input type="search" class="form-control col-md-6" id="q" name="q" aria-labelledby="SearchInput" autofocus="" required=""> <button type="submit" class="btn btn-primary"> Tìm kiếm </button>	   </form>
 

--- a/pages/translated-posts/search-zh-hans.html
+++ b/pages/translated-posts/search-zh-hans.html
@@ -5,7 +5,7 @@ meta: "搜索COVID-19网站。"
 author: "State of California"
 publishdate: "2020-06-16T23:43:04.000Z"
 tags: ["lang-zh-Hans"]
-addtositemap: true
+addtositemap: false
 ---
  <h2>搜索该网站。</h2><label id="SearchInput" for="q"> 输入您的搜索文字 </label> <form class="form-inline"><input type="search" class="form-control col-md-6" id="q" name="q" aria-labelledby="SearchInput" autofocus="" required=""> <button type="submit" class="btn btn-primary"> 搜索 </button>	   </form>
 

--- a/pages/translated-posts/search-zh-hant.html
+++ b/pages/translated-posts/search-zh-hant.html
@@ -5,7 +5,7 @@ meta: "搜尋新型冠狀病毒網站。"
 author: "State of California"
 publishdate: "2020-06-16T23:43:04.000Z"
 tags: ["lang-zh-Hant"]
-addtositemap: true
+addtositemap: false
 ---
  <h2>搜尋本網站</h2><label id="SearchInput" for="q"> 輸入搜尋文本 </label> <form class="form-inline"><input type="search" class="form-control col-md-6" id="q" name="q" aria-labelledby="SearchInput" autofocus="" required=""> <button type="submit" class="btn btn-primary"> 搜尋 </button>	   </form>
 


### PR DESCRIPTION
Translated pages need to inherit the tags of their original pages.  This is a temporary fix to seach pages not being removed from sitemap.