### PR TITLE
adding dynamic tier dates

### DIFF
--- a/pages/_includes/dashboard.njk
+++ b/pages/_includes/dashboard.njk
@@ -19,8 +19,8 @@
 {%-set _varStatIcuChange_ = (data.ICU_COVID_CONFIRMED_PATIENTS_DAILY + data.ICU_SUSPECTED_COVID_PATIENTS_DAILY) | formatNumber(tags)-%}
 {%-set _varStatHospitalChangeText_ = 'an increase of' if _varStatHospitalChange_ >= 0 else 'a decrease of' -%}
 {%-set _varStatIcuChangeText_ = 'an increase of' if _varStatIcuChange_ >= 0 else 'a decrease of' -%}
-{%-set _varTierDate_ = 'November 10, 2020' -%}
-{%-set _varTierEndDate_ = 'October 31, 2020' -%}
+{%-set _varTierDate_ = data.TIER_DATE | formatDate2(false, tags) -%}
+{%-set _varTierEndDate_ = data.TIER_ENDDATE | formatDate2(false, tags) -%}
 
 
 <div class="bg-lightblue py-5">

--- a/pages/wordpress-posts/safer-economy.html
+++ b/pages/wordpress-posts/safer-economy.html
@@ -8,6 +8,10 @@ tags: ["translate"]
 addtositemap: true
 ---
 
+<!--{%-set data = tableauCovidMetrics[0] -%}-->
+<!--{%-set _varTierDate_ = data.TIER_DATE | formatDate2(false, tags) -%}-->
+<!--{%-set _varTierEndDate_ = data.TIER_ENDDATE | formatDate2(false, tags) -%}-->
+
 <p>California has a blueprint for reducing COVID-19 in the state with revised criteria for loosening and tightening restrictions on activities.</p>
 
 
@@ -44,7 +48,7 @@ addtositemap: true
 
 
 
-<h3 class="has-text-align-center">Current tier assignments as of November 10, 2020</h3>
+<h3 class="has-text-align-center">Current tier assignments as of {{_varTierDate_}}</h3>
 
 
 
@@ -57,7 +61,7 @@ addtositemap: true
 
 
 
-<p class="small-text">All data and tier assignments are based on results from week ending October 31, 2020. See how tiers are assigned and change, as well as county historical data (<strong>California Blueprint Data Chart</strong>), at the <a href="https://www.cdph.ca.gov/Programs/CID/DCDC/Pages/COVID-19/COVID19CountyMonitoringOverview.aspx">California Department of Public Health guidance page</a>.</p>
+<p class="small-text">All data and tier assignments are based on results from week ending {{_varTierEndDate_}}. See how tiers are assigned and change, as well as county historical data (<strong>California Blueprint Data Chart</strong>), at the <a href="https://www.cdph.ca.gov/Programs/CID/DCDC/Pages/COVID-19/COVID19CountyMonitoringOverview.aspx">California Department of Public Health guidance page</a>.</p>
 
 
 

--- a/pages/wordpress-posts/safer-economy.html
+++ b/pages/wordpress-posts/safer-economy.html
@@ -8,10 +8,6 @@ tags: ["translate"]
 addtositemap: true
 ---
 
-<!--{%-set data = tableauCovidMetrics[0] -%}-->
-<!--{%-set _varTierDate_ = data.TIER_DATE | formatDate2(false, tags) -%}-->
-<!--{%-set _varTierEndDate_ = data.TIER_ENDDATE | formatDate2(false, tags) -%}-->
-
 <p>California has a blueprint for reducing COVID-19 in the state with revised criteria for loosening and tightening restrictions on activities.</p>
 
 
@@ -45,6 +41,12 @@ addtositemap: true
 <p class="small-text">*Small counties (those with a population less than 106,000) may be subject to alternate case assessment measures for purposes of tier assignment.</br>
 **Health equity metric is not applied for small counties. The health equity metric is used to move to a less restrictive tier.</p>
 <p>&nbsp;</p>
+
+
+
+<!--{%-set data = tableauCovidMetrics[0] -%}-->
+<!--{%-set _varTierDate_ = data.TIER_DATE | formatDate2(false, tags) -%}-->
+<!--{%-set _varTierEndDate_ = data.TIER_ENDDATE | formatDate2(false, tags) -%}-->
 
 
 


### PR DESCRIPTION
Adding dynamic tier dates.

Tier dates will be pulled from daily update instead of manual update.

Must take the "safer-economy" page out of "staging-only" for this to deploy.
https://as-go-covid19-d-001.azurewebsites.net/wp-admin/post.php?post=5563&action=edit