### PR TITLE
fixing hero link on translations

### DIFF
--- a/pages/_includes/main.njk
+++ b/pages/_includes/main.njk
@@ -170,7 +170,7 @@
 
 	<div class="hero-photo" role="complementary" aria-labelledby="hero-background">
 		<div class="hero-photo-fade"></div>
-		<img class="hero-photo-pic" src="img/hero-mobile.jpg" srcset="img/hero-tablet.jpg 740w, img/hero.jpg 1300w" alt="California State Capitol building">
+		<img class="hero-photo-pic" src="/img/hero-mobile.jpg" srcset="/img/hero-tablet.jpg 740w, /img/hero.jpg 1300w" alt="California State Capitol building">
 		<div id="hero-background" class="hero-photo-description">California State Capitol building</div>
 	</div>
 


### PR DESCRIPTION
Changing the Hero banner to use root links to support translated paths