### PR TITLE
Using ES6 Export Default

### DIFF
--- a/src/js/alerts/rollup.config.js
+++ b/src/js/alerts/rollup.config.js
@@ -2,7 +2,7 @@ import resolve from '@rollup/plugin-node-resolve';
 import json from '@rollup/plugin-json';
 import { terser } from 'rollup-plugin-terser';
 
-module.exports = {
+export default {
   input: 'src/js/alerts/index.js',
   output: {
     file: 'pages/_includes/alerts.js',

--- a/src/js/es5.js
+++ b/src/js/es5.js
@@ -10,4 +10,4 @@ import './feature-detect/webp.js';
 import applyAccordionListeners from './tracking-you/index.js';
 window.onload = (event) => {
   applyAccordionListeners();
-}
+};

--- a/src/js/plasma/rollup.config.js
+++ b/src/js/plasma/rollup.config.js
@@ -2,7 +2,7 @@ import resolve from '@rollup/plugin-node-resolve';
 import json from '@rollup/plugin-json';
 import { terser } from 'rollup-plugin-terser';
 
-module.exports = {
+export default {
   input: 'src/js/plasma/index.js',
   output: {
     file: 'pages/_includes/plasma.js',

--- a/src/js/rollup.config.js
+++ b/src/js/rollup.config.js
@@ -1,7 +1,7 @@
 import resolve from '@rollup/plugin-node-resolve';
 import { terser } from 'rollup-plugin-terser';
 
-module.exports = {
+export default {
   input: 'src/js/index.js',
   output: {
     file: 'pages/_includes/built.js',

--- a/src/js/survey/rollup.config.js
+++ b/src/js/survey/rollup.config.js
@@ -1,7 +1,7 @@
 import resolve from '@rollup/plugin-node-resolve';
 import { terser } from 'rollup-plugin-terser';
 
-module.exports = {
+export default {
   input: 'src/js/survey/index.js',
   output: {
     file: 'pages/_includes/survey.js',

--- a/src/js/telehealth/rollup.config.js
+++ b/src/js/telehealth/rollup.config.js
@@ -2,7 +2,7 @@ import resolve from '@rollup/plugin-node-resolve';
 import json from '@rollup/plugin-json';
 import { terser } from 'rollup-plugin-terser';
 
-module.exports = {
+export default {
   input: 'src/js/telehealth/index.js',
   output: {
     file: 'pages/_includes/telehealth.js',


### PR DESCRIPTION
Using ES6 export default since we are using Babel.

This is one of the changes in the build system PR.

https://github.com/cagov/covid19/pull/1250

Build tested on browserstack in IE11.