### PR TITLE
changing default html template engine to nunjucks

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -562,6 +562,7 @@ ${bodyHTML}
 
   eleventyConfig.htmlTemplateEngine = "njk,findaccordions,findlinkstolocalize";
   return {
+    htmlTemplateEngine: "njk",
     templateFormats: ["html", "njk", "11ty.js"],
     dir: {
       input: "pages",


### PR DESCRIPTION
Turns out 11ty was processing html pages using "Liquid" instead of Nunjucks.  Simply adding a `{% set value = 1 %}` at the top of a html template was causing a Liquid error.  Now we can safely use Nunjucks in our basic templates.