### PR TITLE
Equity page markup fix to prevent double charts and missing charts.

### DIFF
--- a/pages/wordpress-posts/equity.html
+++ b/pages/wordpress-posts/equity.html
@@ -263,43 +263,43 @@ addtositemap: false
 
 <div class="container">
   <div class="row">
-    <div class="col">
-      <cagov-chart-re-pop class="chart d-none">
-             <ul>
-          <li data-label="chartTitle--cases">Cases relative to percentage of population in placeholderForDynamicLocation</li>
-          <li data-label="chartTitle--deaths">Deaths relative to percentage of population in placeholderForDynamicLocation</li>
-          <li data-label="chartTitle--tests">Testing relative to percentage of population in placeholderForDynamicLocation</li>
-          
-          <li data-label="chartLegend1County--cases">of cases in county</li>
-          <li data-label="chartLegend1County--deaths">of deaths in county</li>
-          <li data-label="chartLegend1County--tests">of testing in county</li>
-          <li data-label="chartLegend1State--cases">of cases statewide</li>
-          <li data-label="chartLegend1State--deaths">of deaths statewide</li>
-          <li data-label="chartLegend1State--tests">of testing statewide</li>
-          <li data-label="chartLegend2--cases">of state population</li>
-          <li data-label="chartLegend2--deaths">of state population</li>
-          <li data-label="chartLegend2--tests">of state population</li>
-          <li data-label="chartDescription--cases">Compare the percentage of each race and ethnicity’s share of statewide cases to their percentage of placeholderForDynamicLocation’s population.</li>
-          <li data-label="chartDescription--deaths">Compare the percentage of each race and ethnicity’s share of statewide deaths to their percentage of placeholderForDynamicLocation’s population.</li>
-          <li data-label="chartDescription--tests">Compare the percentage of each race and ethnicity’s share of statewide tests to their percentage of placeholderForDynamicLocation’s population.</li>
-          <li data-label="chartLineDiff">change since previous month</li>
-          <li data-label="relative-percentage-state-population">% of state population</li>
-          <li data-label="relative-percentage-statewide">% of cases statewide</li>
-          <li data-label="relative-percentage-county">% of cases in county</li>
-          <li data-label="county-label">County</li>
-          <li data-label="applied-suppression-total">To protect people’s privacy, we’re not showing any data. This is because there’s either too few cases or tests in this group.</li>
-          <li data-label="applied-suppression-population">To protect people’s privacy, we’re not showing any data. This is because there are less than 20,000 people in this group.</li>
-          <li data-label="missing-data-caption-line-delimiter"><br></li>
-          <li data-label="chartToolTip1-caption">placeholder_DEMOGRAPHIC_SET_CATEGORY people make up <span class="highlight-data"> placeholder_METRIC_TOTAL_PERCENTAGE</span> placeholder_LegendString
-          and <span class="highlight-data"> placeholder_POPULATION_PERCENTAGE </span> of California&#8217;s population</li>
-          <li data-label="chartToolTip2-caption">placeholder_DEMOGRAPHIC_SET_CATEGORY people make up<span class="highlight-data"> placeholder_POPULATION_PERCENTAGE</span>
-          of California&#8217;s population and <span class="highlight-data"> placeholder_METRIC_TOTAL_PERCENTAGE</span> of
-          placeholder_SelectedMetric statewide</li>
-        </ul></cagov-chart-re-pop>
+      <div class="col">
+        <cagov-chart-re-pop class="chart d-none">
+          <ul>
+            <li data-label="chartTitle--cases">Cases relative to percentage of population in placeholderForDynamicLocation</li>
+            <li data-label="chartTitle--deaths">Deaths relative to percentage of population in placeholderForDynamicLocation</li>
+            <li data-label="chartTitle--tests">Testing relative to percentage of population in placeholderForDynamicLocation</li>
+            <li data-label="chartLegend1County--cases">of cases in county</li>
+            <li data-label="chartLegend1County--deaths">of deaths in county</li>
+            <li data-label="chartLegend1County--tests">of testing in county</li>
+            <li data-label="chartLegend1State--cases">of cases statewide</li>
+            <li data-label="chartLegend1State--deaths">of deaths statewide</li>
+            <li data-label="chartLegend1State--tests">of testing statewide</li>
+            <li data-label="chartLegend2--cases">of state population</li>
+            <li data-label="chartLegend2--deaths">of state population</li>
+            <li data-label="chartLegend2--tests">of state population</li>
+            <li data-label="chartDescription--cases">Compare the percentage of each race and ethnicity’s share of statewide cases to their percentage of placeholderForDynamicLocation’s population.</li>
+            <li data-label="chartDescription--deaths">Compare the percentage of each race and ethnicity’s share of statewide deaths to their percentage of placeholderForDynamicLocation’s population.</li>
+            <li data-label="chartDescription--tests">Compare the percentage of each race and ethnicity’s share of statewide tests to their percentage of placeholderForDynamicLocation’s population.</li>
+            <li data-label="chartLineDiff">change since previous month</li>
+            <li data-label="relative-percentage-state-population">% of state population</li>
+            <li data-label="relative-percentage-statewide">% of cases statewide</li>
+            <li data-label="relative-percentage-county">% of cases in county</li>
+            <li data-label="county-label">County</li>
+            <li data-label="applied-suppression-total">To protect people’s privacy, we’re not showing any data. This is because there’s either too few cases or tests in this group.</li>
+            <li data-label="applied-suppression-population">To protect people’s privacy, we’re not showing any data. This is because there are less than 20,000 people in this group.</li>
+            <li data-label="missing-data-caption-line-delimiter"><br></li>
+            <li data-label="chartToolTip1-caption">placeholder_DEMOGRAPHIC_SET_CATEGORY people make up <span class="highlight-data"> placeholder_METRIC_TOTAL_PERCENTAGE</span> placeholder_LegendString
+            and <span class="highlight-data"> placeholder_POPULATION_PERCENTAGE </span> of California&#8217;s population</li>
+            <li data-label="chartToolTip2-caption">placeholder_DEMOGRAPHIC_SET_CATEGORY people make up<span class="highlight-data"> placeholder_POPULATION_PERCENTAGE</span>
+            of California&#8217;s population and <span class="highlight-data"> placeholder_METRIC_TOTAL_PERCENTAGE</span> of
+            placeholder_SelectedMetric statewide</li>
+        </ul>
+      </cagov-chart-re-pop>
     </div>
     <div class="col">
       <cagov-chart-re-100k class="chart d-none"> 
