### PR TITLE
Rollup for ES5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1222,6 +1222,31 @@
         "fastq": "^1.6.0"
       }
     },
+    "@rollup/plugin-babel": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-babel/-/plugin-babel-5.1.0.tgz",
+      "integrity": "sha512-zXBEYmfiLAMvB+ZBa6m/q9hsQYAq1sUFdjuP1F6C2pf6uQcpHwAWQveZgzS63zXdKPUYHD3Dr7BhjCqcr0bbLw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.7.4",
+        "@rollup/pluginutils": "^3.0.8"
+      }
+    },
+    "@rollup/plugin-commonjs": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-14.0.0.tgz",
+      "integrity": "sha512-+PSmD9ePwTAeU106i9FRdc+Zb3XUWyW26mo5Atr2mk82hor8+nPwkztEjFo8/B1fJKfaQDg9aM2bzQkjhi7zOw==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.0.8",
+        "commondir": "^1.0.1",
+        "estree-walker": "^1.0.1",
+        "glob": "^7.1.2",
+        "is-reference": "^1.1.2",
+        "magic-string": "^0.25.2",
+        "resolve": "^1.11.0"
+      }
+    },
     "@rollup/plugin-json": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-4.1.0.tgz",
@@ -5982,6 +6007,15 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
       "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
     },
+    "is-reference": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+      "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "*"
+      }
+    },
     "is-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
@@ -6524,6 +6558,15 @@
       "version": "1.24.1",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.24.1.tgz",
       "integrity": "sha512-CgnIMKAWT0ghcuWFfCWBnWGOddM0zu6c4wZAWmD0NN7MZTnro0+833DF6tJep+xlxRPg4KtsYEHYLfTMBQKwYg=="
+    },
+    "magic-string": {
+      "version": "0.25.7",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
+      "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "dev": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.4"
+      }
     },
     "make-dir": {
       "version": "2.1.0",
@@ -9845,6 +9888,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
+    },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
     },
     "spdx-correct": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   "devDependencies": {
     "@babel/core": "^7.11.1",
     "@babel/preset-env": "^7.11.0",
+    "@rollup/plugin-babel": "^5.1.0",
+    "@rollup/plugin-commonjs": "^14.0.0",
     "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^8.4.0",
     "acorn": ">=7.4.0",
@@ -57,7 +59,8 @@
     "watch": "onchange 'src/**' -- npm run rebuild",
     "rebuild": "npm run build && touch pages/_includes/main.njk",
     "local": "npm run build && run-p watch start",
-    "compress:img": "cd src/build && node img.js"
+    "compress:img": "cd src/build && node img.js",
+    "new:build:js:ancient": "rollup --config src/js/rollup.config.es5.js"
   },
   "repository": {
     "type": "git",

--- a/src/js/rollup.config.es5.js
+++ b/src/js/rollup.config.es5.js
@@ -1,0 +1,41 @@
+import path from 'path';
+import resolve from '@rollup/plugin-node-resolve';
+import { terser } from 'rollup-plugin-terser';
+import commonjs from '@rollup/plugin-commonjs';
+import babel from '@rollup/plugin-babel';
+
+export default {
+  input: 'src/js/es5.js',
+  output: {
+    file: 'docs/js/es5.js',
+    format: 'cjs'
+  },
+  moduleContext: {
+    // whatwg-fetch angers Rollup due to ancient use of 'this'.
+    // This fix is not essential to function. It removes a warning during the build process.
+    // https://rollupjs.org/guide/en/#error-this-is-undefined
+    [path.resolve('./node_modules/whatwg-fetch/fetch.js')]: 'window'
+  },
+  plugins: [
+    resolve({
+      browser: true
+    }),
+    commonjs(),
+    babel({
+      babelHelpers: 'bundled',
+      exclude: ['node_modules/@babel/**'],
+      presets: [
+        [
+          '@babel/preset-env',
+          {
+            modules: false,
+            targets: {
+              browsers: '> 1%'
+            }
+          }
+        ]
+      ]
+    }),
+    terser()
+  ]
+};


### PR DESCRIPTION
Adds a new Rollup file (_src/js/rollup.config.es5.js_) to process legacy ES5 Javascript for older browsers. The intention is to eventually replace the current Webpack file (_src/js/webpack.config.es5.js_) which does the same. Phasing out Webpack would allow us to run all JS through Rollup, a significant simplification within the build process. Compared to the Webpack file, this new Rollup file still uses a very similar Babel configuration. 

This should be a relatively safe change as no existing functionality is touched. Yet. I'm assuming we'll want to test this new file more thoroughly before putting it into real service, to ensure nothing breaks. That prospective testing can be done here via the new `npm run new:build:js:ancient` without breaking the current site. I've done preliminary testing in IE11 to my satisfaction. But I don't know where the gremlins hide, and I'd be keen to learn if we need to check any other legacy browsers.

This change is an incremental chunk of the larger PR #1250. 