### PR TITLE
removing URL encoding on slash rewrite

### DIFF
--- a/pages/manual-content/web.config.njk
+++ b/pages/manual-content/web.config.njk
@@ -54,7 +54,7 @@ eleventyExcludeFromCollections: true
         </rule>
         <rule name="AddTrailingSlash BeforeStaticRewrites" stopProcessing="true">
           <match url="(^[^.]*[^/]$)" />
-          <action type="Redirect" url="{UrlEncode:{R:1}}/" />
+          <action type="Redirect" url="{R:1}/" />
         </rule>
         <rule name="Static Rewrite Rule" stopProcessing="true">
           <match url=".*" />


### PR DESCRIPTION
This fixes a problem when attempting to access a translated page without the trailing slash.

https://covid19.ca.gov/es/workers/
works fine but...
https://covid19.ca.gov/es/workers
works, but has a funny encoded URL.

Tested here...
https://netwebsitetest.azurewebsites.net/es/workers#gsc.tab=0&yo=1&test=1+1
