### PR TITLE
Cross-platform dev support with Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4072,6 +4072,12 @@
         "is-symbol": "^1.0.2"
       }
     },
+    "es6-object-assign": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
+      "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=",
+      "dev": true
+    },
     "escalade": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.0.2.tgz",
@@ -8598,6 +8604,15 @@
         "picomatch": "^2.2.1"
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
     "recursive-copy": {
       "version": "2.0.10",
       "resolved": "https://registry.npmjs.org/recursive-copy/-/recursive-copy-2.0.10.tgz",
@@ -9411,6 +9426,28 @@
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
       "integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
       "dev": true
+    },
+    "shelljs": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
+    },
+    "shx": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.2.tgz",
+      "integrity": "sha512-aS0mWtW3T2sHAenrSrip2XGv39O9dXIFUqxAEWHEOS1ePtGIBavdPJY1kE2IHl14V/4iCbUiNDPGdyYTtmhSoA==",
+      "dev": true,
+      "requires": {
+        "es6-object-assign": "^1.0.3",
+        "minimist": "^1.2.0",
+        "shelljs": "^0.8.1"
+      }
     },
     "sigmund": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "rollup": "^2.23.0",
     "rollup-plugin-terser": "^6.1.0",
     "sass-loader": "^8.0.2",
+    "shx": "^0.3.2",
     "style-loader": "^1.2.1",
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.12"
@@ -45,7 +46,7 @@
   "scripts": {
     "start": "npm run serve",
     "serve": "npx @11ty/eleventy --serve --quiet --formats=html,njk --input ./pages --output ./docs",
-    "build": "npm run build:rollup && npm run build:ancient && webpack --mode production && cp ./docs/css/build/built.css ./pages/_includes/built.css",
+    "build": "npm run build:rollup && npm run build:ancient && webpack --mode production && shx cp ./docs/css/build/built.css ./pages/_includes/built.css",
     "build:rollup": "rollup --config src/js/rollup.config.js && npm run build:alerts && npm run build:survey && npm run build:telehealth && npm run build:video && npm run build:whatwhere && npm run build:plasma",
     "build:alerts": "rollup --config src/js/alerts/rollup.config.js",
     "build:survey": "rollup --config src/js/survey/rollup.config.js",
@@ -55,7 +56,7 @@
     "build:video": "rollup --config src/js/video/rollup.config.js",
     "build:ancient": "webpack --config src/js/webpack.config.es5.js",
     "watch": "onchange 'src/**' -- npm run rebuild",
-    "rebuild": "npm run build && touch pages/_includes/main.njk",
+    "rebuild": "npm run build && shx touch pages/_includes/main.njk",
     "local": "npm run build && run-p watch start",
     "compress:img": "cd src/build && node img.js"
   },


### PR DESCRIPTION
This change adds cross-platform support for developers of the site. No code changes will be necessary when switching between Mac, Linux, and Windows. 

It's a small change, but I didn't want to commit directly to `trilogydev` and risk breaking everyone's local builds. Hence, a pull request.

Note that this change brings in a new devDependency, [shx](https://github.com/shelljs/shx). You'll probably need to `npm i` before this will work.