### PR TITLE
fix button behavior, add more buttons

### DIFF
--- a/pages/_includes/dashboard.njk
+++ b/pages/_includes/dashboard.njk
@@ -91,6 +91,10 @@
         <div class="row d-flex justify-content-md-center">
             <span id="county-query-error" class="error-text d-none">County not found</span>
         </div>
+
+        <script type="text/javascript" src="https://public.tableau.com/javascripts/api/tableau-2.js"></script>
+
+        <h3 class="text-center mt-4">Daily cases and deaths</h3>
         <div class="row d-flex justify-content-md-center">
             <div class="toggle-link-container js-toggle-county-container d-none">
                 <div class="grid-layout-hd toggle-links bg-darkblue bd-darkblue">
@@ -99,10 +103,6 @@
                 </div>
             </div>
         </div>
-
-        <script type="text/javascript" src="https://public.tableau.com/javascripts/api/tableau-2.js"></script>
-
-        <h3 class="text-center mt-4">Daily cases and deaths</h3>
         <p>California has {{_varStatTotalCases_}} confirmed cases of COVID-19, resulting in {{_varStatTotalDeaths_}} deaths.</p>
  
         <div class="row d-flex justify-content-md-center">
@@ -122,6 +122,8 @@
         <div class="row d-flex justify-content-md-center">
             <p class="small-text">Note: Numbers do not represent true day-over-day change as these results include cases from prior to yesterday.</p>
         </div>
+
+        <h3 class="text-center mt-4 mb-0">Testing for COVID-19</h3>
         <div class="row d-flex justify-content-md-center">
             <div class="toggle-link-container js-toggle-county-container d-none">
                 <div class="grid-layout-hd toggle-links bg-darkblue bd-darkblue">
@@ -130,8 +132,6 @@
                 </div>
             </div>
         </div>
-
-        <h3 class="text-center mt-4 mb-0">Testing for COVID-19</h3>
         <p>The number of COVID-19 diagnostic test results in California reached a total of {{_varStatTested_}}, an increase of {{_varStatTestedDaily_}} tests from the previous day. The rate of positive tests over the last 14 days is {{_varStarPos_14DayAvg_}} percent.  </p>
 
         <div class="row d-flex justify-content-md-center">
@@ -145,6 +145,8 @@
             </div>
             </div>
         </div>
+
+        <h3 class="text-center mb-0">Impact on hospitals and ICUs</h3>
         <div class="row d-flex justify-content-md-center">
             <div class="toggle-link-container js-toggle-county-container d-none">
                 <div class="grid-layout-hd toggle-links bg-darkblue bd-darkblue">
@@ -153,8 +155,6 @@
                 </div>
             </div>
         </div>
-
-        <h3 class="text-center mb-0">Impact on hospitals and ICUs</h3>
         <p>
             The number of hospitalizations due to confirmed and suspected COVID-19 cases in California reached a total of {{_varStatHospitalTotal_}}, a decrease of {{_varStatHospitalChange_}} from the previous day.
             The number of ICU patients due to confirmed and suspected COVID-19 cases in California reached a total of {{_varStatIcuTotal_}}, a decrease of {{_varStatIcuChange_}} from the previous day.

--- a/pages/_includes/dashboard.njk
+++ b/pages/_includes/dashboard.njk
@@ -92,16 +92,15 @@
             <span id="county-query-error" class="error-text d-none">County not found</span>
         </div>
         <div class="row d-flex justify-content-md-center">
-            <div class="toggle-link-container">
-            <div class="grid-layout-hd toggle-links bg-darkblue bd-darkblue">
-                <a href="#" class="js-toggle-county county d-none">Alameda</a>
-                <a href="#" class="toggle-active js-toggle-county statewide">Statewide</a>
+            <div class="toggle-link-container js-toggle-county-container d-none">
+                <div class="grid-layout-hd toggle-links bg-darkblue bd-darkblue">
+                    <a href="#" class="js-toggle-county county d-none">Alameda</a>
+                    <a href="#" class="toggle-active js-toggle-county statewide">Statewide</a>
+                </div>
             </div>
-            </div>
-        </div>  
+        </div>
 
         <script type="text/javascript" src="https://public.tableau.com/javascripts/api/tableau-2.js"></script>
-
 
         <h3 class="text-center mt-4">Daily cases and deaths</h3>
         <p>California has {{_varStatTotalCases_}} confirmed cases of COVID-19, resulting in {{_varStatTotalDeaths_}} deaths.</p>
