### PR TITLE
Remove expanded-menu clickables from headings on desktop

### DIFF
--- a/src/css/trilogy/namespaced/shell/_expanded-menu.scss
+++ b/src/css/trilogy/namespaced/shell/_expanded-menu.scss
@@ -105,14 +105,6 @@ cagov-navoverlay {
           font-size: 0.9rem;
           padding: 0.25rem;
           border-radius: 1.5rem;
-          
-          @include tablet {
-            font-size: 1rem;
-            width: auto;
-          }
-          @include desktop {
-            font-size: 1.1rem;
-          }
           &:hover {
             color: $white;
           }
@@ -129,6 +121,21 @@ cagov-navoverlay {
           }
           &.white {
             color: $white;
+          }
+          @include tablet {
+            cursor: default;
+            &:hover {
+              color: $orange;
+            }
+            &:focus {
+              color: $white;
+            }
+            text-decoration: inherit;
+            font-size: 1rem;
+            width: auto;
+          }
+          @include desktop {
+            font-size: 1.1rem;
           }
         }
         &-arrow {


### PR DESCRIPTION
Per #1951, this removes link-like behavior from headings ("Get Help", "Health Information", etc.) in the header's expanded hamburger menu. 

On mobile, these headings need to be links to allow expansion of drop-down lists of links. On desktop, these links are useless because the lists are already expanded to fill the larger screen. So the challenge is to remove link-like behavior from these headings on desktop, while preserving it on mobile.

Note that these headings still maintain focus-state behavior on desktop with this set of changes.