### PR TITLE
Feature/equity cleanup

### DIFF
--- a/src/css/_equitydash.scss
+++ b/src/css/_equitydash.scss
@@ -320,3 +320,12 @@ learn-more-section {
 }
 
 cagov-chart-d3-bar h2 {margin-top: 3rem;}
+
+@media (max-width: 900px) { 
+  .awesomplete {
+    display: inline-block;
+  }
+  .form-inline {
+    align-items: start;
+  }
+}

--- a/src/js/equity-dash/charts/r-e-by-100k/index.js
+++ b/src/js/equity-dash/charts/r-e-by-100k/index.js
@@ -135,7 +135,7 @@ class CAGOVEquityRE100K extends window.HTMLElement {
         .call(d3.axisBottom(x).ticks(width / 50, "s"))
         .remove()      
 
-    let statewideRatePer100k = this.combinedData[this.selectedMetric].METRIC_VALUE_PER_100K;
+    let statewideRatePer100k = this.combinedData[this.selectedMetric] ? this.combinedData[this.selectedMetric].METRIC_VALUE_PER_100K : null;
     drawBars(this.svg, x, this.y, yAxis, stackedData, this.color, data, this.tooltip, this.selectedMetricDescription, statewideRatePer100k)  
   }
 


### PR DESCRIPTION
- escape undefined error that was breaking javascript (set it to null) @jbum 
- adjust awesomeplete and form-inline alignment for county form. (this branch isn't synced with other global style changes so contained this css change to the equitydash.scss file. This file is only scoped for the equity page, correct @aaronhans? 