### PR TITLE
translate strings in chart

### DIFF
--- a/pages/wordpress-posts/equity.html
+++ b/pages/wordpress-posts/equity.html
@@ -314,7 +314,19 @@ addtositemap: false
 
 
 
-<cagov-chart-d3-bar></cagov-chart-d3-bar>
+<cagov-chart-d3-bar class="d-none">
+  <ul>
+    <li class="sectionTitle">Factors that increase risk of infection and severe illness</li>
+    <li class="sectionDescription">Californians in crowded housing or transportation, and with less access to paid leave and other worker protections have a higher risk of infection of COVID-19. Social determinants of health, such as food insecurity, lack of health insurance, and housing instability can increase the risk of poor outcomes. These social determinants of health are often the result of structural racism.</li>
+    <li class="chartTitleIncome">Case rate by median annual household income bracket</li>
+    <li class="chartTitleHousing">Case rate by crowding housing</li>
+    <li class="chartTitleHealthcare">Case rate by access to healthcare</li>
+    <li class="chartButtonIncome">Income</li>
+    <li class="chartButtonHousing">Crowded housing</li>
+    <li class="chartButtonHealthcare">Access to health insurance</li>
+    <li class="footnote">Note: Data comes from the American Community Survey and is statewide. It does not reflect individual counties. Data shown is cumulative for the last 7 days and updated daily</li>
+  </ul>
+</cagov-chart-d3-bar>
 
 
 

--- a/pages/wordpress-posts/equity.html
+++ b/pages/wordpress-posts/equity.html
@@ -316,15 +316,15 @@ addtositemap: false
 
 <cagov-chart-d3-bar class="d-none">
   <ul>
-    <li class="sectionTitle">Factors that increase risk of infection and severe illness</li>
-    <li class="sectionDescription">Californians in crowded housing or transportation, and with less access to paid leave and other worker protections have a higher risk of infection of COVID-19. Social determinants of health, such as food insecurity, lack of health insurance, and housing instability can increase the risk of poor outcomes. These social determinants of health are often the result of structural racism.</li>
-    <li class="chartTitleIncome">Case rate by median annual household income bracket</li>
-    <li class="chartTitleHousing">Case rate by crowding housing</li>
-    <li class="chartTitleHealthcare">Case rate by access to healthcare</li>
-    <li class="chartButtonIncome">Income</li>
-    <li class="chartButtonHousing">Crowded housing</li>
-    <li class="chartButtonHealthcare">Access to health insurance</li>
-    <li class="footnote">Note: Data comes from the American Community Survey and is statewide. It does not reflect individual counties. Data shown is cumulative for the last 7 days and updated daily</li>
+    <li data-label="sectionTitle">Factors that increase risk of infection and severe illness</li>
+    <li data-label="sectionDescription">Californians in crowded housing or transportation, and with less access to paid leave and other worker protections have a higher risk of infection of COVID-19. Social determinants of health, such as food insecurity, lack of health insurance, and housing instability can increase the risk of poor outcomes. These social determinants of health are often the result of structural racism.</li>
+    <li data-label="chartTitleIncome">Case rate by median annual household income bracket</li>
+    <li data-label="chartTitleHousing">Case rate by crowding housing</li>
+    <li data-label="chartTitleHealthcare">Case rate by access to healthcare</li>
+    <li data-label="chartButtonIncome">Income</li>
+    <li data-label="chartButtonHousing">Crowded housing</li>
+    <li data-label="chartButtonHealthcare">Access to health insurance</li>
+    <li data-label="footnote">Note: Data comes from the American Community Survey and is statewide. It does not reflect individual counties. Data shown is cumulative for the last 7 days and updated daily</li>
   </ul>
 </cagov-chart-d3-bar>
 

--- a/src/js/equity-dash/charts/social/bar-barriers.js
+++ b/src/js/equity-dash/charts/social/bar-barriers.js
@@ -1,5 +1,6 @@
 import template from './template.js';
 import {writeXAxis, rewriteLegend, writeLegend, writeBars, rewriteBars, writeBarLabels, writeSparklines, rewriteBarLabels} from './draw.js';