@@ -123,6 +122,15 @@
         <div class="row d-flex justify-content-md-center">
             <p class="small-text">Note: Numbers do not represent true day-over-day change as these results include cases from prior to yesterday.</p>
         </div>
+        <div class="row d-flex justify-content-md-center">
+            <div class="toggle-link-container js-toggle-county-container d-none">
+                <div class="grid-layout-hd toggle-links bg-darkblue bd-darkblue">
+                    <a href="#" class="js-toggle-county county d-none">Alameda</a>
+                    <a href="#" class="toggle-active js-toggle-county statewide">Statewide</a>
+                </div>
+            </div>
+        </div>
+
         <h3 class="text-center mt-4 mb-0">Testing for COVID-19</h3>
         <p>The number of COVID-19 diagnostic test results in California reached a total of {{_varStatTested_}}, an increase of {{_varStatTestedDaily_}} tests from the previous day. The rate of positive tests over the last 14 days is {{_varStarPos_14DayAvg_}} percent.  </p>
 
@@ -136,9 +144,16 @@
                 <div class='tableauPlaceholder' id="testingChartState"></div>
             </div>
             </div>
-
-
         </div>
+        <div class="row d-flex justify-content-md-center">
+            <div class="toggle-link-container js-toggle-county-container d-none">
+                <div class="grid-layout-hd toggle-links bg-darkblue bd-darkblue">
+                    <a href="#" class="js-toggle-county county d-none">Alameda</a>
+                    <a href="#" class="toggle-active js-toggle-county statewide">Statewide</a>
+                </div>
+            </div>
+        </div>
+
         <h3 class="text-center mb-0">Impact on hospitals and ICUs</h3>
         <p>
             The number of hospitalizations due to confirmed and suspected COVID-19 cases in California reached a total of {{_varStatHospitalTotal_}}, a decrease of {{_varStatHospitalChange_}} from the previous day.

--- a/pages/_includes/dashboard.njk
+++ b/pages/_includes/dashboard.njk
@@ -20,7 +20,7 @@
 <div class="bg-lightblue py-5">
     <div class="container py-2">
         <div class="row pb-4">
-            <div class="col-md-10 mx-auto">
+            <div class="col-lg-10 mx-auto">
             <h2 class="text-center color-purple">Update for {{_varStatDate_}}</h2>
                 <p>As of {{_varStatDateNoYear_}}, California has {{_varStatTotalCases_}} confirmed cases of COVID-19, resulting in {{_varStatTotalDeaths_}} deaths. The number of COVID-related deaths increased by {{_varStatTotalDeathsChange_}} percent from the previous day's total of {{_varStatTotalDeathsLast_}}.</p>
                 </p>Updated {{_varStatDate_}}, with data from {{_varStatYesterdayDate_}}.</p>
@@ -62,7 +62,7 @@
 </div><!--END LIGHT BLUE BG-->
 
 <div class="container py-4">
-    <div class="col-md-10 mx-auto">
+    <div class="col-lg-10 mx-auto">
         <h2 class="text-center color-purple">See the data statewide and in each county</h2>
         <div class="row d-flex justify-content-md-center">
             <form class="form-inline" id="county-form">
@@ -94,7 +94,7 @@
 
         <script type="text/javascript" src="https://public.tableau.com/javascripts/api/tableau-2.js"></script>
 
-        <h3 class="text-center mt-4">Daily cases and deaths</h3>
+        <h3 class="text-center mt-4 mb-0">Daily cases and deaths</h3>
         <div class="row d-flex justify-content-md-center">
             <div class="toggle-link-container js-toggle-county-container d-none">
                 <div class="grid-layout-hd toggle-links bg-darkblue bd-darkblue">
@@ -223,7 +223,7 @@
 <div class="bg-lightblue py-5">
     <div class="container py-2">
     <h2 class="text-center color-orange">Infections by group</h2>
-        <div class="col-md-12 bg-white px-3 py-4">
+        <div class="col-lg-12 bg-white px-3 py-4">
             <div class="row d-flex justify-content-md-center">
 
                 <div class="toggle-link-container">

--- a/src/js/dashboard/index.js
+++ b/src/js/dashboard/index.js
@@ -17,7 +17,7 @@ window.fetch('/countystatus.json')
       let before = this.input.value.match(/^.+,\s*|/)[0];
       let finalval = before + text;
       this.input.value = finalval;        
