### PR TITLE
d-none rolls without importance 

### DIFF
--- a/src/css/_charts.scss
+++ b/src/css/_charts.scss
@@ -12,6 +12,10 @@
   margin: auto;
   width: 100%;
 
+  &.d-none {
+    display: none;
+  }
+
   .svg-holder {
     max-width: 613px;
   }


### PR DESCRIPTION
and .chart class is loaded after it with display: block so it wasn't hiding anything