### PR TITLE
ie11 fixes

### DIFF
--- a/src/js/config/staging.js
+++ b/src/js/config/staging.js
@@ -1,5 +1,4 @@
 window.config = {
   equityChartsDataLoc: 'https://files.covid19.ca.gov/data/to-review/'
 }
-console.log('window config is')
-console.log(window.config)
+// only used by es5.js

--- a/src/js/config/staging.js
+++ b/src/js/config/staging.js
@@ -1,0 +1,5 @@
+window.config = {
+  equityChartsDataLoc: 'https://files.covid19.ca.gov/data/to-review/'
+}
+console.log('window config is')
+console.log(window.config)

--- a/src/js/equity-dash/charts/ie11.scss
+++ b/src/js/equity-dash/charts/ie11.scss
@@ -1,33 +1,33 @@
-// cagov-chart-re-pop {  
-//   .svg-holder svg {
-//     height: 670px;
-//     width: 430px;
-//   }
-// }
-// cagov-chart-re-100k {  
-//   .svg-holder svg {
-//     height: 614px;
-//     width: 430px;
-//   }
-// }
-// cagov-chart-d3-lines {  
-//   .svg-holder svg {
-//     width: 737px;
-//     height: 369px;
-//   }
-// }
-// cagov-chart-equity-data-completeness {  
-//   .svg-holder svg {
-//     width: 613px;
-//     height: 300px;
-//   }
-// }
-// cagov-chart-d3-bar {  
-//   .svg-holder svg {
-//     width: 720px;
-//     height: 428px;
-//   }
-// }
+cagov-chart-re-pop {  
+  .svg-holder svg {
+    height: 670px;
+    width: 430px;
+  }
+}
+cagov-chart-re-100k {  
+  .svg-holder svg {
+    height: 614px;
+    width: 430px;
+  }
+}
+cagov-chart-d3-lines {  
+  .svg-holder svg {
+    width: 737px;
+    height: 369px;
+  }
+}
+cagov-chart-equity-data-completeness {  
+  .svg-holder svg {
+    width: 613px;
+    height: 300px;
+  }
+}
+cagov-chart-d3-bar {  
+  .svg-holder svg {
+    width: 720px;
+    height: 428px;
+  }
+}
 
 svg .tick text {
   text-anchor: start;

--- a/src/js/equity-dash/charts/relative-percentage-by-pop/index.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-pop/index.js
@@ -278,14 +278,14 @@ class CAGOVEquityREPop extends window.HTMLElement {
   //   return `of ${this.selectedMetricDescription.toLowerCase()} in county`;
   // }
 
-  legendStrings = function() {
+  legendStrings() {
     let isStatewide = this.county === 'California';
     let key1 = 'chartLegend1' + (isStatewide? 'State' : "County") + '--'+this.selectedMetric;
     let key2 = 'chartLegend2' + '--'+this.selectedMetric;
     return [this.translationsObj[key1], this.translationsObj[key2]];
   }
 
-  getToolTipCaption1 = function(d, legendString) {
+  getToolTipCaption1(d, legendString) {
     let templateStr = this.translationsObj['chartToolTip1-caption'];
     let caption = templateStr
                     .replace('placeholder_DEMOGRAPHIC_SET_CATEGORY',d.data.DEMOGRAPHIC_SET_CATEGORY)
@@ -295,7 +295,7 @@ class CAGOVEquityREPop extends window.HTMLElement {
     return caption;
   }
 
-  getToolTipCaption2 = function(d, selectedMetric) {
+  getToolTipCaption2(d, selectedMetric) {
     let templateStr = this.translationsObj['chartToolTip2-caption'];
     let caption = templateStr
                     .replace('placeholder_DEMOGRAPHIC_SET_CATEGORY',d.data.DEMOGRAPHIC_SET_CATEGORY)

--- a/src/js/equity-dash/index.js
+++ b/src/js/equity-dash/index.js
@@ -7,5 +7,3 @@ import './charts/healthy-places-index/index.js'
 import './charts/data-completeness/index.js'
 import './charts/social-determinants/index.js'
 import './learn-more/index.js'
-// console.log('config is:')
-// console.log(config);

--- a/src/js/es5.js
+++ b/src/js/es5.js
@@ -1,3 +1,4 @@
+import './config/staging.js';
 import '@webcomponents/webcomponentsjs';
 import 'whatwg-fetch';
 import './polyfills/endswith.js';


### PR DESCRIPTION
the ie11.css file is imported by the es5.js bundle so it is only used by browsers that execute the type=nomodule script tags instead of the module ones. IE has a problem with svg sizing which is fixed by px hardcoding

The changes to relative-percentage-by-pop/index.js are fixing issues the babel transpiler couldn't handle

The config file is used as an import because it was missing from the es5 bundle and importing from a separate file preserves the code order