### PR TITLE
only build most of the js bundles when the files in those dirs changed after the last generated file

### DIFF
--- a/src/js/rollup.config.all.js
+++ b/src/js/rollup.config.all.js
@@ -26,11 +26,11 @@ const getLastUpdatedFile = (directoryPath) => {
 
 // Combines all the Rollup files into one.
 export default [
-  ...((getLastUpdatedFile(__dirname + '/alerts/') > getFileUpdatedDate(path.join(__dirname, '../../docs/js/alerts.js'))) ? [alerts] : []),
-  ...((getLastUpdatedFile(__dirname + '/plasma/') > getFileUpdatedDate(path.join(__dirname, '../../docs/js/plasma.js'))) ? [plasma] : []),
-  ...((getLastUpdatedFile(__dirname + '/roadmap/') > getFileUpdatedDate(path.join(__dirname, '../../docs/js/roadmap.js'))) ? [reopening] : []),
-  ...((getLastUpdatedFile(__dirname + '/telehealth/') > getFileUpdatedDate(path.join(__dirname, '../../docs/js/telehealth.js'))) ? [telehealth] : []),
-  ...((getLastUpdatedFile(__dirname + '/video/') > getFileUpdatedDate(path.join(__dirname, '../../docs/js/video.js'))) ? [video] : []),
+  ...((process.env.NODE_ENV === 'development' && getLastUpdatedFile(__dirname + '/alerts/') > getFileUpdatedDate(path.join(__dirname, '../../docs/js/alerts.js'))) ? [alerts] : []),
+  ...((process.env.NODE_ENV === 'development' && getLastUpdatedFile(__dirname + '/plasma/') > getFileUpdatedDate(path.join(__dirname, '../../docs/js/plasma.js'))) ? [plasma] : []),
+  ...((process.env.NODE_ENV === 'development' && getLastUpdatedFile(__dirname + '/roadmap/') > getFileUpdatedDate(path.join(__dirname, '../../docs/js/roadmap.js'))) ? [reopening] : []),
+  ...((process.env.NODE_ENV === 'development' && getLastUpdatedFile(__dirname + '/telehealth/') > getFileUpdatedDate(path.join(__dirname, '../../docs/js/telehealth.js'))) ? [telehealth] : []),
+  ...((process.env.NODE_ENV === 'development' && getLastUpdatedFile(__dirname + '/video/') > getFileUpdatedDate(path.join(__dirname, '../../docs/js/video.js'))) ? [video] : []),
   esm,
   // Don't include ES5 file in dev mode.
   ...((process.env.NODE_ENV === 'development') ? [] : [es5])

--- a/src/js/rollup.config.all.js
+++ b/src/js/rollup.config.all.js
@@ -6,14 +6,32 @@ import reopening from './roadmap/rollup.config';
 import telehealth from './telehealth/rollup.config';
 import video from './video/rollup.config';
 
+import fs from 'fs';
+import path from 'path';
+const getFileUpdatedDate = (path) => {
+  const stats = fs.statSync(path)
+  return stats.mtime
+}
+const getLastUpdatedFile = (directoryPath) => {
+  let files = fs.readdirSync(directoryPath);
+  let latestFileTime = new Date('01/01/2020');
+  files.forEach(function (file) {
+    let thisFileUpdate = getFileUpdatedDate(directoryPath + file);
+    if(thisFileUpdate > latestFileTime) {
+      latestFileTime = thisFileUpdate;
+    }
+  });
+  return latestFileTime;
+}
+
 // Combines all the Rollup files into one.
 export default [
-  alerts,
+  ...((getLastUpdatedFile(__dirname + '/alerts/') > getFileUpdatedDate(path.join(__dirname, '../../docs/js/alerts.js'))) ? [alerts] : []),
+  ...((getLastUpdatedFile(__dirname + '/plasma/') > getFileUpdatedDate(path.join(__dirname, '../../docs/js/plasma.js'))) ? [plasma] : []),
+  ...((getLastUpdatedFile(__dirname + '/roadmap/') > getFileUpdatedDate(path.join(__dirname, '../../docs/js/roadmap.js'))) ? [reopening] : []),
+  ...((getLastUpdatedFile(__dirname + '/telehealth/') > getFileUpdatedDate(path.join(__dirname, '../../docs/js/telehealth.js'))) ? [telehealth] : []),
+  ...((getLastUpdatedFile(__dirname + '/video/') > getFileUpdatedDate(path.join(__dirname, '../../docs/js/video.js'))) ? [video] : []),
   esm,
-  plasma,
-  reopening,
-  telehealth,
-  video,
   // Don't include ES5 file in dev mode.
   ...((process.env.NODE_ENV === 'development') ? [] : [es5])
 ];


### PR DESCRIPTION
Compare file modified dates of source files to generated files before running rollup bundling.

Why do this?
- The rollup bundling is taking around half a second per separate bundle if there are any imports
- This change skips any bundle whose source hasn't been updated more recently that its generated output
- This takes a few seconds off builds with js changes during development

This seems weird what are other possible ways to handle this?
- Usually this is handled in one big bundle with dynamic imports

Why don't we put everything in one js file and use dynamic imports like everybody else?
- This is faster for the end user
  - If we had one big bundle the page specific js would not be requested until the dynamic import executed after the page was delivered.
  - We are deciding which code goes on which page in the server side template and it gets delivered inline with the first request instead of waiting for client side code to execute before retrieving the page specific js
