### PR TITLE
Made chart informational overlay reusable.

### DIFF
--- a/src/css/_charts.scss
+++ b/src/css/_charts.scss
@@ -168,6 +168,29 @@
     min-width: 100px;
   }
 
+  .chart-overlaybox-container {
+    /* display:inline-block; */
+    position: absolute;
+    z-index: 10;
+    visibility: hidden;
+    background: #fff;
+    width: 250px;
+  }
+  
+  .chart-overlaybox {
+    // position: absolute;
+    // z-index: 10;
+    // visibility: hidden;
+    // background: #fff;
+    pointer-events: none;
+
+    padding: 10px;
+    box-shadow: -12px 11px 5px -4px rgba(0, 0, 0, 0.4);
+    border: solid 1px #ccc;
+    min-width: 100px;
+  }
+
+
   .highlight-data {
     font-weight: bold;
     padding-right: 2px; // not in cagov chart

--- a/src/js/equity-dash/chart-overlay-box.js
+++ b/src/js/equity-dash/chart-overlay-box.js
@@ -1,0 +1,32 @@
+function chartOverlayBox(svg,        // svg to change to 50% opacity
+                         chartClass, // chart's class
+                         boxClass,   // custom class name for this box
+                         chartDims,  // dict that contains width and height
+                         caption)    // caption text
+{                         
+
+      // 250 is current width of chart-overlaybox-container
+      let boxWidth = 250;
+      let boxHeight = boxWidth/2;
+
+      d3.selectAll("." + boxClass).remove();
+      svg.style("opacity",.5);
+      // append informative box
+      d3
+      .select(chartClass)
+      .append("div")
+      .attr("class", "chart-overlaybox-container " + boxClass)
+      .style("visibility", "visible")
+      .style("left", (chartDims.width - boxWidth)/2 + "px")
+      .style("top", (chartDims.height - boxHeight)/2 + "px")
+      .append("div")
+      .attr("class", "chart-overlaybox")
+      .text(caption)
+}
+
+function chartOverlayBoxClear(svg, boxClass) {
+    // clears previous box, if any and resets opacity of svg
+    d3.selectAll("." + boxClass).remove();
+    svg.style("opacity",1);
+}
+export {chartOverlayBox, chartOverlayBoxClear};

--- a/src/js/equity-dash/charts/healthy-places-index/index.js
+++ b/src/js/equity-dash/charts/healthy-places-index/index.js
@@ -5,7 +5,7 @@ import Tooltip from "./tooltip.js";
 import template from "./template.js";
 import getTranslations from "./../../get-strings-list.js";
 import getScreenResizeCharts from "./../../get-window-size.js";
-
+import { chartOverlayBox, chartOverlayBoxClear } from "../../chart-overlay-box.js";
 class CAGOVChartD3Lines extends window.HTMLElement {
   connectedCallback() {
     // console.log("Setting up CAGOVChartD3Lines");
@@ -265,7 +265,7 @@ class CAGOVChartD3Lines extends window.HTMLElement {
     svg.selectAll(".county_positivity_all_nopris").remove();
     svg.selectAll(".tick").remove(); // remove previous axes annotations
     svg.selectAll(".y-label").remove();
-    d3.selectAll(".tooltip-container--d3-lines").remove();
+    // d3.selectAll(".tooltip-container--d3-lines").remove();
 
     if (!missing_eq_data) {
       svg
@@ -308,22 +308,16 @@ class CAGOVChartD3Lines extends window.HTMLElement {
     svg.append("g").call(yAxisLabel);
 
     let is_debugging_infobox = false;
+    let boxClass = "chartOverlay-d3-lines";
     if (missing_eq_data || is_debugging_infobox) {
-      svg.style("opacity",.5);
-      // append informative box
-      d3
-      .select("cagov-chart-d3-lines")
-      .append("div")
-      .attr("class", "tooltip-container tooltip-container--d3-lines")
-      .style("visibility", "visible")
-      // 250 is current width of tooltip-container - need a better way of centering
-      .style("left", (this.chartBreakpointValues.width - 250)/2 + "px")
-      .style("top", "90px")
-      .append("div")
-      .attr("class", "chart-tooltip")
-      .text(this.textLabels.missingDataCaption)
+      chartOverlayBox(svg,                      
+                     "cagov-chart-d3-lines",     // class of chart
+                     boxClass,                   // class of box
+                     this.chartBreakpointValues, // dimensions dict (contains width,height)
+                     this.textLabels.missingDataCaption // caption
+                     )
     } else {
-      svg.style("opacity",1);
+      chartOverlayBoxClear(svg, boxClass);
     }
 
     //tooltip


### PR DESCRIPTION
Added chart-overlay-box.js to equity-dash/

```
    // sample usage
    if (missing_eq_data || is_debugging_infobox) {
      chartOverlayBox(svg,                      
                     "cagov-chart-d3-lines",     // class of chart
                     boxClass,                   // class of box
                     this.chartBreakpointValues, // dimensions dict (contains width,height)
                     this.textLabels.missingDataCaption // caption
                     )
    } else {
      chartOverlayBoxClear(svg, boxClass);
    }

```