### PR TITLE
add link color styles for links on bg-darkblue

### DIFF
--- a/src/css/_equitydash.scss
+++ b/src/css/_equitydash.scss
@@ -330,3 +330,19 @@ cagov-chart-d3-bar h2 {margin-top: 3rem;}
     margin: 0 auto;
   }
 }
+
+.bg-darkblue a,
+.bg-darkblue a:focus {
+  color: #92C5DE; 
+  text-decoration: underline;
+}
+
+.bg-darkblue a:hover {
+  color: #92C5DE;
+  text-decoration: none;
+}
+
+.bg-darkblue a:visited {
+  color: #B797D8;
+  text-decoration: underline;
+}


### PR DESCRIPTION
Link color on dark blue backgrounds was unstyled. Used the color assignments from Figma. Publishing just to equitydash.scss for today, we can port this up into general next & confirm it doesn't have conflicts with other styles and classes.