### PR TITLE
Fixing bugs with tooltips, updating accessible charts

### DIFF
--- a/src/js/equity-dash/charts/data-completeness/draw.js
+++ b/src/js/equity-dash/charts/data-completeness/draw.js
@@ -50,7 +50,31 @@ function drawBars(svg, x, y, yAxis, stackedData, color, data, tooltip, translati
     .attr("width", d => x(d[1]) - x(d[0]))
     .attr("height", "10px")
 
-    .on("mouseover", function(event, d) {
+    .attr("tabindex", "0")
+    .attr("aria-label", (d, i) => {
+      let percentNotMissing = d.data.NOT_MISSING
+        ? parseFloat(d.data.NOT_MISSING * 100).toFixed(1) + "%"
+        : 0;
+
+      let percentMissing = d.data.MISSING
+        ? parseFloat(d.data.MISSING * 100).toFixed(1) + "%"
+        : 0;
+
+      if (d[0] == 0) {
+        return translations.chartTooltip({
+          metric: d.data.METRIC,
+          highlightData: percentNotMissing,
+          complete: true,
+        });
+      } else {
+        return translations.chartTooltip({
+          metric: d.data.METRIC,
+          highlightData: percentMissing,
+          complete: false,
+        });
+      }})
+
+    .on("mouseover focus", function(event, d) {
       d3.select(this).transition();
       tooltip.html(() => {
         let percentNotMissing = d.data.NOT_MISSING

--- a/src/js/equity-dash/charts/data-completeness/index.js
+++ b/src/js/equity-dash/charts/data-completeness/index.js
@@ -321,7 +321,7 @@ class CAGOVEquityMissingness extends window.HTMLElement {
         tooltipHTML = tooltipHTML.replace('<span data-replace="highlight-data"></span>', `<span data-replace="highlight-data">${highlightData}</span>`);
         tooltipHTML = tooltipHTML.replace('<span data-replace="location">California</span>', `<span data-replace="location">${location}</span>`);
         tooltipHTML = tooltipHTML.replace('<span data-replace="data-type">race and ethnicity</span>', `<span data-replace="data-type">${dataType}</span>`);
-        return tooltipHTML;
+        return `<div class="chart-tooltip"><div>${tooltipHTML}</div></div>`;
       }
     return translations;
   }

--- a/src/js/equity-dash/charts/healthy-places-index/index.js
+++ b/src/js/equity-dash/charts/healthy-places-index/index.js
@@ -371,6 +371,7 @@ class CAGOVChartD3Lines extends window.HTMLElement {
       const tooltip = new Tooltip(true);
       const tooltip2 = new Tooltip(false);
 
+      
       svg
         .on("mousemove", (event) => {
           // console.log("move: " + event.offsetX);

--- a/src/js/equity-dash/charts/relative-percentage-by-100k/draw-chart.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-100k/draw-chart.js
@@ -41,9 +41,14 @@ export default function drawBars(stackedData, data, statewideRatePer100k) {
     .attr("height", "10px")
 
     .attr("tabindex", "0")
-    .attr("aria-label", (d, i) => `<div class="chart-tooltip">
-    <div >placeholder</div>
-  </div>`)
+    .attr("aria-label", (d, i) => {
+      let caption = component.toolTipCaption(
+        d.data.DEMOGRAPHIC_SET_CATEGORY, 
+        d.data.METRIC_VALUE_PER_100K ? parseFloat(d.data.METRIC_VALUE_PER_100K).toFixed(0) : 0,
+        filterScope.toLowerCase()
+        );
+      return `<div class="chart-tooltip"><div>${caption}</div></div>`
+    })
 
     .on("mouseover focus", function(event, d) {
       d3.select(this).transition();

--- a/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart-second.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart-second.js
@@ -40,8 +40,8 @@ export default function drawSecondBars({
     .attr("height", "10px")
 
     .attr("tabindex", "0")
-    .attr("aria-label", (d, i) => `<div class="chart-tooltip">
-    <div>unused_caption2</div>`)
+    // .attr("aria-label", (d, i) => `<div class="chart-tooltip">
+    // <div>unused_caption2</div>`)
 
      // jbum: event handlers appear to be unused
     .on("mouseover focus", function (event, d) {
@@ -49,11 +49,12 @@ export default function drawSecondBars({
       d3.select(this).transition();
 
       // Rephrase as "X people make up XX% of cases statewide and XX% of California's population"
-      tooltip.html(`<div class="chart-tooltip">
-          <div>unused_caption1 </div>`);
-      tooltip.style("visibility", "visible");
-      tooltip.style("left", "90px");
-      tooltip.style("top", `${event.offsetY + 100}px`);
+      // @TODO Commented out so that we do not launch with incomplete code.
+      // tooltip.html(`<div class="chart-tooltip">
+      //     <div>unused_caption1 </div>`);
+      // tooltip.style("visibility", "visible");
+      // tooltip.style("left", "90px");
+      // tooltip.style("top", `${event.offsetY + 100}px`);
     })
     .on("mouseout", function (d) {
       d3.select(this).transition();

--- a/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart.js
@@ -47,15 +47,18 @@ export default function drawBars({
     .attr("width", (d) => x1(d[1]) - x1(d[0]))
     .attr("height", "10px")
     .attr("tabindex", "0")
-    .attr("aria-label", (d, i) => `<div class="chart-tooltip">
-    <div >placeholder</div>
-    </div>`)
+    .attr("aria-label", (d, i) => {
+      let caption = component.getToolTipCaption1(d, legendStrings[0]);
+      return `<div class="chart-tooltip">
+      <div>${caption}</div>
+      </div>`}
+    )
     
     .on("mouseover focus", function (event, d) {
       d3.select(this).transition();
       // Rephrase as "X people make up XX% of cases statewide and XX% of California's population"
       let caption = component.getToolTipCaption1(d, legendStrings[0]);
-      tooltip.html(`<div class="chart-tooltip"><div >${caption}</div></div>`);
+      tooltip.html(`<div class="chart-tooltip"><div>${caption}</div></div>`);
       tooltip.style("visibility", "visible");
       tooltip.style("left", "90px");
       tooltip.style("top", `${event.offsetY + 100}px`);

--- a/src/js/equity-dash/charts/social-determinants/draw.js
+++ b/src/js/equity-dash/charts/social-determinants/draw.js
@@ -64,26 +64,30 @@ function writeBars(svg, data, x, y, width, tooltip) {
       .on("mouseover focus", function(event, d, i) {
         d3.select(this).style("fill", "#003D9D");
         // problem the svg is not the width in px in page as the viewbox width
-        tooltip.style.top = "50%";
-        let barIdInt = this.id.replace('barid-','');
-        let svgLeft = x(barIdInt)
-        let percentLeft = svgLeft / width;
-        let elWidth = document.querySelector('.svg-holder .equity-bar-chart').getBoundingClientRect().width; 
-        let actualLeft = parseInt(percentLeft * elWidth) - 70;
-        // @TODO 70 is quick approximation, could actually be subtract half width of tooltip - half width of bar
-        tooltip.style.left = parseInt(actualLeft)+"px";
-        
-        // @TODO Adapt from example from data completeness, add to translations.
-        tooltip.innerHTML = `<div class="chart-tooltip-desc">
-          <span class="highlight-data">${parseFloat(d.CASE_RATE_PER_100K).toFixed(1)}</span> 
-          cases per 100K people. ${parseFloat(d.RATE_DIFF_30_DAYS).toFixed(1)}% 
-          change since previous week
-          </div>`;
-        tooltip.style.visibility = "visible";
+        if (tooltip !== null) { // @TODO Q: why is tooltip coming null
+          tooltip.style.top = "50%";
+          let barIdInt = this.id.replace('barid-','');
+          let svgLeft = x(barIdInt)
+          let percentLeft = svgLeft / width;
+          let elWidth = document.querySelector('.svg-holder .equity-bar-chart').getBoundingClientRect().width; 
+          let actualLeft = parseInt(percentLeft * elWidth) - 70;
+          tooltip.style.left = parseInt(actualLeft)+"px";
+          // @TODO 70 is quick approximation, could actually be subtract half width of tooltip - half width of bar
+
+            // @TODO Adapt from example from data completeness, add to translations.
+            tooltip.innerHTML = `<div class="chart-tooltip chart-tooltip-desc">
+            <span class="highlight-data">${parseFloat(d.CASE_RATE_PER_100K).toFixed(1)}</span> 
+            cases per 100K people. ${parseFloat(d.RATE_DIFF_30_DAYS).toFixed(1)}% 
+            change since previous week
+            </div>`;
+            tooltip.style.visibility = "visible";
+        }
       })
       .on("mouseout blur", function(d) {
         d3.select(this).style("fill", "#92C5DE");
-        tooltip.style.visibility = "hidden";
+        if (tooltip !== null) { // @TODO Q: why is tooltip coming null
+          tooltip.style.visibility = "hidden";
+        }
       });
 }
 function rewriteBars(svg, data, x, y) {

--- a/src/js/equity-dash/charts/social-determinants/index.js
+++ b/src/js/equity-dash/charts/social-determinants/index.js
@@ -130,7 +130,7 @@ class CAGOVChartD3Bar extends window.HTMLElement {
         .padding(0.1)
 
       this.innerHTML = template(this.translationsObj);
-      this.tooltip = this.querySelector('.chart-tooltip')  
+      this.tooltip = this.querySelector('.tooltip-container'); // @TODO: Q: where did the class go? tooltip is coming back null.
       writeBars(this.svg, dataincome, x, y, this.chartBreakpointValues.width, this.tooltip);
       writeBarLabels(this.svg, dataincome, x, y, this.chartBreakpointValues.sparkline);
       let xAxis = writeXAxis(dataincome, this.chartBreakpointValues.height, this.chartBreakpointValues.margin, x);


### PR DESCRIPTION
fix errors with with tooltips, hide in-progress code that has visible placeholders, add chart accessibility to all charts except healthy-places-index. The accessibility for the line-chart needs some research since the interaction pattern for that chart differs from the others.