### PR TITLE
Inject environment variables into templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 node_modules
 docs
 pages/_includes/built.css
+pages/_includes/development.css
 pages/_includes/built.js
 pages/_includes/alerts.js
 pages/_includes/survey.js

--- a/pages/_data/env.js
+++ b/pages/_data/env.js
@@ -1,0 +1,4 @@
+module.exports = {
+  // dev: Resolves to true in development environment, otherwise false.
+  dev: (process.env.NODE_ENV === 'development')
+};

--- a/pages/_includes/main.njk
+++ b/pages/_includes/main.njk
@@ -48,12 +48,17 @@
     {% for item in page | getAltPageRows -%}
       <link rel="alternate" hreflang="{{item.langcode}}" href="https://covid19.ca.gov{{item.url}}">
     {%- endfor %}
+    
     {% set css %}
     {% include "built.css" %}
     {% endset %}
-    <style>
-      {{css | cssmin | safe}}
-    </style>
+    {% if env.dev %}
+      <link rel="stylesheet" type="text/css" href="/css/build/development.css">
+    {% else %}
+      <style>
+        {{css | cssmin | safe}}
+      </style>
+    {% endif %}
   </head>
   <body>
     {% include "header.njk" %}

--- a/pages/_includes/page.njk
+++ b/pages/_includes/page.njk
@@ -34,12 +34,18 @@
     {% for item in page | getAltPageRows -%}
       <link rel="alternate" hreflang="{{item.langcode}}" href="https://covid19.ca.gov{{item.url}}">
     {%- endfor %}
+    
     {% set css %}
     {% include "built.css" %}
     {% endset %}
-    <style>
-      {{css | cssmin | safe}}
-    </style>
+    {% if env.dev %}
+      <link rel="stylesheet" type="text/css" href="/css/build/development.css">
+    {% else %}
+      <style>
+        {{css | cssmin | safe}}
+      </style>
+    {% endif %}
+
     <!-- WC polyfill for legacy Edge -->
     <script>
       (function () {


### PR DESCRIPTION
Changes here are prerequisites to meet the larger aims of PR #1250. This PR is the first step toward implementing special features for local development. This could allow much more rapid iteration on CSS files. 

Currently, every time a CSS file is changed, we need to re-run the whole Eleventy build process to (1) re-purge the CSS and (2) re-embed the CSS. This is a costly operation for iterative local development, often up to 30 seconds per hop on my machine. By using a separate, un-purged _development.css_ file in a development environment, this operation can be trimmed to milliseconds. Could be useful when trying to troubleshoot design problems. This is what's happening in the _main.njk_ and _page.njk_ changes.

So where is this _development.css_ file then? Not here! That file is generated by Gulp within PR #1250. And how do we set this so-called development mode? Same deal. That's handled within `npm run` scripts in #1250.  We could add some more of that stuff here, but it'll make this PR much larger. I think it's worthwhile to just try to get these template changes working on the current site, with current defaults, as an iterative first step.

This change is a little more invasive than my other two PRs tonight, #1284 and #1285. Ultimately everything should still work as-is and as expected. I've tested the changes to _main.njk_ and _page.njk_ on Mac and Linux (Debian) with success. Seems to be good. Fingers crossed.