-      countySelected(finalval);
+      // countySelected(finalval);
     },
     list: aList
   };
@@ -51,7 +51,6 @@ function countySelected(county) {
   let casesChartActiveSheet = casesChartCountyViz.getWorkbook().getActiveSheet().getWorksheets()[1];
   let testingChartActiveSheet = testingChartCounty.getWorkbook().getActiveSheet().getWorksheets()[1];
   let hospitalChartActiveSheet = hospitalChartCounty.getWorkbook().getActiveSheet().getWorksheets()[1];
-  document.querySelector('.js-toggle-county.county').innerHTML = county;
 
   function resetCounties() {
     if(casesChartActiveSheet && testingChartActiveSheet && hospitalChartActiveSheet) {
@@ -64,7 +63,13 @@ function countySelected(county) {
   }
   resetCounties();
   showCounties();
-  document.querySelector('.js-toggle-county.county').style.display = 'block';
+  document.querySelectorAll('.js-toggle-county-container').forEach(c => {
+    c.classList.remove('d-none');
+  })
+  document.querySelectorAll('.js-toggle-county.county').forEach(c => {
+    c.innerHTML = county;
+    c.classList.remove('d-none');
+  });
 }
 
 function displayChart(containerSelector,width,height,url) {
@@ -109,7 +114,7 @@ let ageGroupChart = ''; // we aren't loading this until they click
 
 function resetGroupToggles() {
   groupTogglers.forEach(toggle => {
-    toggle.classList.remove('toggle-active')  
+    toggle.classList.remove('toggle-active')
   });
   document.getElementById('gender-graph').style.display = 'none';
   document.getElementById('ethnicity-graph').style.display = 'none';
@@ -169,7 +174,6 @@ countyTogglers.forEach(toggle => {
 function showStateWides() {
   resetCountyToggles();
   document.querySelector('.js-toggle-county.statewide').classList.add('toggle-active');
-
   document.getElementById('cases-state-graph').style.display = 'block';
   document.getElementById('testing-state-graph').style.display = 'block';
   document.getElementById('hospital-state-graph').style.display = 'block';
@@ -177,7 +181,9 @@ function showStateWides() {
 
 function showCounties() {
   resetCountyToggles();
-  document.querySelector('.js-toggle-county.county').classList.add('toggle-active');
+  document.querySelectorAll('.js-toggle-county.county').forEach(c => {
+    c.classList.add('toggle-active');
+  });
 
   document.getElementById('cases-county-graph').style.display = 'block';
   document.getElementById('testing-county-graph').style.display = 'block';
@@ -186,4 +192,3 @@ function showCounties() {
 
 // normally we would display none stuff we don't want to hide but this wreaks havoc with tableau's internal layout logic and we end up with mobile views even when we specifically pass it dimensions so we are avoiding displaying none on these for now
 // showStateWides();
-

--- a/src/js/dashboard/index.js
+++ b/src/js/dashboard/index.js
@@ -167,13 +167,14 @@ countyTogglers.forEach(toggle => {
     if(this.classList.contains('county')) {
       showCounties();
     }
-    this.classList.add('toggle-active');
   })
 })
 
 function showStateWides() {
   resetCountyToggles();
-  document.querySelector('.js-toggle-county.statewide').classList.add('toggle-active');
+  document.querySelectorAll('.js-toggle-county.statewide').forEach(c => {
+    c.classList.add('toggle-active');
+  })
   document.getElementById('cases-state-graph').style.display = 'block';
   document.getElementById('testing-state-graph').style.display = 'block';
   document.getElementById('hospital-state-graph').style.display = 'block';

--- a/src/js/roadmap/index.js
+++ b/src/js/roadmap/index.js
@@ -106,7 +106,7 @@ class CAGovReopening extends window.HTMLElement {
         let finalval = before + text;
         this.input.value = finalval;        
         component.state[fieldName] = finalval;
-        component.layoutCards();
+        // component.layoutCards();
       },
       list: aList
     };


### PR DESCRIPTION
p1 fixes to the state dashboard

issues 50-52

- Hide state tab on default (tabs should only appear after a user has searched for a county)
- Force users to click the get county data to submit the county data vs automatically
- Repeat county/state tab above all sections and move tabs below the H3 title (1. ideally locally controlled and if not then 2. continue to have them globally controlled)

This has been merged to staging and should not be merged until it passes QA there