-    <ul>
+        <ul>
           <li data-label="chartTitle--cases">Cases rate per 100K by race and ethnicity group in placeholderForDynamicLocation</li>
           <li data-label="chartTitle--deaths">Deaths rate per 100K by race and ethnicity group in placeholderForDynamicLocation</li>
           <li data-label="chartTitle--tests">Testing rate per 100K by race and ethnicity group in placeholderForDynamicLocation</li>
@@ -319,78 +319,11 @@ addtositemap: false
           <li data-label="chartToolTip-caption"><span class="highlight-data">placeholderDEMO_CAT</span> people have <span
             class="highlight-data">placeholderMETRIC_100K</span> placeholderFilterScope for 100k people of the same race and
           ethnicity.</li>
-        </ul></cagov-chart-re-100k>
-    </div>
-  </div>
-</div><cagov-county-search></cagov-county-search>
-
-<cagov-county-toggle-buttons></cagov-county-toggle-buttons>
-
-<!--SMALL TABS-->
-<cagov-chart-filter-buttons class="js-re-smalls">
-  <div class="d-flex justify-content-center">
-    <button class="small-tab active" data-key="cases">Cases</button>
-    <button class="small-tab" data-key="deaths">Deaths</button>
-    <button class="small-tab" data-key="tests">Testing</button>
-  </div>
-</cagov-chart-filter-buttons>
-
-<div class="container">
-  <div class="row">
-    <div class="col">
-      <cagov-chart-re-pop class="chart d-none">
-        <ul>
-          <li data-label="chartTitle--cases">Cases relative to percentage of population in placeholderForDynamicLocation</li>
-          <li data-label="chartTitle--deaths">Deaths relative to percentage of population in placeholderForDynamicLocation</li>
-          <li data-label="chartTitle--tests">Testing relative to percentage of population in placeholderForDynamicLocation</li>
-          <li data-label="chartDescription--cases">Compare the percentage of each race and ethnicity’s share of statewide cases to their percentage of placeholderForDynamicLocation’s population.</li>
-          <li data-label="chartDescription--deaths">Compare the percentage of each race and ethnicity’s share of statewide deaths to their percentage of placeholderForDynamicLocation’s population.</li>
-          <li data-label="chartDescription--tests">Compare the percentage of each race and ethnicity’s share of statewide tests to their percentage of placeholderForDynamicLocation’s population.</li>
-          <li data-label="chartLineDiff">change since previous month</li>
-          <li data-label="chartLegend1County--cases">of cases in county</li>
-          <li data-label="chartLegend1County--deaths">of deaths in county</li>
-          <li data-label="chartLegend1County--tests">of testing in county</li>
-          <li data-label="chartLegend1State--cases">of cases statewide</li>
-          <li data-label="chartLegend1State--deaths">of deaths statewide</li>
-          <li data-label="chartLegend1State--tests">of testing statewide</li>
-          <li data-label="chartLegend2--cases">of state population</li>
-          <li data-label="chartLegend2--deaths">of state population</li>
-          <li data-label="chartLegend2--tests">of state population</li>
-          <li data-label="chartToolTip1-caption">placeholder_DEMOGRAPHIC_SET_CATEGORY people make up <span class="highlight-data"> placeholder_METRIC_TOTAL_PERCENTAGE</span> placeholder_LegendString
-          and <span class="highlight-data"> placeholder_POPULATION_PERCENTAGE </span> of California&#8217;s population</li>
-          <li data-label="chartToolTip2-caption">placeholder_DEMOGRAPHIC_SET_CATEGORY people make up<span class="highlight-data"> placeholder_POPULATION_PERCENTAGE</span>
-          of California&#8217;s population and <span class="highlight-data"> placeholder_METRIC_TOTAL_PERCENTAGE</span> of
-          placeholder_SelectedMetric statewide</li>
-
-        </ul></cagov-chart-re-pop>
-    </div>
-    <div class="col">
-      <cagov-chart-re-100k class="chart d-none"> 
-<ul>
-          <li data-label="chartTitle--cases">Cases rate per 100K by race and ethnicity group in placeholderForDynamicLocation</li>
-          <li data-label="chartTitle--deaths">Deaths rate per 100K by race and ethnicity group in placeholderForDynamicLocation</li>
-          <li data-label="chartTitle--tests">Testing rate per 100K by race and ethnicity group in placeholderForDynamicLocation</li>
-          <li data-label="chartDescription--cases">Compare cases adjusted by population size across each race and ethnicity.</li>
-          <li data-label="chartDescription--deaths">Compare deaths adjusted by population size across each race and ethnicity.</li>
-          <li data-label="chartDescription--tests">Compare tests adjusted by population size across each race and ethnicity.</li>
-          <li data-label="chartLineDiff">change since previous month</li>
-          <li data-label="chartLegend--cases">Cases per 100k people</li>
-          <li data-label="chartLegend--deaths">Deaths per 100k people</li>
-          <li data-label="chartLegend--tests">Tests per 100k people</li>
-          <li data-label="chartFilterLegendPfxCounty--cases">placeholderForDynamicLocation cases per 100k: </li>
-          <li data-label="chartFilterLegendPfxCounty--deaths">placeholderForDynamicLocation deaths per 100k: </li>
-          <li data-label="chartFilterLegendPfxCounty--tests">placeholderForDynamicLocation tests per 100k: </li>
-          <li data-label="chartFilterLegendPfxState--cases">Statewide cases per 100k: </li>
-          <li data-label="chartFilterLegendPfxState--deaths">Statewide deaths per 100k: </li>
-          <li data-label="chartFilterLegendPfxState--tests">Statewide tests per 100k: </li>
-          <li data-label="chartToolTip-caption"><span class="highlight-data">placeholderDEMO_CAT</span> people have <span class="highlight-data">placeholderMETRIC_100K</span> placeholderFilterScope for 100k people of the same race and
-          ethnicity</li>
-        </ul></cagov-chart-re-100k>
+        </ul>
+      </cagov-chart-re-100k>
     </div>
   </div>
 </div>
