### PR TITLE
Industrylinks

### DIFF
--- a/src/js/roadmap/index.js
+++ b/src/js/roadmap/index.js
@@ -199,7 +199,7 @@ class CAGovReopening extends window.HTMLElement {
         this.cardHTML += `<div class="card-activity">
           <h4>${ac["0"]}</h4>
           <p>${ac[item['Overall Status']]}</p>
-          <p>${ac["5"] ? `${this.seeGuidanceText} ${replaceAllInMap(ac["5"])}` : ""}</p>
+          <p>${ac["5"].indexOf('href') > -1 ? `${this.seeGuidanceText} ${replaceAllInMap(ac["5"])}` : ""}</p>
         </div>`
       })
     })

--- a/src/js/roadmap/index.js
+++ b/src/js/roadmap/index.js
@@ -199,7 +199,7 @@ class CAGovReopening extends window.HTMLElement {
         this.cardHTML += `<div class="card-activity">
           <h4>${ac["0"]}</h4>
           <p>${ac[item['Overall Status']]}</p>
-          <p>${this.seeGuidanceText} ${ac["5"] ? replaceAllInMap(ac["5"]) : ""}</p>
+          <p>${ac["5"] ? `${this.seeGuidanceText} ${replaceAllInMap(ac["5"])}` : ""}</p>
         </div>`
       })
     })

--- a/src/js/roadmap/index.js
+++ b/src/js/roadmap/index.js
@@ -13,9 +13,9 @@ class CAGovReopening extends window.HTMLElement {
     if(this.dataset.title) {
       title = this.dataset.title;
     }
-    let seeGuidanceText = 'See guidance for';
+    this.seeGuidanceText = 'See guidance for';
     if(this.dataset.seeGuidanceText) {
-      seeGuidanceText = this.dataset.seeGuidanceText;
+      this.seeGuidanceText = this.dataset.seeGuidanceText;
     }
     let countyLabel = 'County';
     if(this.dataset.countyLabel) {
@@ -199,7 +199,7 @@ class CAGovReopening extends window.HTMLElement {
         this.cardHTML += `<div class="card-activity">
           <h4>${ac["0"]}</h4>
           <p>${ac[item['Overall Status']]}</p>
-          <p>${seeGuidanceText} ${ac["5"] ? replaceAllInMap(ac["5"]) : ""}</p>
+          <p>${this.seeGuidanceText} ${ac["5"] ? replaceAllInMap(ac["5"]) : ""}</p>
         </div>`
       })
     })

--- a/src/js/roadmap/index.js
+++ b/src/js/roadmap/index.js
@@ -153,6 +153,18 @@ class CAGovReopening extends window.HTMLElement {
   }
 
   layoutCards() {
+    let replaceAllInMap = function(str){
+      let mapObj = {
+        '&lt;': '<',
+        '&gt;': '>',
+        '’': '"',
+        '”': '"'
+      }
+      var re = new RegExp(Object.keys(mapObj).join("|"),"gi");
+      return str.replace(re, function(matched){
+        return mapObj[matched.toLowerCase()];
+      });
+    }
     this.cardHTML = '';
     let selectedCounties = this.countyStatuses;
     if(this.state['county']) {
@@ -183,7 +195,7 @@ class CAGovReopening extends window.HTMLElement {
         this.cardHTML += `<div class="card-activity">
           <h4>${ac["0"]}</h4>
           <p>${ac[item['Overall Status']]}</p>
-          <p><a href="/industry-guidance">${this.industryGuidanceLinkText}</a></p>
+          <p>${ac["5"] ? replaceAllInMap(ac["5"]) : ""}</p>
         </div>`
       })
     })

--- a/src/js/roadmap/index.js
+++ b/src/js/roadmap/index.js
@@ -13,6 +13,10 @@ class CAGovReopening extends window.HTMLElement {
     if(this.dataset.title) {
       title = this.dataset.title;
     }
+    let seeGuidanceText = 'See guidance for';
+    if(this.dataset.seeGuidanceText) {
+      seeGuidanceText = this.dataset.seeGuidanceText;
+    }
     let countyLabel = 'County';
     if(this.dataset.countyLabel) {
       countyLabel = this.dataset.countyLabel;
@@ -195,7 +199,7 @@ class CAGovReopening extends window.HTMLElement {
         this.cardHTML += `<div class="card-activity">
           <h4>${ac["0"]}</h4>
           <p>${ac[item['Overall Status']]}</p>
-          <p>${ac["5"] ? replaceAllInMap(ac["5"]) : ""}</p>
+          <p>${seeGuidanceText} ${ac["5"] ? replaceAllInMap(ac["5"]) : ""}</p>
         </div>`
       })
     })


### PR DESCRIPTION
This uses the new industry guidance links that are now in WordPress

The string replacement is required because the fields need to have multiple links in them and the json comes back fully escaped. I think WordPress is doing the escaping before it reaches our publishing system. This replacement is a little goofy but seems to work ok