### PR TITLE
CCG-677

### DIFF
--- a/pages/_includes/dashboard.njk
+++ b/pages/_includes/dashboard.njk
@@ -177,6 +177,14 @@
 
         </div>
 
+        <div class="text-center">
+
+            <a class="button trigger cwdsarrow-parent hi-50" href="/data-and-tools/">
+            <div class="button-label">Explore more data</div>
+            <cwds-arrow data-class-prefix="more-news" data-class-list="cwdsarrow-size-md cwdsarrow-idle-blue cwdsarrow-hover-darkblue cwdsarrow-focus-orangeback"><figure class="cwdsarrow more-news-cwdsarrow cwdsarrow-size-md cwdsarrow-idle-blue cwdsarrow-hover-darkblue cwdsarrow-focus-orangeback" aria-hidden="true"></cwds-arrow>
+            </a>
+        </div>
+
         <div class="row d-flex justify-content-md-center">
 
             <h2 class="text-center color-purple">This data drives decisions that keep California healthy and safe</h2>

--- a/pages/_includes/dashboard.njk
+++ b/pages/_includes/dashboard.njk
@@ -178,11 +178,11 @@
         </div>
 
         <div class="text-center">
-
-            <a class="button trigger cwdsarrow-parent hi-50" href="/data-and-tools/">
-            <div class="button-label">Explore more data</div>
-            <cwds-arrow data-class-prefix="more-news" data-class-list="cwdsarrow-size-md cwdsarrow-idle-blue cwdsarrow-hover-darkblue cwdsarrow-focus-orangeback"><figure class="cwdsarrow more-news-cwdsarrow cwdsarrow-size-md cwdsarrow-idle-blue cwdsarrow-hover-darkblue cwdsarrow-focus-orangeback" aria-hidden="true"></cwds-arrow>
-            </a>
+        
+            <a href="/data-and-tools/" class="link-arrow-blue">
+            <div class="link-arrow-label">Explore more data</div>
+            <cagov-arrow></cagov-arrow>
+            </a>  
         </div>
 
         <div class="row d-flex justify-content-md-center">
@@ -226,9 +226,9 @@
   
         <div class="text-center">
 
-            <a class="button trigger cwdsarrow-parent hi-50" href="/safer-economy/">
-            <div class="button-label">See what can be open in your county</div>
-            <cwds-arrow data-class-prefix="more-news" data-class-list="cwdsarrow-size-md cwdsarrow-idle-blue cwdsarrow-hover-darkblue cwdsarrow-focus-orangeback"><figure class="cwdsarrow more-news-cwdsarrow cwdsarrow-size-md cwdsarrow-idle-blue cwdsarrow-hover-darkblue cwdsarrow-focus-orangeback" aria-hidden="true"></cwds-arrow>
+            <a href="/safer-economy/" class="link-arrow-blue">
+            <div class="link-arrow-label">See what can be open in your county</div>
+            <cagov-arrow></cagov-arrow>
             </a>
         </div>
     </div><!--END col-10-->


### PR DESCRIPTION
This change is to add a link to the Data & tools page, as called for in Adam's Figma design. I used the existing code for the "See what can be open in your county" call-to-action to create this and swapped out the text and the URL as appropriate.

Please stage this change before publishing to production to check that this didn't break anything. Hopefully I placed it in the right spot. Ideally it would be nice to have some space between this link and the "This data drives decisions..." header.

Thank you!