-
-
 
 <p class="chart-data-label">Note: Data shown is cumulative since January 2020 and updated daily. Population estimates do not include &#8220;other&#8221; or &#8220;unknown&#8221; race and ethnicity categories, therefore their percentage of state population is not available. To see race and ethnicity data broken out by age groups, see the California Department of Public Health’s COVID-19 <a href="https://www.cdph.ca.gov/Programs/CID/DCDC/Pages/COVID-19/Race-Ethnicity.aspx" target="_blank" rel="noopener noreferrer">Race and Ethnicity Data</a>. Numbers between 1 and 11 are shown as &#8220;&lt;11&#8221; to protect patient privacy.</p>
 
@@ -410,17 +343,16 @@ addtositemap: false
 
 <div class="col-lg-10 mx-auto">
 <cagov-chart-d3-lines class="chart d-none">
-  <ul>
     <div>
-<ul>
+      <ul>
         <li data-label="y-axis-label">Test positivity</li>
         <li data-label="data1-legend">Statewide positivity</li>
         <li data-label="data1-legend-local">placeholderForDynamicLocation test positivity</li>
         <li data-label="data2-legend">Health equity quartile positivity</li>
-        <li data-label="missing-data-caption">The health equity metric is not<br>applied to counties with a
-          population<br>less than 106,000.</li>
+        <li data-label="missing-data-caption">The health equity metric is not<br>applied to counties with a population<br>less than 106,000.</li>
         <li data-label="missing-data-caption-line-delimiter"><br></li>
       </ul>
