### PR TITLE
Adding redirect for the pdf folder to blob storage

### DIFF
--- a/pages/manual-content/web.config.njk
+++ b/pages/manual-content/web.config.njk
@@ -40,6 +40,10 @@ eleventyExcludeFromCollections: true
           <match url="(?:wordpress-posts|manual-content)/(.*)" />
           <action type="Redirect" url="/{R:1}" />
         </rule>
+        <rule name="PdfToBlobStorage" stopProcessing="true">
+          <match url="^pdf/(.*)" />
+          <action type="Redirect" url="https://files.covid19.ca.gov/pdf/{R:1}" appendQueryString="false" />
+        </rule>
         <rule name="AddTrailingSlash BeforeStaticRewrites" stopProcessing="true">
           <match url="(^[^.]*[^/]$)" />
           <action type="Redirect" url="{UrlEncode:{R:1}}/" />


### PR DESCRIPTION
This will update the web config to point all requests from "https://covid19.ca.gov/pdf/..." to "https://files.covid19.ca.gov/pdf/..."