+import getTranslations from '../../get-strings-list.js';
 
 class CAGOVChartD3Bar extends window.HTMLElement {
   connectedCallback () {
@@ -8,6 +9,7 @@ class CAGOVChartD3Bar extends window.HTMLElement {
     let width = 842;
     let margin = ({top: 50, right: 0, bottom: 30, left: 10})
 
+    this.translationsObj = getTranslations(this);
     function sortedOrder(a,b) {
       return parseInt(a.SORT) - parseInt(b.SORT)
     }
@@ -69,7 +71,8 @@ class CAGOVChartD3Bar extends window.HTMLElement {
         
       writeLegend(this.svg, ["Cases per 100K people"], width);
   
-      this.innerHTML = template();
+      this.innerHTML = template(this.translationsObj);
+      this.classList.remove('d-none')
       this.querySelector('.svg-holder').appendChild(this.svg.node());
       window.tooltip = this.querySelector('.bar-overlay')
   
@@ -86,15 +89,15 @@ class CAGOVChartD3Bar extends window.HTMLElement {
         event.preventDefault();
         if(this.classList.contains('healthcare')) {
           rewriteBar(datahealthcare)
-          component.querySelector('.chart-title').innerHTML = 'Case rate by access to healthcare';
+          component.querySelector('.chart-title').innerHTML = component.translationsObj.chartTitleHealthcare;
         }
         if(this.classList.contains('housing')) {
           rewriteBar(datacrowding)
-          component.querySelector('.chart-title').innerHTML = 'Case rate by crowding housing';
+          component.querySelector('.chart-title').innerHTML = component.translationsObj.chartTitleHousing;
         }
         if(this.classList.contains('income')) {
           rewriteBar(dataincome)
-          component.querySelector('.chart-title').innerHTML = 'Case rate by median annual household income bracket';
+          component.querySelector('.chart-title').innerHTML = component.translationsObj.chartTitleIncome;
         }
         resetToggles();
         tog.classList.add('toggle-active')

--- a/src/js/equity-dash/charts/social/template.js
+++ b/src/js/equity-dash/charts/social/template.js
@@ -1,27 +1,27 @@
-export default function template(inputval) {
+export default function template(translationsObj) {
   return /*html*/`<div class="bg-lightblue py-2 full-bleed">
     <div class="container">
-    <h2 class="text-center">Factors that increase risk of infection and severe illness</h2>
-    <p>Californians in crowded housing or transportation, and with less access to paid leave and other worker protections have a higher risk of infection of COVID-19. Social determinants of health, such as food insecurity, lack of health insurance, and housing instability can increase the risk of poor outcomes. These social determinants of health are often the result of structural racism.</p>
+    <h2 class="text-center">${translationsObj.sectionTitle}</h2>
+    <p>${translationsObj.sectionDescription}</p>
     <div class="col-lg-12 bg-white px-3 py-4">
         <div class="row d-flex justify-content-md-center">
 
             <div class="inline-toggle-link-container">
                 <div class="toggle-links bg-darkblue bd-darkblue">
-                  <a href="#" class="toggle-active js-toggle-group income">Income</a><a href="#" class="js-toggle-group  housing">Crowded housing</a><a href="#" class="js-toggle-group healthcare">Access to health insurance</a>
+                  <a href="#" class="toggle-active js-toggle-group income">${translationsObj.chartButtonIncome}</a><a href="#" class="js-toggle-group  housing">${translationsObj.chartButtonHousing}</a><a href="#" class="js-toggle-group healthcare">${translationsObj.chartButtonHousing}</a>
                 </div>
             </div>
         </div>
         <div class="row">
             <div class="col-10 mx-auto">
-              <div class="chart-title">Case rate by median annual household income bracket</div>
+              <div class="chart-title">${translationsObj.chartTitleIncome}</div>
               <div class="svg-holder">
                 <div class="bar-overlay">an empty tooltip</div>
               </div>
             </div>
         </div>
         <div class="row d-flex justify-content-md-center">
-          <p class="text-xs">Note: Data comes from the American Community Survey and is statewide. It does not reflect individual counties. Data shown is cumulative for the last 7 days and updated daily</p>
+          <p class="text-xs">${translationsObj.footnote}</p>
         </div>
     </div><!--END col-12-->
   </div><!--END CONTAINER-->

--- a/src/js/equity-dash/get-strings-list.js
+++ b/src/js/equity-dash/get-strings-list.js
@@ -1,0 +1,8 @@
+export default function getTranslations(container) {
+  let translationsObj = {};
+  let translateEls = container.querySelectorAll('li');
+  translateEls.forEach(item => {
+    translationsObj[item.classList] = item.innerHTML;
+  })
+  return translationsObj;
+}

--- a/src/js/equity-dash/get-strings-list.js
+++ b/src/js/equity-dash/get-strings-list.js
@@ -1,8 +1,8 @@
 export default function getTranslations(container) {
   let translationsObj = {};
-  let translateEls = container.querySelectorAll('li');
+  let translateEls = container.querySelectorAll('[data-label]');
   translateEls.forEach(item => {
-    translationsObj[item.classList] = item.innerHTML;
+    translationsObj[item.dataset.label] = item.innerHTML;
   })
   return translationsObj;
 }


### PR DESCRIPTION
This is a PR with an example of retrieving translated strings from the body of the WordPress post. Our constraints are:

- The translation vendor receives content from the WordPress post
- The translation vendor ignores HTML attributes so we can't use data attributes

This requires strings be put in list elements that are children of the custom element with their keys set as classnames

We briefly discussed an alternate approach where we could use a separate table-data post. That would work too and we could end up passing the translation string object into the custom element but the method in this PR seems fine as well.
