### PR TITLE
fixing quick answers url

### DIFF
--- a/pages/_includes/search.njk
+++ b/pages/_includes/search.njk
@@ -55,7 +55,7 @@
 		}
 		history.pushState(null,null,`${currentHost}${window.location.pathname}?q=${query}`);
 		document.querySelector('#answersNow').innerHTML = "";
-		fetch(`https://fa-go-alph-covidqna-001.azurewebsites.net/api/CovidAnswer?q=${query}&name=123`)
+		fetch(`https://fa-go-alph-covidqna-001.azurewebsites.net/CovidAnswer?q=${query}&name=123`)
 		.then(response => response.json())
 		.then(data => {
 			let answers = [...data[0].answers];


### PR DESCRIPTION
removing the /api/ from the covidanswers url