+    </div>
 </cagov-chart-d3-lines>
 </div>
 

--- a/pages/wordpress-posts/equity.html
+++ b/pages/wordpress-posts/equity.html
@@ -440,6 +440,8 @@ addtositemap: false
     <li data-label="footnote">Note: Data comes from the American Community Survey and is statewide. It does not reflect individual counties. Data shown is cumulative for the last 7 days and updated daily</li>
    <li data-label="casesPer100KPeople">Cases per 100k people</li>
    <li data-label="statewideCaseRate">Statewide case rate:</li>
+   <li data-label="ariaBarLabel">placeholderCaseRate cases per 100K people. placeholderRateDiff30 change since previous week</li>
+   <li data-label="tooltipCaption"><span class="highlight-data">placeholderCaseRate</span> cases per 100K people. placeholderRateDiff30 change since previous week</li>
   </ul></cagov-chart-d3-bar>
 
 

--- a/src/js/equity-dash/charts/relative-percentage-by-100k/index.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-100k/index.js
@@ -107,7 +107,7 @@ this.chartOptions = {
     this.county = "California";
     this.drawBars = drawBars;
     this.chartTitle = function () {
-      console.log("Getting chart title 100k metric=", this.selectedMetric);
+      // console.log("Getting chart title 100k metric=", this.selectedMetric);
       return this.translationsObj["chartTitle--" + this.selectedMetric].replace(
         "placeholderForDynamicLocation",
         this.county

--- a/src/js/equity-dash/charts/relative-percentage-by-pop/index.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-pop/index.js
@@ -395,7 +395,7 @@ class CAGOVEquityREPop extends window.HTMLElement {
   }
 
   checkAppliedDataSuppression(data) {
-    console.log(data);
+    // console.log(data);
     let suppressionAllocations = {
       None: 0,
       Total: 0,
@@ -410,7 +410,7 @@ class CAGOVEquityREPop extends window.HTMLElement {
     if (suppressionAllocations["Population"] === data.length) {
     }
 
-    console.log("suppressionAllocations", suppressionAllocations);
+    // console.log("suppressionAllocations", suppressionAllocations);
     // APPLIED_SUPPRESSION: "None"
     // COUNTY: "California"
     // DEMOGRAPHIC_SET: "race_ethnicity"
@@ -459,7 +459,7 @@ class CAGOVEquityREPop extends window.HTMLElement {
   }
 
   getMissingDataBox(appliedSuppressionType) {
-    console.log("this", this);
+    // console.log("this", this);
     let type = "appliedSuppressionTotal"; // @TODO connect to logic
 
     // let messagesByType = {

--- a/src/js/equity-dash/charts/social-determinants/draw.js
+++ b/src/js/equity-dash/charts/social-determinants/draw.js
@@ -46,7 +46,7 @@ function writeLegend(svg, legendLabels, width, legendPositions) {
     .attr('text-anchor', 'start')
     .attr('alignment-baseline', 'hanging');
 }
-function writeBars(svg, data, x, y, width, tooltip) {
+function writeBars(component, svg, data, x, y, width, tooltip) {
   svg.append("g")
     .attr("fill", "#92C5DE")
     .attr('class','barshere')
@@ -60,7 +60,7 @@ function writeBars(svg, data, x, y, width, tooltip) {
       .attr("width", x.bandwidth())
       .attr("id", (d, i) => "barid-"+i)
       .attr("tabindex", "0")
-      .attr("aria-label", (d, i) => `${parseFloat(d.CASE_RATE_PER_100K).toFixed(1)} cases per 100K people. ${parseFloat(d.RATE_DIFF_30_DAYS).toFixed(1)}% change since previous week`)
+      .attr("aria-label", (d, i) => `${component.ariaLabel(d)}`)
       .on("mouseover focus", function(event, d, i) {
         d3.select(this).style("fill", "#003D9D");
         // problem the svg is not the width in px in page as the viewbox width
@@ -75,11 +75,7 @@ function writeBars(svg, data, x, y, width, tooltip) {
           // @TODO 70 is quick approximation, could actually be subtract half width of tooltip - half width of bar
 
             // @TODO Adapt from example from data completeness, add to translations.
-            tooltip.innerHTML = `<div class="chart-tooltip chart-tooltip-desc">
-            <span class="highlight-data">${parseFloat(d.CASE_RATE_PER_100K).toFixed(1)}</span> 
-            cases per 100K people. ${parseFloat(d.RATE_DIFF_30_DAYS).toFixed(1)}% 
-            change since previous week
-            </div>`;
+            tooltip.innerHTML = `<div class="chart-tooltip chart-tooltip-desc">${component.tooltipCaption(d)}</div>`;
             tooltip.style.visibility = "visible";
         }
       })
@@ -90,14 +86,14 @@ function writeBars(svg, data, x, y, width, tooltip) {
         }
       });
 }
-function rewriteBars(svg, data, x, y) {
+function rewriteBars(component, svg, data, x, y) {
   svg.selectAll(".barshere rect")
     .data(data)
     .transition().duration(300)
     .attr("x", (d, i) => x(i))
     .attr("y", d => y(d.CASE_RATE_PER_100K))
     .attr("height", d => y(0) - y(d.CASE_RATE_PER_100K))
-    .attr("aria-label", (d, i) => `${parseFloat(d.CASE_RATE_PER_100K).toFixed(1)} cases per 100K people. ${parseFloat(d.RATE_DIFF_30_DAYS).toFixed(1)}% change since previous week`)
+    .attr("aria-label", (d, i) => `${component.ariaLabel(d)}`)
 }
 
 function writeBarLabels(svg, data, x, y, sparkline) {


### PR DESCRIPTION
There were two errors in equity.html (which I've fixed on WP already). There was a long block of code that was duplicated (the top two charts) due to cut & paste error. There were mismatched tags on the line-chart introduced recently, which I fixed, preventing subsequent charts from displaying.