### PR TITLE
CCG-740 Fix extra capitalization

### DIFF
--- a/src/css/_charts.scss
+++ b/src/css/_charts.scss
@@ -95,10 +95,6 @@
     font-weight: 100;
   }
   
-  .bar-label .tick text {
-    text-transform: capitalize;
-  }
-
   .tick text {
     font-size: 0.85rem;
   }

--- a/src/js/equity-dash/charts/data-completeness/index.scss
+++ b/src/js/equity-dash/charts/data-completeness/index.scss
@@ -1,52 +1,8 @@
 cagov-chart-equity-data-completeness {
-//   position: relative;
-//   display: block;
-//   margin: auto;
-//   width: 100%;
-//   .chart-title {
-//     max-width: 613px;
-//   }
-//   .svg-holder {
-//     max-width: 613px;
-//   }
-//   .bars {
-//     font-weight: bold;
-//     font-size: 0.95rem;
-//     text-anchor: unset;
-//   }
-//   .more-than-labels {
-//     font-size: 0.75rem;
-//   }
-//   .change-from-month-labels {
-//     font-size: 0.75rem;
-//   }
-//   .bar-label {
-//     font-weight: bold;
-//     font-size: 0.95rem;
-//     text-anchor: unset;
-//   }
-//   .bar-label .tick text {
-//     text-transform: capitalize;
-//   }
-//   .label {
-//     font-size: 0.95rem;
-//   }
-//   .highlight-data {
-//     font-weight: bold;
-//     padding-right: 2px;
-//   }
-//   .chart-tooltip {
-//     position: absolute;
-//     z-index: 10;
-//     visibility: hidden;
-//     background: #fff;
-//     pointer-events: none;
-
-//     padding: 10px;
-//     box-shadow: -12px 11px 5px -4px rgba(0, 0, 0, 0.4);
-//     border: solid 1px #ccc;
-//   }
   .chart-tooltip--missingness {
     min-width: 300px;
+  }
+  .bar-label .tick text {
+    text-transform: capitalize;
   }
 }


### PR DESCRIPTION
Move CSS capitalization from .bar-label .tick text to the specific location where we need it (for rendering data that was lower case but needs to be capitalized.