### PR TITLE
Add es5 to all rollup

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -49,9 +49,7 @@ const eleventy = (done) => {
 
 // Build the site's javascript via Rollup.
 const rollup = (done) => {
-  // Switch to the all-Rollup file after it's merged.
-  // const command = ['rollup', '--config', 'src/js/rollup.config.all.js'];
-  const command = ['npm', 'run', 'build:rollup'];
+  const command = ['rollup', '--config', 'src/js/rollup.config.all.js'];
   spawn('npx', command, {
     stdio: 'inherit'
   }).on('close', () => {

--- a/src/js/rollup.config.all.js
+++ b/src/js/rollup.config.all.js
@@ -1,5 +1,6 @@
 import alerts from './alerts/rollup.config';
 import esm from './rollup.config';
+import es5 from './rollup.config.es5';
 import plasma from './plasma/rollup.config';
 import survey from './survey/rollup.config';
 import telehealth from './telehealth/rollup.config';
@@ -8,6 +9,7 @@ import telehealth from './telehealth/rollup.config';
 export default [
   alerts,
   esm,
+  es5,
   plasma,
   survey,
   telehealth


### PR DESCRIPTION
A couple simple changes to add the ES5 Rollup config into the all-Rollups config file. This follows previous merges related to #1299. 