### PR TITLE
Combining Rollups into one file

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "watch": "onchange 'src/**' -- npm run rebuild",
     "rebuild": "npm run build && touch pages/_includes/main.njk",
     "local": "npm run build && run-p watch start",
-    "compress:img": "cd src/build && node img.js"
+    "compress:img": "cd src/build && node img.js",
+    "new:build:js:all": "rollup --config src/js/rollup.config.all.js"
   },
   "repository": {
     "type": "git",

--- a/src/js/rollup.config.all.js
+++ b/src/js/rollup.config.all.js
@@ -1,0 +1,14 @@
+import alerts from './alerts/rollup.config';
+import esm from './rollup.config';
+import plasma from './plasma/rollup.config';
+import survey from './survey/rollup.config';
+import telehealth from './telehealth/rollup.config';
+
+// Combines all the Rollup files into one.
+export default [
+  alerts,
+  esm,
+  plasma,
+  survey,
+  telehealth
+];


### PR DESCRIPTION
Adds a new Rollup file (_src/js/rollup.config.all.js_), which references all the other Rollup files. Using this combined file speeds up the build process by removing a lot of execution boilerplate. Only one single Rollup call is needed, which means fewer hops through `npm run`, etc. 

None of the existing Rollup files are modified in any way. You can continue using them as-is. This should be a fairly safe change. 

This change is an incremental chunk of the larger PR #1250. Unlike #1250, here I'm **not** including the new ES5 config within this all-Rollup file (see related PR #1285). This means you could put this new file into service within the existing build system, no fuss. When ready, you could swap `npm run build:rollup` with the new command here, `npm run new:build:js:all`.