### PR TITLE
fix unscoped call on chart options 

### DIFF
--- a/src/js/equity-dash/charts/data-completeness/index.js
+++ b/src/js/equity-dash/charts/data-completeness/index.js
@@ -111,7 +111,9 @@ class CAGOVEquityMissingness extends window.HTMLElement {
 
     this.retrieveData(this.dataUrl);
     this.listenForLocations();
-    this.querySelector('.d-none').classList.remove("d-none");
+    if (this.querySelector('.d-none') !== null) {
+      this.querySelector('.d-none').classList.remove("d-none");
+    }
   }
 
   listenForLocations() {

--- a/src/js/equity-dash/charts/healthy-places-index/index.js
+++ b/src/js/equity-dash/charts/healthy-places-index/index.js
@@ -113,7 +113,9 @@ class CAGOVChartD3Lines extends window.HTMLElement {
     this.writeLegendColors(this.chartOptions.chartColors, this.legend);
     this.writeLegendLabels(legendLabels, this.legend);
     this.listenForLocations();
-    this.querySelector('.d-none').classList.remove("d-none");
+    if (this.querySelector('.d-none') !== null) {
+      this.querySelector('.d-none').classList.remove("d-none");
+    }
   }
 
   listenForLocations() {

--- a/src/js/equity-dash/charts/social-determinants/index.js
+++ b/src/js/equity-dash/charts/social-determinants/index.js
@@ -141,13 +141,13 @@ class CAGOVChartD3Bar extends window.HTMLElement {
 
       this.querySelector('.svg-holder').appendChild(this.svg.node());
       window.tooltip = this.querySelector('.bar-overlay')  
-      this.applyListeners(this.svg, x, y, this.chartBreakpointValues.height, this.chartBreakpointValues.margin, xAxis, dataincome, datacrowding, datahealthcare)
+      this.applyListeners(this.svg, x, y, this.chartBreakpointValues.height, this.chartBreakpointValues.margin, xAxis, dataincome, datacrowding, datahealthcare, this.chartBreakpointValues)
       this.classList.remove('d-none')
     }.bind(this));
 
   }
 
-  applyListeners(svg, x, y, height, margin, xAxis, dataincome, datacrowding, datahealthcare) {
+  applyListeners(svg, x, y, height, margin, xAxis, dataincome, datacrowding, datahealthcare, chartBreakpointValues) {
     let toggles = this.querySelectorAll('.js-toggle-group');
     let component = this;
     toggles.forEach(tog => {
@@ -179,11 +179,11 @@ class CAGOVChartD3Bar extends window.HTMLElement {
     function rewriteBar(dataset) {
       y = d3.scaleLinear()
         .domain([0, d3.max(dataset, d => d.CASE_RATE_PER_100K)]).nice()
-        .range([this.chartBreakpointValues.height - this.chartBreakpointValues.margin.bottom, this.chartBreakpointValues.margin.top])
+        .range([chartBreakpointValues.height - chartBreakpointValues.margin.bottom, chartBreakpointValues.margin.top])
 
       rewriteBars(svg, dataset, x, y);
-      rewriteBarLabels(svg, dataset, x, y, this.chartBreakpointValues.sparkline);
-      xAxis = writeXAxis(dataset, this.chartBreakpointValues.height, this.chartBreakpointValues.margin, x);
+      rewriteBarLabels(svg, dataset, x, y, chartBreakpointValues.sparkline);
+      xAxis = writeXAxis(dataset, chartBreakpointValues.height, chartBreakpointValues.margin, x);
       svg.selectAll(".xaxis")
         .call(xAxis);
     }


### PR DESCRIPTION
& escape check for d-none for markup from WordPress