### PR TITLE
Making sure the small text font update overrides other font size

### DIFF
--- a/src/css/_covid.scss
+++ b/src/css/_covid.scss
@@ -113,7 +113,7 @@ h4 {
 }
 
 .small-text {
-	font-size: .95rem;
+	font-size: .95rem !important;
 }
 .text-disclaim {
   font-size:.8em;


### PR DESCRIPTION
Need Konstantin or Art to review.

Problem is `small-text` is being overridden in the content of this page...
https://staging.covid19.ca.gov/safer-economy

look for...
_*Small counties (those with a population less than 106,000) may be subject to alternate case assessment measures for purposes of tier assignment.
**Health equity metric is not applied for small counties._