### PR TITLE
Fixing extra "}" in state-dash

### DIFF
--- a/pages/_includes/dashboard.njk
+++ b/pages/_includes/dashboard.njk
@@ -20,7 +20,7 @@
 {%-set _varStatHospitalChangeText_ = 'an increase of' if _varStatHospitalChange_ >= 0 else 'a decrease of' -%}
 {%-set _varStatIcuChangeText_ = 'an increase of' if _varStatIcuChange_ >= 0 else 'a decrease of' -%}
 {%-set _varTierDate_ = 'October 13, 2020' -%}
-{%-set _varTierEndDate_ = 'October 3, 2020' -%}}
+{%-set _varTierEndDate_ = 'October 3, 2020' -%}
 
 
 <div class="bg-lightblue py-5">


### PR DESCRIPTION
Seen between header and title.

https://covid19.ca.gov/state-dashboard/