### PR TITLE
Remove "View All" from dimmer switch form

### DIFF
--- a/src/js/roadmap/index.js
+++ b/src/js/roadmap/index.js
@@ -63,7 +63,7 @@ class CAGovReopening extends window.HTMLElement {
     .then(function(data) {
       this.allActivities = data.Table1;
       let aList = []
-      aList.push(this.viewall);
+      // aList.push(this.viewall);
       data.Table1.forEach(item => {
         aList.push(item['0'])
       })


### PR DESCRIPTION
Removes the "View all" option from the safer-economy page, per #1923. 

With this change, there's no longer any hint in the UI that people can view all activities. I'm assuming this is a deliberate choice based on the text of #1923 and recent code changes (disabling the card rendering on auto-complete of the county field).