### PR TITLE
CCG-184 Link County Map button to County Status Map section on Safer …

### DIFF
--- a/pages/_includes/main.njk
+++ b/pages/_includes/main.njk
@@ -81,7 +81,7 @@
 						</div>
 					</div>		
 					<div class="hero-stats-footer">
-						<a class="hero-stats-footer-link mt-2" href="{{ 'safer-economy/' | toTranslatedPath(tags) }}">{{varCountyMap}}</a>
+						<a class="hero-stats-footer-link mt-2" href="{{ 'safer-economy/' | toTranslatedPath(tags) }}#county-status">{{varCountyMap}}</a>
 						<a class="hero-stats-footer-link mt-2" href="https://update.covid19.ca.gov/">{{varStateSummary}}</a>
 					</div>
 				</div>


### PR DESCRIPTION
CCG-184 Link County Map button to County Status Map section on Safer Economy page. The page id is hard coded, as is the reference to varCountyMap so it makes sense to append the anchor outside of the translated path handler.