### PR TITLE
new homepage and schools language

### DIFF
--- a/pages/manual-content/homepages/ar.html
+++ b/pages/manual-content/homepages/ar.html
@@ -17,7 +17,7 @@ varCountyMap: خريطة المقاطعات
 varStateSummary: ملخص الحالة
 varDataAndTools: بيانات وأدوات COVID-19
 varUpdateText: أرقام محدثة [UpdatedDate] بمعلومات من [DataDate]
-varHeroTitle: أفعالك تنقذ الأرواح
+varHeroTitle: في عيد العمال هذا، يمكن لتصرفاتكم أن تنقذ أرواحاً
 varHeroP1: "اعرض خريطة المقاطعة لمعرفة ما هو مفتوح"
 varHeroP2: ارتدِ قناعاً واغسل يديك وحافظ على التباعد.
 varHeroAlertSocial: راجع المستجدات المعلنة من قبل المحافظ 

--- a/pages/manual-content/homepages/english.html
+++ b/pages/manual-content/homepages/english.html
@@ -17,7 +17,7 @@ varCountyMap: "County Map"
 varStateSummary: State dashboard
 varDataAndTools: COVID-19 data and tools
 varUpdateText: "In California, Updated [UpdatedDate] with data from [DataDate]"
-varHeroTitle: Your actions save lives
+varHeroTitle: This Labor Day, your actions save lives
 varHeroP1: "View the county map to see what's open"
 varHeroP2: Wear a mask, wash your hands, keep your distance.
 varHeroAlertSocial: Check the Governor’s Updates

--- a/pages/manual-content/homepages/es.html
+++ b/pages/manual-content/homepages/es.html
@@ -17,7 +17,7 @@ varCountyMap: Mapa de los condados
 varStateSummary: Resumen del estado
 varDataAndTools: Datos y herramientas de COVID-19
 varUpdateText: "Números actualizados ([UpdatedDate]) con información (del [DataDate])"
-varHeroTitle: Sus acciones salvan vidas
+varHeroTitle: Este Día del Trabajo, ¡sus acciones pueden salvar vidas!
 varHeroP1: "Ver el mapa del condado para ver qué está abierto"
 varHeroP2: Use mascarilla, lávese las manos y mantenga su distancia.
 varHeroAlertSocial: Consulte las actualizaciones del gobernador

--- a/pages/manual-content/homepages/ko.html
+++ b/pages/manual-content/homepages/ko.html
@@ -17,7 +17,7 @@ varCountyMap: 카운티지도
 varStateSummary: 상태 요약
 varDataAndTools: COVID-19 데이터 및 도구
 varUpdateText: "[UpdatedDate] 업데이트 된 숫자 [DataDate] 정보"
-varHeroTitle: 여러분의 행동이 생명을 살릴 수 있습니다
+varHeroTitle: 이번 노동절 기간에는 여러분의 행동이 생명을 살릴 수 있습니다
 varHeroP1: 열리는 곳을 보려면 카운티지도를보십시오.
 varHeroP2: 마스크를 착용하며 손을 씻고 거리를 유지하십시오.
 varHeroAlertSocial: 주지사가 새로 발표하는 내용을 확인하십시오.

--- a/pages/manual-content/homepages/zh-hans.html
+++ b/pages/manual-content/homepages/zh-hans.html
@@ -17,7 +17,7 @@ varCountyMap: 县地图
 varStateSummary: 状态摘要
 varDataAndTools: COVID-19数据和工具
 varUpdateText: "[UpdatedDate]更新的数字 从[DataDate]开始提供信息"
-varHeroTitle: 您的行动可拯救生命
+varHeroTitle: 今年劳工节，您的行动能拯救生命
 varHeroP1: 查看县地图，看看有什么开放
 varHeroP2: 佩戴口罩、清洗双手、与他人保持距离。
 varHeroAlertSocial: 查看州长的更新

--- a/pages/manual-content/homepages/zh-hant.html
+++ b/pages/manual-content/homepages/zh-hant.html
@@ -17,7 +17,7 @@ varCountyMap: 縣地圖
 varStateSummary: 狀態摘要
 varDataAndTools: COVID-19數據和工具
 varUpdateText: "[UpdatedDate]更新的數字 從[DataDate]開始提供信息"
-varHeroTitle: 您的行動可拯救生命
+varHeroTitle: 今年勞工節，您的行動能拯救生命
 varHeroP1: 查看縣地圖，看看有什麼開放
 varHeroP2: 請佩戴口罩、洗淨雙手、與他人保持距離。
 varHeroAlertSocial: 查看州長的更新資訊

--- a/src/js/roadmap/index.js
+++ b/src/js/roadmap/index.js
@@ -179,6 +179,14 @@ class CAGovReopening extends window.HTMLElement {
         }
       })
     }
+    // if we are in one of these counties schools can reopen: 
+    let schoolOKList = ["Alpine", "Del Norte", "El Dorado", "Humboldt", "Lake", "Lassen", "Mariposa", "Modoc", "Mono", "Nevada", "Placer", "Plumas", "San Diego", "Shasta", "Siskiyou", "Trinity", "Tuolumne"];
+    let schoolShenanigans = function(county) {
+      if(schoolOKList.indexOf(county) > -1) {
+        return 'Schools may reopen fully for in-person instruction. Local school officials will decide whether and when that will occur.'
+      }
+      return /*html*/`Schools may not reopen fully for in-person instruction until the county has been in the Substantial (Red) Tier for two weeks. Local school and health officials <a href="https://www.cdph.ca.gov/Programs/CID/DCDC/Pages/COVID-19/In-Person-Elementary-Waiver-Process.aspx">may decide to open elementary schools</a>, and school officials <a href="https://www.cdph.ca.gov/Programs/CID/DCDC/Pages/COVID-19/Schools-FAQ.aspx">may decide to conduct in-person instruction</a> for a limited set of students in small cohorts.`;
+    }
     let selectedActivities = this.allActivities;
     selectedCounties.forEach(item => {
       this.cardHTML += `<div class="card-county county-color-${item['Overall Status']}">
@@ -198,7 +206,7 @@ class CAGovReopening extends window.HTMLElement {
       selectedActivities.forEach(ac => {
         this.cardHTML += `<div class="card-activity">
           <h4>${ac["0"]}</h4>
-          <p>${ac[item['Overall Status']]}</p>
+          <p>${ac["0"] === "Schools" ? schoolShenanigans(item.county) : ac[item['Overall Status']]}</p>
           <p>${ac["5"].indexOf('href') > -1 ? `${this.seeGuidanceText} ${replaceAllInMap(ac["5"])}` : ""}</p>
         </div>`
       })


### PR DESCRIPTION
This update includes:

- Changing h1 text on the homepage to labor day specific language for most languages. Tagalog and Vietnamese are not included because the translated text was so long it broke the layout on some mobile phone sizes
- Special logic for schools because they do not conform to regular tier guidance which is quite weird. This is supposed to be temporary

These updates are browsable in staging now