### PR TITLE
moving 11ty build args to js

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -467,5 +467,12 @@ module.exports = function(eleventyConfig) {
   });
 
   eleventyConfig.htmlTemplateEngine = "njk,findaccordions,findlinkstolocalize";
+  return {
+    templateFormats: ["html", "njk"],
+    dir: {
+      input: "pages",
+      output: "docs",
+    }
+  };
 };
 

--- a/.github/workflows/azure-static-web-apps-lively-river-07342ea1e.yml
+++ b/.github/workflows/azure-static-web-apps-lively-river-07342ea1e.yml
@@ -20,8 +20,6 @@ jobs:
           submodules: true
       - name: Build 11ty
         uses: cagov/actions-eleventy@2.0
-        with:
-          args: --formats=html,njk --input ./pages --output ./docs
       - name: Build And Deploy
         id: builddeploy
         uses: Azure/static-web-apps-deploy@v0.0.1-preview

--- a/.github/workflows/eleventy_build.yml
+++ b/.github/workflows/eleventy_build.yml
@@ -16,8 +16,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Build
         uses: cagov/actions-eleventy@2.0
-        with:
-          args: --formats=html,njk --input ./pages --output ./docs
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "scripts": {
     "start": "npm run serve",
-    "serve": "npx @11ty/eleventy --serve --quiet --formats=html,njk --input ./pages --output ./docs",
+    "serve": "npx @11ty/eleventy --serve --quiet",
     "build": "npm run build:rollup && npm run build:ancient && webpack --mode production && cp ./docs/css/build/built.css ./pages/_includes/built.css",
     "build:rollup": "rollup --config src/js/rollup.config.js && npm run build:alerts && npm run build:survey && npm run build:telehealth && npm run build:plasma",
     "build:alerts": "rollup --config src/js/alerts/rollup.config.js",


### PR DESCRIPTION
Moves the arguments for 11ty from the command line to the .js file.


Part of the work done in this PR...
https://github.com/cagov/covid19/pull/1250/