### PR TITLE
highlight template literals

### DIFF
--- a/src/js/roadmap/template.js
+++ b/src/js/roadmap/template.js
@@ -1,5 +1,5 @@
 export default function template(title, countyLabel, countyPlaceholder, activityLabel, activityPlaceholder) {
-  return `
+  return /*html*/`
   <div class="reopening-fields">
   <h2 class="subtitle-color">${title}</h2>
     <form action="#" class="reopening-activities">


### PR DESCRIPTION
Using comment syntax to trigger javascript template literal syntax highlighting in VSCode using this plugin: https://marketplace.visualstudio.com/items?itemName=Tobermory.es6-string-html