### PR TITLE
use global regex flag to avoid error on latest node

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -344,7 +344,7 @@ module.exports = function(eleventyConfig) {
         
         
         const getNextTag = (searchArea, tag) => 
-           [...searchArea.matchAll(new RegExp('<(?<closeslash>/?)'+tag+'\\b[^>]*>','m'))]
+           [...searchArea.matchAll(new RegExp('<(?<closeslash>/?)'+tag+'\\b[^>]*>','gm'))]
             .map(r=> ({
               index: r.index,
               isCloseTag: r.groups.closeslash.length>0,


### PR DESCRIPTION
This fixes the build error that happened if you tried to build when running latest node.js version 14