### PR TITLE
Health equity dashboard: fix font size & alignment for chart data labels.

### DIFF
--- a/src/css/_equitydash.scss
+++ b/src/css/_equitydash.scss
@@ -61,6 +61,7 @@ cagov-chart-d3-bar {
 }
 
 cagov-chart-d3-lines {
+  max-width: 613px;
   .tick {
     font-size: 0.2rem;
   }
@@ -292,8 +293,8 @@ learn-more-section {
   margin: 0 auto;
 
   p {
-    font-size: 0.85rem;
-
+    font-size: 0.95rem;
+    margin-bottom: 0;
     &::before {
       font-family: "CaGov" !important;
       content: "\e072";
@@ -345,4 +346,7 @@ cagov-chart-d3-bar h2 {margin-top: 3rem;}
 .bg-darkblue a:visited {
   color: #B797D8;
   text-decoration: underline;
+}
+.chart-data-label {
+  font-size: 0.95rem;
 }


### PR DESCRIPTION
Add new .chart-data-label class with the font-size for chart labels from figma. Set a max width for  cagov-chart-d3-lines so it will not exceed the other chart widths; Remove bottom padding inside the highlighted chart label.