### PR TITLE
Added vaccines placeholders and many pagenames

### DIFF
--- a/pages/_data/pageNames.json
+++ b/pages/_data/pageNames.json
@@ -513,23 +513,51 @@
   },
   {
     "slug": "hotel-rooms-for-california-healthcare-workers",
-    "lang-en": "Hotels for health workers"
+    "lang-en": "Hotels for health workers",
+    "lang-es": "Habitaciones de hotel para trabajadores sanitarios de California",
+    "lang-tl": "Mga hotel room para sa mga manggagawa sa pangangalagang pangkalusugan ng California",
+    "lang-ar": "غرف فندقية لموظفي الرعاية الصحية في كاليفورنيا",
+    "lang-ko": "캘리포니아 의료 종사자를 위한 호텔 객실",
+    "lang-vi": "Phòng khách sạn dành cho nhân viên chăm sóc sức khỏe của California",
+    "lang-zh-Hant": "供加州醫務人員使用的酒店客房",
+    "lang-zh-Hans": "供加州医务人员使用的酒店客房"
   },
   {
     "slug": "housing-for-agricultural-workers",
-    "lang-en": "Housing for agricultural workers"
+    "lang-en": "Housing for agricultural workers",
+    "lang-es": "Viviendas para trabajadores agrícolas",
+    "lang-tl": "Pabahay para sa mga manggagawa sa agrikultura",
+    "lang-ar": "السكن للعمال الزراعيين",
+    "lang-ko": "농업 근로자를 위한 거처",
+    "lang-vi": "Nhà ở dành cho người lao động trong ngành nông nghiệp",
+    "lang-zh-Hant": "為農業勞工提供的住房",
+    "lang-zh-Hans": "为农业劳工提供的住房"
   },
   {
     "slug": "more-ways-to-help",
-    "lang-en": "More ways to help"
+    "lang-en": "More ways to help",
+    "lang-es": "Más formas de ayudar",
+    "lang-tl": "Higit pang paraan para makatulong",
+    "lang-ar": "مزيد من الطرق للمساعدة",
+    "lang-ko": "다양한 지원 방법",
+    "lang-vi": "Nhiều cách để hỗ trợ",
+    "lang-zh-Hant": "更多幫助方式",
+    "lang-zh-Hans": "更多帮助方式"
+  },
+  {
+    "slug": "treatment-for-covid-19",
+    "lang-en": "Treatment",
+    "lang-es": "Tratamiento",
+    "lang-tl": "Paggamot",
+    "lang-ar": "العلاج",
+    "lang-ko": "치료",
+    "lang-vi": "Điều trị",
+    "lang-zh-Hant": "治療",
+    "lang-zh-Hans": "治疗"
   },
   {
     "slug": "get-tested",
     "lang-en": "Testing"
-  },
-  {
-    "slug": "treatment-for-covid-19",
-    "lang-en": "Treatment"
   },
   {
     "slug": "vaccines",

--- a/pages/translated-posts/vaccines-ar.html
+++ b/pages/translated-posts/vaccines-ar.html
@@ -1,0 +1,195 @@
+---
+layout: "page.njk"
+title: "Vaccines"
+meta: "A safe and effective COVID-19 vaccine will be one of the most important tools to end the COVID-19 pandemic.&nbsp; On this page you will find: When will a COVID-19 vaccine be here? How is California planning for COVID-19 vaccination?&nbsp; How will COVID-19 vaccines work? What are the benefits of getting vaccinated? Busting myths about vaccination [&hellip;]"
+author: "State of California"
+publishdate: "2020-12-03T12:44:25Z"
+tags: ["translate"]
+addtositemap: true
+---
+
+<p>A safe and effective COVID-19 vaccine will be one of the most important tools to end the COVID-19 pandemic.&nbsp;</p>
+
+
+
+<p>On this page you will find:</p>
+
+
+
+<ul><li><strong><a href="#When-will-a-COVID-19-vaccine-be-here">When will a COVID-19 vaccine be here?</a></strong></li><li><strong><a href="#How-is-California-planning-for-COVID-19-vaccination">How is California planning for COVID-19 vaccination?&nbsp;</a></strong></li><li><strong><a href="#How-will-COVID-19-vaccines-work">How will COVID-19 vaccines work?</a></strong></li><li><strong><a href="#What-are-the-benefits-of-getting-vaccinated">What are the benefits of getting vaccinated?</a></strong></li><li><strong><a href="#Busting-myths-about-vaccination">Busting myths about vaccination</a></strong></li><li><strong><a href="#Questions-and-answers">Questions and answers</a></strong></li></ul>
+
+
+
+<h2 id="When-will-a-COVID-19-vaccine-be-here">When will a COVID-19 vaccine be here?</h2>
+
+
+
+<p>There is currently no approved vaccine to prevent COVID-19. One or more vaccines might be available before the end of the year.&nbsp;</p>
+
+
+
+<p>At first, COVID-19 vaccines might be used under an Emergency Use Authorization (EUA) from the U.S. Food and Drug Administration (FDA). Learn more about <a href="https://www.fda.gov/emergency-preparedness-and-response/mcm-legal-regulatory-and-policy-framework/emergency-use-authorization">FDA’s Emergency Use Authorization authority</a> and watch a <a href="https://www.youtube.com/watch?v=iGkwaESsGBQ">video on what an EUA is</a>.</p>
+
+
+
+<h3><strong>Vaccine safety is a top priority</strong></h3>
+
+
+
+<p>The U.S. vaccine safety system ensures that all vaccines are as safe as possible. Learn how the federal government is working to <a href="https://www.cdc.gov/coronavirus/2019-ncov/vaccines/safety.html">ensure the safety of COVID-19 vaccines</a>.</p>
+
+
+
+<p>To ensure the COVID-19 vaccine meets safety requirements, California formed a <a href="https://www.cdph.ca.gov/Programs/CID/DCDC/Pages/COVID-19/Scientific-Safety-Review-Workgroup.aspx">Scientific Safety Review Workgroup</a> to provide recommendations to California leadership and build public confidence in vaccine safety.</p>
+
+
+
+<h3><strong>Vaccine distribution and prioritization</strong></h3>
+
+
+
+<p>California is planning to distribute and administer vaccines as quickly as possible. This will be done only after a vaccine’s safety has been reviewed and approved by top health experts.</p>
+
+
+
+<p>Initially vaccine supply will be very limited. California is making sure that these supplies are distributed and administered equitably, at first to Californians working in healthcare settings and then to others critical to our daily existence and those at highest risk of becoming infected, severely ill or spreading COVID-19.&nbsp; &nbsp;&nbsp;</p>
+
+
+
+<h2 id="How-is-California-planning-for-COVID-19-vaccination">How is California planning for COVID-19 vaccination?&nbsp;</h2>
+
+
+
+<p>California’s distribution of COVID-19 vaccines will be guided by the following principles:</p>
+
+
+
+<ol><li>The vaccine meets safety requirements.</li><li>The vaccine is distributed and administered equitably.&nbsp;</li><li>Community partners have been included in planning from the beginning for broad input and transparency.</li></ol>
+
+
+
+<p>California will be transparent, careful, and equitable in its vaccine distribution. The state will provide COVID-19 vaccine to everyone in California who wants it.</p>
+
+
+
+<h2 id="How-will-COVID-19-vaccines-work">How will COVID-19 vaccines work?</h2>
+
+
+
+<p>COVID-19 vaccines will protect us from the virus that causes COVID-19 without having to get the illness. Different vaccines work in different ways, but they all help our immune system fight infections in the future.</p>
+
+
+
+<p>It typically takes a few weeks after the last dose in a series to become fully protected. Sometimes vaccination can cause mild fever or cold-like symptoms, but these are not harmful.</p>
+
+
+
+<h2 id="What-are-the-benefits-of-getting-vaccinated">What are the benefits of getting vaccinated?</h2>
+
+
+
+<p>COVID-19 vaccines that have been authorized by FDA will have been carefully evaluated in clinical trials for their ability to protect us from COVID-19.&nbsp;</p>
+
+
+
+<p>The ability of COVID-19 vaccines to protect us from spreading the virus to others is not yet known but is being studied carefully.</p>
+
+
+
+<h2 id="Busting-myths-about-vaccination">Busting myths about vaccination</h2>
+
+
+
+<h3>COVID-19 vaccines will not give you COVID-19</h3>
+
+
+
+<p>None of the COVID-19 vaccines under development can cause COVID-19. There are several different types of vaccines in development. However, the goal for each of them is to teach our immune systems how to fight the virus that causes COVID-19. Learn more about <a href="https://www.cdc.gov/coronavirus/2019-ncov/vaccines/about-vaccines/how-they-work.html">how COVID-19 vaccines work</a>.</p>
+
+
+
+<h3>COVID-19 vaccines will not cause you to test positive on COVID-19 viral tests</h3>
+
+
+
+<p>Vaccines currently in clinical trials in the United States won’t cause you to test positive on <a href="https://www.cdc.gov/coronavirus/2019-ncov/testing/diagnostic-testing.html">viral tests</a>, which are used to see if you have a current infection.</p>
+
+
+
+<p>If your body develops an immune response, which is the goal of vaccination, there is a possibility you may test positive on some <a href="https://www.cdc.gov/coronavirus/2019-ncov/testing/serology-overview.html">antibody tests</a>. Antibody tests indicate you had a previous infection and that you may have some level of protection against the virus. Experts are currently looking at how COVID-19 vaccination may affect antibody testing results.</p>
+
+
+
+<h3>People who have gotten sick with COVID-19 may still benefit from getting vaccinated</h3>
+
+
+
+<p>Due to the severe health risks associated with COVID-19 and the fact that re-infection with COVID-19 is possible, people may be advised to get a COVID-19 vaccine even if they have been sick with COVID-19 before.</p>
+
+
+
+<p>At this time, we do not know how long someone is protected from getting sick again after recovering from COVID-19.</p>
+
+
+
+<p>We won’t know how long immunity produced by vaccination lasts until we have a vaccine and more data on how well it works.</p>
+
+
+
+<h3>Vaccination can help prevent getting sick with COVID-19</h3>
+
+
+
+<p>While many people with COVID-19 have only a mild illness, others may get a <a href="https://www.cdc.gov/coronavirus/2019-ncov/symptoms-testing/symptoms.html">severe illness</a> or even die. There is no way to know how COVID-19 will affect you, even if you are not at <a href="https://www.cdc.gov/coronavirus/2019-ncov/need-extra-precautions/index.html">increased risk of severe complications</a>. COVID-19 vaccination helps protect you without having to get the disease. Learn more about <a href="https://www.cdc.gov/coronavirus/2019-ncov/vaccines/about-vaccines/how-they-work.html">how COVID-19 vaccines work</a>.</p>
+
+
+
+<h2 id="Questions-and-answers">Questions and answers</h2>
+
+
+
+<h4 class="wp-accordion">Will I still need to wear a mask after getting a COVID-19 vaccine?&nbsp;</h4>
+
+
+
+<p class="wp-accordion-content">Yes. While experts learn more about the protection that COVID-19 vaccines provide under real-life conditions, it will be important for everyone to continue using all the tools available to us to help stop this pandemic, like wearing masks, washing hands often, and social distancing. Together, COVID-19 vaccination and recommendations for <a href="https://www.cdc.gov/coronavirus/2019-ncov/prevent-getting-sick/prevention.html">how to protect yourself and others</a> will offer the best protection from getting and spreading COVID-19. We need to understand more about the protection that COVID-19 vaccines provide before we change recommendations on mask use.</p>
+
+
+
+<h4 class="wp-accordion">How many COVID-19 vaccine doses are needed?</h4>
+
+
+
+<p class="wp-accordion-content">All but one of the COVID-19 vaccines currently in development in the United States need two shots to be effective. The other COVID-19 vaccine uses one shot.</p>
+
+
+
+<h4 class="wp-accordion">How much will the COVID-19 vaccine cost?</h4>
+
+
+
+<p class="wp-accordion-content">Vaccines purchased with U.S. taxpayer dollars will be given to the American people at no cost. Vaccination providers will be able to charge an administration fee to those who can afford to pay it or bill an insurance company.</p>
+
+
+
+<h4 class="wp-accordion">What steps are being taken to ensure that COVID-19 vaccines are safe?&nbsp;</h4>
+
+
+
+<p class="wp-accordion-content">CDC and FDA encourage the public to report possible side effects (called adverse events) to the <a href="https://vaers.hhs.gov/reportevent.html">Vaccine Adverse Event Reporting System (VAERS)</a>. This national system collects these data to look for adverse events that are unexpected, appear to happen more often than expected, or have unusual patterns of occurrence. Learn about the <a href="https://www.cdc.gov/vaccinesafety/ensuringsafety/sideeffects/index.html">difference between a vaccine side effect and an adverse event</a>. Reports to VAERS help the CDC monitor the safety of vaccines. Safety is a top priority.</p>
+
+
+
+<p class="wp-accordion-content">Healthcare providers will be required to report certain adverse events following vaccination to VAERS. Healthcare providers also have to adhere to any revised safety reporting requirements according to FDA’s conditions of authorized use throughout the duration of any Emergency Use Authorization. These requirements would be posted on <a href="https://www.fda.gov/emergency-preparedness-and-response/mcm-legal-regulatory-and-policy-framework/emergency-use-authorization">FDA’s website.</a></p>
+
+
+
+<p class="wp-accordion-content">CDC is also implementing a new smartphone-based tool called <a href="https://www.cdc.gov/vaccines/acip/meetings/downloads/slides-2020-09/COVID-03-Shimabukuro.pdf">v-safe</a> to check-in on people’s health after they receive a COVID-19 vaccine. When you receive your vaccine, you should also receive an information sheet telling you how to enroll in v-safe. If you enroll, you will receive regular text messages directing you to surveys where you can report any problems or adverse reactions you have after receiving a COVID-19 vaccine.</p>
+
+
+
+<h2>Stay informed</h2>
+
+
+
+<ul><li>CDPH: <a href="https://www.cdph.ca.gov/Programs/CID/DCDC/Pages/COVID-19/COVID-19Vaccine.aspx">COVID-19 vaccine planning</a></li><li>CDC: <a href="https://www.cdc.gov/coronavirus/2019-ncov/vaccines/index.html">Vaccines</a></li></ul>

--- a/pages/translated-posts/vaccines-es.html
+++ b/pages/translated-posts/vaccines-es.html
@@ -1,0 +1,195 @@
+---
+layout: "page.njk"
+title: "Vaccines"
+meta: "A safe and effective COVID-19 vaccine will be one of the most important tools to end the COVID-19 pandemic.&nbsp; On this page you will find: When will a COVID-19 vaccine be here? How is California planning for COVID-19 vaccination?&nbsp; How will COVID-19 vaccines work? What are the benefits of getting vaccinated? Busting myths about vaccination [&hellip;]"
+author: "State of California"
+publishdate: "2020-12-03T12:44:25Z"
+tags: ["translate"]
+addtositemap: true
+---
+
+<p>A safe and effective COVID-19 vaccine will be one of the most important tools to end the COVID-19 pandemic.&nbsp;</p>
+
+
+
+<p>On this page you will find:</p>
+
+
+
+<ul><li><strong><a href="#When-will-a-COVID-19-vaccine-be-here">When will a COVID-19 vaccine be here?</a></strong></li><li><strong><a href="#How-is-California-planning-for-COVID-19-vaccination">How is California planning for COVID-19 vaccination?&nbsp;</a></strong></li><li><strong><a href="#How-will-COVID-19-vaccines-work">How will COVID-19 vaccines work?</a></strong></li><li><strong><a href="#What-are-the-benefits-of-getting-vaccinated">What are the benefits of getting vaccinated?</a></strong></li><li><strong><a href="#Busting-myths-about-vaccination">Busting myths about vaccination</a></strong></li><li><strong><a href="#Questions-and-answers">Questions and answers</a></strong></li></ul>
+
+
+
+<h2 id="When-will-a-COVID-19-vaccine-be-here">When will a COVID-19 vaccine be here?</h2>
+
+
+
+<p>There is currently no approved vaccine to prevent COVID-19. One or more vaccines might be available before the end of the year.&nbsp;</p>
+
+
+
+<p>At first, COVID-19 vaccines might be used under an Emergency Use Authorization (EUA) from the U.S. Food and Drug Administration (FDA). Learn more about <a href="https://www.fda.gov/emergency-preparedness-and-response/mcm-legal-regulatory-and-policy-framework/emergency-use-authorization">FDA’s Emergency Use Authorization authority</a> and watch a <a href="https://www.youtube.com/watch?v=iGkwaESsGBQ">video on what an EUA is</a>.</p>
+
+
+
+<h3><strong>Vaccine safety is a top priority</strong></h3>
+
+
+
+<p>The U.S. vaccine safety system ensures that all vaccines are as safe as possible. Learn how the federal government is working to <a href="https://www.cdc.gov/coronavirus/2019-ncov/vaccines/safety.html">ensure the safety of COVID-19 vaccines</a>.</p>
+
+
+
+<p>To ensure the COVID-19 vaccine meets safety requirements, California formed a <a href="https://www.cdph.ca.gov/Programs/CID/DCDC/Pages/COVID-19/Scientific-Safety-Review-Workgroup.aspx">Scientific Safety Review Workgroup</a> to provide recommendations to California leadership and build public confidence in vaccine safety.</p>
+
+
+
+<h3><strong>Vaccine distribution and prioritization</strong></h3>
+
+
+
+<p>California is planning to distribute and administer vaccines as quickly as possible. This will be done only after a vaccine’s safety has been reviewed and approved by top health experts.</p>
+
+
+
+<p>Initially vaccine supply will be very limited. California is making sure that these supplies are distributed and administered equitably, at first to Californians working in healthcare settings and then to others critical to our daily existence and those at highest risk of becoming infected, severely ill or spreading COVID-19.&nbsp; &nbsp;&nbsp;</p>
+
+
+
+<h2 id="How-is-California-planning-for-COVID-19-vaccination">How is California planning for COVID-19 vaccination?&nbsp;</h2>
+
+
+
+<p>California’s distribution of COVID-19 vaccines will be guided by the following principles:</p>
+
+
+
+<ol><li>The vaccine meets safety requirements.</li><li>The vaccine is distributed and administered equitably.&nbsp;</li><li>Community partners have been included in planning from the beginning for broad input and transparency.</li></ol>
+
+
+
+<p>California will be transparent, careful, and equitable in its vaccine distribution. The state will provide COVID-19 vaccine to everyone in California who wants it.</p>
+
+
+
+<h2 id="How-will-COVID-19-vaccines-work">How will COVID-19 vaccines work?</h2>
+
+
+
+<p>COVID-19 vaccines will protect us from the virus that causes COVID-19 without having to get the illness. Different vaccines work in different ways, but they all help our immune system fight infections in the future.</p>
+
+
+
+<p>It typically takes a few weeks after the last dose in a series to become fully protected. Sometimes vaccination can cause mild fever or cold-like symptoms, but these are not harmful.</p>
+
+
+
+<h2 id="What-are-the-benefits-of-getting-vaccinated">What are the benefits of getting vaccinated?</h2>
+
+
+
+<p>COVID-19 vaccines that have been authorized by FDA will have been carefully evaluated in clinical trials for their ability to protect us from COVID-19.&nbsp;</p>
+
+
+
+<p>The ability of COVID-19 vaccines to protect us from spreading the virus to others is not yet known but is being studied carefully.</p>
+
+
+
+<h2 id="Busting-myths-about-vaccination">Busting myths about vaccination</h2>
+
+
+
+<h3>COVID-19 vaccines will not give you COVID-19</h3>
+
+
+
+<p>None of the COVID-19 vaccines under development can cause COVID-19. There are several different types of vaccines in development. However, the goal for each of them is to teach our immune systems how to fight the virus that causes COVID-19. Learn more about <a href="https://www.cdc.gov/coronavirus/2019-ncov/vaccines/about-vaccines/how-they-work.html">how COVID-19 vaccines work</a>.</p>
+
+
+
+<h3>COVID-19 vaccines will not cause you to test positive on COVID-19 viral tests</h3>
+
+
+
+<p>Vaccines currently in clinical trials in the United States won’t cause you to test positive on <a href="https://www.cdc.gov/coronavirus/2019-ncov/testing/diagnostic-testing.html">viral tests</a>, which are used to see if you have a current infection.</p>
+
+
+
+<p>If your body develops an immune response, which is the goal of vaccination, there is a possibility you may test positive on some <a href="https://www.cdc.gov/coronavirus/2019-ncov/testing/serology-overview.html">antibody tests</a>. Antibody tests indicate you had a previous infection and that you may have some level of protection against the virus. Experts are currently looking at how COVID-19 vaccination may affect antibody testing results.</p>
+
+
+
+<h3>People who have gotten sick with COVID-19 may still benefit from getting vaccinated</h3>
+
+
+
+<p>Due to the severe health risks associated with COVID-19 and the fact that re-infection with COVID-19 is possible, people may be advised to get a COVID-19 vaccine even if they have been sick with COVID-19 before.</p>
+
+
+
+<p>At this time, we do not know how long someone is protected from getting sick again after recovering from COVID-19.</p>
+
+
+
+<p>We won’t know how long immunity produced by vaccination lasts until we have a vaccine and more data on how well it works.</p>
+
+
+
+<h3>Vaccination can help prevent getting sick with COVID-19</h3>
+
+
+
+<p>While many people with COVID-19 have only a mild illness, others may get a <a href="https://www.cdc.gov/coronavirus/2019-ncov/symptoms-testing/symptoms.html">severe illness</a> or even die. There is no way to know how COVID-19 will affect you, even if you are not at <a href="https://www.cdc.gov/coronavirus/2019-ncov/need-extra-precautions/index.html">increased risk of severe complications</a>. COVID-19 vaccination helps protect you without having to get the disease. Learn more about <a href="https://www.cdc.gov/coronavirus/2019-ncov/vaccines/about-vaccines/how-they-work.html">how COVID-19 vaccines work</a>.</p>
+
+
+
+<h2 id="Questions-and-answers">Questions and answers</h2>
+
+
+
+<h4 class="wp-accordion">Will I still need to wear a mask after getting a COVID-19 vaccine?&nbsp;</h4>
+
+
+
+<p class="wp-accordion-content">Yes. While experts learn more about the protection that COVID-19 vaccines provide under real-life conditions, it will be important for everyone to continue using all the tools available to us to help stop this pandemic, like wearing masks, washing hands often, and social distancing. Together, COVID-19 vaccination and recommendations for <a href="https://www.cdc.gov/coronavirus/2019-ncov/prevent-getting-sick/prevention.html">how to protect yourself and others</a> will offer the best protection from getting and spreading COVID-19. We need to understand more about the protection that COVID-19 vaccines provide before we change recommendations on mask use.</p>
+
+
+
+<h4 class="wp-accordion">How many COVID-19 vaccine doses are needed?</h4>
+
+
+
+<p class="wp-accordion-content">All but one of the COVID-19 vaccines currently in development in the United States need two shots to be effective. The other COVID-19 vaccine uses one shot.</p>
+
+
+
+<h4 class="wp-accordion">How much will the COVID-19 vaccine cost?</h4>
+
+
+
+<p class="wp-accordion-content">Vaccines purchased with U.S. taxpayer dollars will be given to the American people at no cost. Vaccination providers will be able to charge an administration fee to those who can afford to pay it or bill an insurance company.</p>
+
+
+
+<h4 class="wp-accordion">What steps are being taken to ensure that COVID-19 vaccines are safe?&nbsp;</h4>
+
+
+
+<p class="wp-accordion-content">CDC and FDA encourage the public to report possible side effects (called adverse events) to the <a href="https://vaers.hhs.gov/reportevent.html">Vaccine Adverse Event Reporting System (VAERS)</a>. This national system collects these data to look for adverse events that are unexpected, appear to happen more often than expected, or have unusual patterns of occurrence. Learn about the <a href="https://www.cdc.gov/vaccinesafety/ensuringsafety/sideeffects/index.html">difference between a vaccine side effect and an adverse event</a>. Reports to VAERS help the CDC monitor the safety of vaccines. Safety is a top priority.</p>
+
+
+
+<p class="wp-accordion-content">Healthcare providers will be required to report certain adverse events following vaccination to VAERS. Healthcare providers also have to adhere to any revised safety reporting requirements according to FDA’s conditions of authorized use throughout the duration of any Emergency Use Authorization. These requirements would be posted on <a href="https://www.fda.gov/emergency-preparedness-and-response/mcm-legal-regulatory-and-policy-framework/emergency-use-authorization">FDA’s website.</a></p>
+
+
+
+<p class="wp-accordion-content">CDC is also implementing a new smartphone-based tool called <a href="https://www.cdc.gov/vaccines/acip/meetings/downloads/slides-2020-09/COVID-03-Shimabukuro.pdf">v-safe</a> to check-in on people’s health after they receive a COVID-19 vaccine. When you receive your vaccine, you should also receive an information sheet telling you how to enroll in v-safe. If you enroll, you will receive regular text messages directing you to surveys where you can report any problems or adverse reactions you have after receiving a COVID-19 vaccine.</p>
+
+
+
+<h2>Stay informed</h2>
+
+
+
+<ul><li>CDPH: <a href="https://www.cdph.ca.gov/Programs/CID/DCDC/Pages/COVID-19/COVID-19Vaccine.aspx">COVID-19 vaccine planning</a></li><li>CDC: <a href="https://www.cdc.gov/coronavirus/2019-ncov/vaccines/index.html">Vaccines</a></li></ul>

--- a/pages/translated-posts/vaccines-ko.html
+++ b/pages/translated-posts/vaccines-ko.html
@@ -1,0 +1,195 @@
+---
+layout: "page.njk"
+title: "Vaccines"
+meta: "A safe and effective COVID-19 vaccine will be one of the most important tools to end the COVID-19 pandemic.&nbsp; On this page you will find: When will a COVID-19 vaccine be here? How is California planning for COVID-19 vaccination?&nbsp; How will COVID-19 vaccines work? What are the benefits of getting vaccinated? Busting myths about vaccination [&hellip;]"
+author: "State of California"
+publishdate: "2020-12-03T12:44:25Z"
+tags: ["translate"]
+addtositemap: true
+---
+
+<p>A safe and effective COVID-19 vaccine will be one of the most important tools to end the COVID-19 pandemic.&nbsp;</p>
+
+
+
+<p>On this page you will find:</p>
+
+
+
+<ul><li><strong><a href="#When-will-a-COVID-19-vaccine-be-here">When will a COVID-19 vaccine be here?</a></strong></li><li><strong><a href="#How-is-California-planning-for-COVID-19-vaccination">How is California planning for COVID-19 vaccination?&nbsp;</a></strong></li><li><strong><a href="#How-will-COVID-19-vaccines-work">How will COVID-19 vaccines work?</a></strong></li><li><strong><a href="#What-are-the-benefits-of-getting-vaccinated">What are the benefits of getting vaccinated?</a></strong></li><li><strong><a href="#Busting-myths-about-vaccination">Busting myths about vaccination</a></strong></li><li><strong><a href="#Questions-and-answers">Questions and answers</a></strong></li></ul>
+
+
+
+<h2 id="When-will-a-COVID-19-vaccine-be-here">When will a COVID-19 vaccine be here?</h2>
+
+
+
+<p>There is currently no approved vaccine to prevent COVID-19. One or more vaccines might be available before the end of the year.&nbsp;</p>
+
+
+
+<p>At first, COVID-19 vaccines might be used under an Emergency Use Authorization (EUA) from the U.S. Food and Drug Administration (FDA). Learn more about <a href="https://www.fda.gov/emergency-preparedness-and-response/mcm-legal-regulatory-and-policy-framework/emergency-use-authorization">FDA’s Emergency Use Authorization authority</a> and watch a <a href="https://www.youtube.com/watch?v=iGkwaESsGBQ">video on what an EUA is</a>.</p>
+
+
+
+<h3><strong>Vaccine safety is a top priority</strong></h3>
+
+
+
+<p>The U.S. vaccine safety system ensures that all vaccines are as safe as possible. Learn how the federal government is working to <a href="https://www.cdc.gov/coronavirus/2019-ncov/vaccines/safety.html">ensure the safety of COVID-19 vaccines</a>.</p>
+
+
+
+<p>To ensure the COVID-19 vaccine meets safety requirements, California formed a <a href="https://www.cdph.ca.gov/Programs/CID/DCDC/Pages/COVID-19/Scientific-Safety-Review-Workgroup.aspx">Scientific Safety Review Workgroup</a> to provide recommendations to California leadership and build public confidence in vaccine safety.</p>
+
+
+
+<h3><strong>Vaccine distribution and prioritization</strong></h3>
+
+
+
+<p>California is planning to distribute and administer vaccines as quickly as possible. This will be done only after a vaccine’s safety has been reviewed and approved by top health experts.</p>
+
+
+
+<p>Initially vaccine supply will be very limited. California is making sure that these supplies are distributed and administered equitably, at first to Californians working in healthcare settings and then to others critical to our daily existence and those at highest risk of becoming infected, severely ill or spreading COVID-19.&nbsp; &nbsp;&nbsp;</p>
+
+
+
+<h2 id="How-is-California-planning-for-COVID-19-vaccination">How is California planning for COVID-19 vaccination?&nbsp;</h2>
+
+
+
+<p>California’s distribution of COVID-19 vaccines will be guided by the following principles:</p>
+
+
+
+<ol><li>The vaccine meets safety requirements.</li><li>The vaccine is distributed and administered equitably.&nbsp;</li><li>Community partners have been included in planning from the beginning for broad input and transparency.</li></ol>
+
+
+
+<p>California will be transparent, careful, and equitable in its vaccine distribution. The state will provide COVID-19 vaccine to everyone in California who wants it.</p>
+
+
+
+<h2 id="How-will-COVID-19-vaccines-work">How will COVID-19 vaccines work?</h2>
+
+
+
+<p>COVID-19 vaccines will protect us from the virus that causes COVID-19 without having to get the illness. Different vaccines work in different ways, but they all help our immune system fight infections in the future.</p>
+
+
+
+<p>It typically takes a few weeks after the last dose in a series to become fully protected. Sometimes vaccination can cause mild fever or cold-like symptoms, but these are not harmful.</p>
+
+
+
+<h2 id="What-are-the-benefits-of-getting-vaccinated">What are the benefits of getting vaccinated?</h2>
+
+
+
+<p>COVID-19 vaccines that have been authorized by FDA will have been carefully evaluated in clinical trials for their ability to protect us from COVID-19.&nbsp;</p>
+
+
+
+<p>The ability of COVID-19 vaccines to protect us from spreading the virus to others is not yet known but is being studied carefully.</p>
+
+
+
+<h2 id="Busting-myths-about-vaccination">Busting myths about vaccination</h2>
+
+
+
+<h3>COVID-19 vaccines will not give you COVID-19</h3>
+
+
+
+<p>None of the COVID-19 vaccines under development can cause COVID-19. There are several different types of vaccines in development. However, the goal for each of them is to teach our immune systems how to fight the virus that causes COVID-19. Learn more about <a href="https://www.cdc.gov/coronavirus/2019-ncov/vaccines/about-vaccines/how-they-work.html">how COVID-19 vaccines work</a>.</p>
+
+
+
+<h3>COVID-19 vaccines will not cause you to test positive on COVID-19 viral tests</h3>
+
+
+
+<p>Vaccines currently in clinical trials in the United States won’t cause you to test positive on <a href="https://www.cdc.gov/coronavirus/2019-ncov/testing/diagnostic-testing.html">viral tests</a>, which are used to see if you have a current infection.</p>
+
+
+
+<p>If your body develops an immune response, which is the goal of vaccination, there is a possibility you may test positive on some <a href="https://www.cdc.gov/coronavirus/2019-ncov/testing/serology-overview.html">antibody tests</a>. Antibody tests indicate you had a previous infection and that you may have some level of protection against the virus. Experts are currently looking at how COVID-19 vaccination may affect antibody testing results.</p>
+
+
+
+<h3>People who have gotten sick with COVID-19 may still benefit from getting vaccinated</h3>
+
+
+
+<p>Due to the severe health risks associated with COVID-19 and the fact that re-infection with COVID-19 is possible, people may be advised to get a COVID-19 vaccine even if they have been sick with COVID-19 before.</p>
+
+
+
+<p>At this time, we do not know how long someone is protected from getting sick again after recovering from COVID-19.</p>
+
+
+
+<p>We won’t know how long immunity produced by vaccination lasts until we have a vaccine and more data on how well it works.</p>
+
+
+
+<h3>Vaccination can help prevent getting sick with COVID-19</h3>
+
+
+
+<p>While many people with COVID-19 have only a mild illness, others may get a <a href="https://www.cdc.gov/coronavirus/2019-ncov/symptoms-testing/symptoms.html">severe illness</a> or even die. There is no way to know how COVID-19 will affect you, even if you are not at <a href="https://www.cdc.gov/coronavirus/2019-ncov/need-extra-precautions/index.html">increased risk of severe complications</a>. COVID-19 vaccination helps protect you without having to get the disease. Learn more about <a href="https://www.cdc.gov/coronavirus/2019-ncov/vaccines/about-vaccines/how-they-work.html">how COVID-19 vaccines work</a>.</p>
+
+
+
+<h2 id="Questions-and-answers">Questions and answers</h2>
+
+
+
+<h4 class="wp-accordion">Will I still need to wear a mask after getting a COVID-19 vaccine?&nbsp;</h4>
+
+
+
+<p class="wp-accordion-content">Yes. While experts learn more about the protection that COVID-19 vaccines provide under real-life conditions, it will be important for everyone to continue using all the tools available to us to help stop this pandemic, like wearing masks, washing hands often, and social distancing. Together, COVID-19 vaccination and recommendations for <a href="https://www.cdc.gov/coronavirus/2019-ncov/prevent-getting-sick/prevention.html">how to protect yourself and others</a> will offer the best protection from getting and spreading COVID-19. We need to understand more about the protection that COVID-19 vaccines provide before we change recommendations on mask use.</p>
+
+
+
+<h4 class="wp-accordion">How many COVID-19 vaccine doses are needed?</h4>
+
+
+
+<p class="wp-accordion-content">All but one of the COVID-19 vaccines currently in development in the United States need two shots to be effective. The other COVID-19 vaccine uses one shot.</p>
+
+
+
+<h4 class="wp-accordion">How much will the COVID-19 vaccine cost?</h4>
+
+
+
+<p class="wp-accordion-content">Vaccines purchased with U.S. taxpayer dollars will be given to the American people at no cost. Vaccination providers will be able to charge an administration fee to those who can afford to pay it or bill an insurance company.</p>
+
+
+
+<h4 class="wp-accordion">What steps are being taken to ensure that COVID-19 vaccines are safe?&nbsp;</h4>
+
+
+
+<p class="wp-accordion-content">CDC and FDA encourage the public to report possible side effects (called adverse events) to the <a href="https://vaers.hhs.gov/reportevent.html">Vaccine Adverse Event Reporting System (VAERS)</a>. This national system collects these data to look for adverse events that are unexpected, appear to happen more often than expected, or have unusual patterns of occurrence. Learn about the <a href="https://www.cdc.gov/vaccinesafety/ensuringsafety/sideeffects/index.html">difference between a vaccine side effect and an adverse event</a>. Reports to VAERS help the CDC monitor the safety of vaccines. Safety is a top priority.</p>
+
+
+
+<p class="wp-accordion-content">Healthcare providers will be required to report certain adverse events following vaccination to VAERS. Healthcare providers also have to adhere to any revised safety reporting requirements according to FDA’s conditions of authorized use throughout the duration of any Emergency Use Authorization. These requirements would be posted on <a href="https://www.fda.gov/emergency-preparedness-and-response/mcm-legal-regulatory-and-policy-framework/emergency-use-authorization">FDA’s website.</a></p>
+
+
+
+<p class="wp-accordion-content">CDC is also implementing a new smartphone-based tool called <a href="https://www.cdc.gov/vaccines/acip/meetings/downloads/slides-2020-09/COVID-03-Shimabukuro.pdf">v-safe</a> to check-in on people’s health after they receive a COVID-19 vaccine. When you receive your vaccine, you should also receive an information sheet telling you how to enroll in v-safe. If you enroll, you will receive regular text messages directing you to surveys where you can report any problems or adverse reactions you have after receiving a COVID-19 vaccine.</p>
+
+
+
+<h2>Stay informed</h2>
+
+
+
+<ul><li>CDPH: <a href="https://www.cdph.ca.gov/Programs/CID/DCDC/Pages/COVID-19/COVID-19Vaccine.aspx">COVID-19 vaccine planning</a></li><li>CDC: <a href="https://www.cdc.gov/coronavirus/2019-ncov/vaccines/index.html">Vaccines</a></li></ul>

--- a/pages/translated-posts/vaccines-tl.html
+++ b/pages/translated-posts/vaccines-tl.html
@@ -1,0 +1,195 @@
+---
+layout: "page.njk"
+title: "Vaccines"
+meta: "A safe and effective COVID-19 vaccine will be one of the most important tools to end the COVID-19 pandemic.&nbsp; On this page you will find: When will a COVID-19 vaccine be here? How is California planning for COVID-19 vaccination?&nbsp; How will COVID-19 vaccines work? What are the benefits of getting vaccinated? Busting myths about vaccination [&hellip;]"
+author: "State of California"
+publishdate: "2020-12-03T12:44:25Z"
+tags: ["translate"]
+addtositemap: true
+---
+
+<p>A safe and effective COVID-19 vaccine will be one of the most important tools to end the COVID-19 pandemic.&nbsp;</p>
+
+
+
+<p>On this page you will find:</p>
+
+
+
+<ul><li><strong><a href="#When-will-a-COVID-19-vaccine-be-here">When will a COVID-19 vaccine be here?</a></strong></li><li><strong><a href="#How-is-California-planning-for-COVID-19-vaccination">How is California planning for COVID-19 vaccination?&nbsp;</a></strong></li><li><strong><a href="#How-will-COVID-19-vaccines-work">How will COVID-19 vaccines work?</a></strong></li><li><strong><a href="#What-are-the-benefits-of-getting-vaccinated">What are the benefits of getting vaccinated?</a></strong></li><li><strong><a href="#Busting-myths-about-vaccination">Busting myths about vaccination</a></strong></li><li><strong><a href="#Questions-and-answers">Questions and answers</a></strong></li></ul>
+
+
+
+<h2 id="When-will-a-COVID-19-vaccine-be-here">When will a COVID-19 vaccine be here?</h2>
+
+
+
+<p>There is currently no approved vaccine to prevent COVID-19. One or more vaccines might be available before the end of the year.&nbsp;</p>
+
+
+
+<p>At first, COVID-19 vaccines might be used under an Emergency Use Authorization (EUA) from the U.S. Food and Drug Administration (FDA). Learn more about <a href="https://www.fda.gov/emergency-preparedness-and-response/mcm-legal-regulatory-and-policy-framework/emergency-use-authorization">FDA’s Emergency Use Authorization authority</a> and watch a <a href="https://www.youtube.com/watch?v=iGkwaESsGBQ">video on what an EUA is</a>.</p>
+
+
+
+<h3><strong>Vaccine safety is a top priority</strong></h3>
+
+
+
+<p>The U.S. vaccine safety system ensures that all vaccines are as safe as possible. Learn how the federal government is working to <a href="https://www.cdc.gov/coronavirus/2019-ncov/vaccines/safety.html">ensure the safety of COVID-19 vaccines</a>.</p>
+
+
+
+<p>To ensure the COVID-19 vaccine meets safety requirements, California formed a <a href="https://www.cdph.ca.gov/Programs/CID/DCDC/Pages/COVID-19/Scientific-Safety-Review-Workgroup.aspx">Scientific Safety Review Workgroup</a> to provide recommendations to California leadership and build public confidence in vaccine safety.</p>
+
+
+
+<h3><strong>Vaccine distribution and prioritization</strong></h3>
+
+
+
+<p>California is planning to distribute and administer vaccines as quickly as possible. This will be done only after a vaccine’s safety has been reviewed and approved by top health experts.</p>
+
+
+
+<p>Initially vaccine supply will be very limited. California is making sure that these supplies are distributed and administered equitably, at first to Californians working in healthcare settings and then to others critical to our daily existence and those at highest risk of becoming infected, severely ill or spreading COVID-19.&nbsp; &nbsp;&nbsp;</p>
+
+
+
+<h2 id="How-is-California-planning-for-COVID-19-vaccination">How is California planning for COVID-19 vaccination?&nbsp;</h2>
+
+
+
+<p>California’s distribution of COVID-19 vaccines will be guided by the following principles:</p>
+
+
+
+<ol><li>The vaccine meets safety requirements.</li><li>The vaccine is distributed and administered equitably.&nbsp;</li><li>Community partners have been included in planning from the beginning for broad input and transparency.</li></ol>
+
+
+
+<p>California will be transparent, careful, and equitable in its vaccine distribution. The state will provide COVID-19 vaccine to everyone in California who wants it.</p>
+
+
+
+<h2 id="How-will-COVID-19-vaccines-work">How will COVID-19 vaccines work?</h2>
+
+
+
+<p>COVID-19 vaccines will protect us from the virus that causes COVID-19 without having to get the illness. Different vaccines work in different ways, but they all help our immune system fight infections in the future.</p>
+
+
+
+<p>It typically takes a few weeks after the last dose in a series to become fully protected. Sometimes vaccination can cause mild fever or cold-like symptoms, but these are not harmful.</p>
+
+
+
+<h2 id="What-are-the-benefits-of-getting-vaccinated">What are the benefits of getting vaccinated?</h2>
+
+
+
+<p>COVID-19 vaccines that have been authorized by FDA will have been carefully evaluated in clinical trials for their ability to protect us from COVID-19.&nbsp;</p>
+
+
+
+<p>The ability of COVID-19 vaccines to protect us from spreading the virus to others is not yet known but is being studied carefully.</p>
+
+
+
+<h2 id="Busting-myths-about-vaccination">Busting myths about vaccination</h2>
+
+
+
+<h3>COVID-19 vaccines will not give you COVID-19</h3>
+
+
+
+<p>None of the COVID-19 vaccines under development can cause COVID-19. There are several different types of vaccines in development. However, the goal for each of them is to teach our immune systems how to fight the virus that causes COVID-19. Learn more about <a href="https://www.cdc.gov/coronavirus/2019-ncov/vaccines/about-vaccines/how-they-work.html">how COVID-19 vaccines work</a>.</p>
+
+
+
+<h3>COVID-19 vaccines will not cause you to test positive on COVID-19 viral tests</h3>
+
+
+
+<p>Vaccines currently in clinical trials in the United States won’t cause you to test positive on <a href="https://www.cdc.gov/coronavirus/2019-ncov/testing/diagnostic-testing.html">viral tests</a>, which are used to see if you have a current infection.</p>
+
+
+
+<p>If your body develops an immune response, which is the goal of vaccination, there is a possibility you may test positive on some <a href="https://www.cdc.gov/coronavirus/2019-ncov/testing/serology-overview.html">antibody tests</a>. Antibody tests indicate you had a previous infection and that you may have some level of protection against the virus. Experts are currently looking at how COVID-19 vaccination may affect antibody testing results.</p>
+
+
+
+<h3>People who have gotten sick with COVID-19 may still benefit from getting vaccinated</h3>
+
+
+
+<p>Due to the severe health risks associated with COVID-19 and the fact that re-infection with COVID-19 is possible, people may be advised to get a COVID-19 vaccine even if they have been sick with COVID-19 before.</p>
+
+
+
+<p>At this time, we do not know how long someone is protected from getting sick again after recovering from COVID-19.</p>
+
+
+
+<p>We won’t know how long immunity produced by vaccination lasts until we have a vaccine and more data on how well it works.</p>
+
+
+
+<h3>Vaccination can help prevent getting sick with COVID-19</h3>
+
+
+
+<p>While many people with COVID-19 have only a mild illness, others may get a <a href="https://www.cdc.gov/coronavirus/2019-ncov/symptoms-testing/symptoms.html">severe illness</a> or even die. There is no way to know how COVID-19 will affect you, even if you are not at <a href="https://www.cdc.gov/coronavirus/2019-ncov/need-extra-precautions/index.html">increased risk of severe complications</a>. COVID-19 vaccination helps protect you without having to get the disease. Learn more about <a href="https://www.cdc.gov/coronavirus/2019-ncov/vaccines/about-vaccines/how-they-work.html">how COVID-19 vaccines work</a>.</p>
+
+
+
+<h2 id="Questions-and-answers">Questions and answers</h2>
+
+
+
+<h4 class="wp-accordion">Will I still need to wear a mask after getting a COVID-19 vaccine?&nbsp;</h4>
+
+
+
+<p class="wp-accordion-content">Yes. While experts learn more about the protection that COVID-19 vaccines provide under real-life conditions, it will be important for everyone to continue using all the tools available to us to help stop this pandemic, like wearing masks, washing hands often, and social distancing. Together, COVID-19 vaccination and recommendations for <a href="https://www.cdc.gov/coronavirus/2019-ncov/prevent-getting-sick/prevention.html">how to protect yourself and others</a> will offer the best protection from getting and spreading COVID-19. We need to understand more about the protection that COVID-19 vaccines provide before we change recommendations on mask use.</p>
+
+
+
+<h4 class="wp-accordion">How many COVID-19 vaccine doses are needed?</h4>
+
+
+
+<p class="wp-accordion-content">All but one of the COVID-19 vaccines currently in development in the United States need two shots to be effective. The other COVID-19 vaccine uses one shot.</p>
+
+
+
+<h4 class="wp-accordion">How much will the COVID-19 vaccine cost?</h4>
+
+
+
+<p class="wp-accordion-content">Vaccines purchased with U.S. taxpayer dollars will be given to the American people at no cost. Vaccination providers will be able to charge an administration fee to those who can afford to pay it or bill an insurance company.</p>
+
+
+
+<h4 class="wp-accordion">What steps are being taken to ensure that COVID-19 vaccines are safe?&nbsp;</h4>
+
+
+
+<p class="wp-accordion-content">CDC and FDA encourage the public to report possible side effects (called adverse events) to the <a href="https://vaers.hhs.gov/reportevent.html">Vaccine Adverse Event Reporting System (VAERS)</a>. This national system collects these data to look for adverse events that are unexpected, appear to happen more often than expected, or have unusual patterns of occurrence. Learn about the <a href="https://www.cdc.gov/vaccinesafety/ensuringsafety/sideeffects/index.html">difference between a vaccine side effect and an adverse event</a>. Reports to VAERS help the CDC monitor the safety of vaccines. Safety is a top priority.</p>
+
+
+
+<p class="wp-accordion-content">Healthcare providers will be required to report certain adverse events following vaccination to VAERS. Healthcare providers also have to adhere to any revised safety reporting requirements according to FDA’s conditions of authorized use throughout the duration of any Emergency Use Authorization. These requirements would be posted on <a href="https://www.fda.gov/emergency-preparedness-and-response/mcm-legal-regulatory-and-policy-framework/emergency-use-authorization">FDA’s website.</a></p>
+
+
+
+<p class="wp-accordion-content">CDC is also implementing a new smartphone-based tool called <a href="https://www.cdc.gov/vaccines/acip/meetings/downloads/slides-2020-09/COVID-03-Shimabukuro.pdf">v-safe</a> to check-in on people’s health after they receive a COVID-19 vaccine. When you receive your vaccine, you should also receive an information sheet telling you how to enroll in v-safe. If you enroll, you will receive regular text messages directing you to surveys where you can report any problems or adverse reactions you have after receiving a COVID-19 vaccine.</p>
+
+
+
+<h2>Stay informed</h2>
+
+
+
+<ul><li>CDPH: <a href="https://www.cdph.ca.gov/Programs/CID/DCDC/Pages/COVID-19/COVID-19Vaccine.aspx">COVID-19 vaccine planning</a></li><li>CDC: <a href="https://www.cdc.gov/coronavirus/2019-ncov/vaccines/index.html">Vaccines</a></li></ul>

--- a/pages/translated-posts/vaccines-vi.html
+++ b/pages/translated-posts/vaccines-vi.html
@@ -1,0 +1,195 @@
+---
+layout: "page.njk"
+title: "Vaccines"
+meta: "A safe and effective COVID-19 vaccine will be one of the most important tools to end the COVID-19 pandemic.&nbsp; On this page you will find: When will a COVID-19 vaccine be here? How is California planning for COVID-19 vaccination?&nbsp; How will COVID-19 vaccines work? What are the benefits of getting vaccinated? Busting myths about vaccination [&hellip;]"
+author: "State of California"
+publishdate: "2020-12-03T12:44:25Z"
+tags: ["translate"]
+addtositemap: true
+---
+
+<p>A safe and effective COVID-19 vaccine will be one of the most important tools to end the COVID-19 pandemic.&nbsp;</p>
+
+
+
+<p>On this page you will find:</p>
+
+
+
+<ul><li><strong><a href="#When-will-a-COVID-19-vaccine-be-here">When will a COVID-19 vaccine be here?</a></strong></li><li><strong><a href="#How-is-California-planning-for-COVID-19-vaccination">How is California planning for COVID-19 vaccination?&nbsp;</a></strong></li><li><strong><a href="#How-will-COVID-19-vaccines-work">How will COVID-19 vaccines work?</a></strong></li><li><strong><a href="#What-are-the-benefits-of-getting-vaccinated">What are the benefits of getting vaccinated?</a></strong></li><li><strong><a href="#Busting-myths-about-vaccination">Busting myths about vaccination</a></strong></li><li><strong><a href="#Questions-and-answers">Questions and answers</a></strong></li></ul>
+
+
+
+<h2 id="When-will-a-COVID-19-vaccine-be-here">When will a COVID-19 vaccine be here?</h2>
+
+
+
+<p>There is currently no approved vaccine to prevent COVID-19. One or more vaccines might be available before the end of the year.&nbsp;</p>
+
+
+
+<p>At first, COVID-19 vaccines might be used under an Emergency Use Authorization (EUA) from the U.S. Food and Drug Administration (FDA). Learn more about <a href="https://www.fda.gov/emergency-preparedness-and-response/mcm-legal-regulatory-and-policy-framework/emergency-use-authorization">FDA’s Emergency Use Authorization authority</a> and watch a <a href="https://www.youtube.com/watch?v=iGkwaESsGBQ">video on what an EUA is</a>.</p>
+
+
+
+<h3><strong>Vaccine safety is a top priority</strong></h3>
+
+
+
+<p>The U.S. vaccine safety system ensures that all vaccines are as safe as possible. Learn how the federal government is working to <a href="https://www.cdc.gov/coronavirus/2019-ncov/vaccines/safety.html">ensure the safety of COVID-19 vaccines</a>.</p>
+
+
+
+<p>To ensure the COVID-19 vaccine meets safety requirements, California formed a <a href="https://www.cdph.ca.gov/Programs/CID/DCDC/Pages/COVID-19/Scientific-Safety-Review-Workgroup.aspx">Scientific Safety Review Workgroup</a> to provide recommendations to California leadership and build public confidence in vaccine safety.</p>
+
+
+
+<h3><strong>Vaccine distribution and prioritization</strong></h3>
+
+
+
+<p>California is planning to distribute and administer vaccines as quickly as possible. This will be done only after a vaccine’s safety has been reviewed and approved by top health experts.</p>
+
+
+
+<p>Initially vaccine supply will be very limited. California is making sure that these supplies are distributed and administered equitably, at first to Californians working in healthcare settings and then to others critical to our daily existence and those at highest risk of becoming infected, severely ill or spreading COVID-19.&nbsp; &nbsp;&nbsp;</p>
+
+
+
+<h2 id="How-is-California-planning-for-COVID-19-vaccination">How is California planning for COVID-19 vaccination?&nbsp;</h2>
+
+
+
+<p>California’s distribution of COVID-19 vaccines will be guided by the following principles:</p>
+
+
+
+<ol><li>The vaccine meets safety requirements.</li><li>The vaccine is distributed and administered equitably.&nbsp;</li><li>Community partners have been included in planning from the beginning for broad input and transparency.</li></ol>
+
+
+
+<p>California will be transparent, careful, and equitable in its vaccine distribution. The state will provide COVID-19 vaccine to everyone in California who wants it.</p>
+
+
+
+<h2 id="How-will-COVID-19-vaccines-work">How will COVID-19 vaccines work?</h2>
+
+
+
+<p>COVID-19 vaccines will protect us from the virus that causes COVID-19 without having to get the illness. Different vaccines work in different ways, but they all help our immune system fight infections in the future.</p>
+
+
+
+<p>It typically takes a few weeks after the last dose in a series to become fully protected. Sometimes vaccination can cause mild fever or cold-like symptoms, but these are not harmful.</p>
+
+
+
+<h2 id="What-are-the-benefits-of-getting-vaccinated">What are the benefits of getting vaccinated?</h2>
+
+
+
+<p>COVID-19 vaccines that have been authorized by FDA will have been carefully evaluated in clinical trials for their ability to protect us from COVID-19.&nbsp;</p>
+
+
+
+<p>The ability of COVID-19 vaccines to protect us from spreading the virus to others is not yet known but is being studied carefully.</p>
+
+
+
+<h2 id="Busting-myths-about-vaccination">Busting myths about vaccination</h2>
+
+
+
+<h3>COVID-19 vaccines will not give you COVID-19</h3>
+
+
+
+<p>None of the COVID-19 vaccines under development can cause COVID-19. There are several different types of vaccines in development. However, the goal for each of them is to teach our immune systems how to fight the virus that causes COVID-19. Learn more about <a href="https://www.cdc.gov/coronavirus/2019-ncov/vaccines/about-vaccines/how-they-work.html">how COVID-19 vaccines work</a>.</p>
+
+
+
+<h3>COVID-19 vaccines will not cause you to test positive on COVID-19 viral tests</h3>
+
+
+
+<p>Vaccines currently in clinical trials in the United States won’t cause you to test positive on <a href="https://www.cdc.gov/coronavirus/2019-ncov/testing/diagnostic-testing.html">viral tests</a>, which are used to see if you have a current infection.</p>
+
+
+
+<p>If your body develops an immune response, which is the goal of vaccination, there is a possibility you may test positive on some <a href="https://www.cdc.gov/coronavirus/2019-ncov/testing/serology-overview.html">antibody tests</a>. Antibody tests indicate you had a previous infection and that you may have some level of protection against the virus. Experts are currently looking at how COVID-19 vaccination may affect antibody testing results.</p>
+
+
+
+<h3>People who have gotten sick with COVID-19 may still benefit from getting vaccinated</h3>
+
+
+
+<p>Due to the severe health risks associated with COVID-19 and the fact that re-infection with COVID-19 is possible, people may be advised to get a COVID-19 vaccine even if they have been sick with COVID-19 before.</p>
+
+
+
+<p>At this time, we do not know how long someone is protected from getting sick again after recovering from COVID-19.</p>
+
+
+
+<p>We won’t know how long immunity produced by vaccination lasts until we have a vaccine and more data on how well it works.</p>
+
+
+
+<h3>Vaccination can help prevent getting sick with COVID-19</h3>
+
+
+
+<p>While many people with COVID-19 have only a mild illness, others may get a <a href="https://www.cdc.gov/coronavirus/2019-ncov/symptoms-testing/symptoms.html">severe illness</a> or even die. There is no way to know how COVID-19 will affect you, even if you are not at <a href="https://www.cdc.gov/coronavirus/2019-ncov/need-extra-precautions/index.html">increased risk of severe complications</a>. COVID-19 vaccination helps protect you without having to get the disease. Learn more about <a href="https://www.cdc.gov/coronavirus/2019-ncov/vaccines/about-vaccines/how-they-work.html">how COVID-19 vaccines work</a>.</p>
+
+
+
+<h2 id="Questions-and-answers">Questions and answers</h2>
+
+
+
+<h4 class="wp-accordion">Will I still need to wear a mask after getting a COVID-19 vaccine?&nbsp;</h4>
+
+
+
+<p class="wp-accordion-content">Yes. While experts learn more about the protection that COVID-19 vaccines provide under real-life conditions, it will be important for everyone to continue using all the tools available to us to help stop this pandemic, like wearing masks, washing hands often, and social distancing. Together, COVID-19 vaccination and recommendations for <a href="https://www.cdc.gov/coronavirus/2019-ncov/prevent-getting-sick/prevention.html">how to protect yourself and others</a> will offer the best protection from getting and spreading COVID-19. We need to understand more about the protection that COVID-19 vaccines provide before we change recommendations on mask use.</p>
+
+
+
+<h4 class="wp-accordion">How many COVID-19 vaccine doses are needed?</h4>
+
+
+
+<p class="wp-accordion-content">All but one of the COVID-19 vaccines currently in development in the United States need two shots to be effective. The other COVID-19 vaccine uses one shot.</p>
+
+
+
+<h4 class="wp-accordion">How much will the COVID-19 vaccine cost?</h4>
+
+
+
+<p class="wp-accordion-content">Vaccines purchased with U.S. taxpayer dollars will be given to the American people at no cost. Vaccination providers will be able to charge an administration fee to those who can afford to pay it or bill an insurance company.</p>
+
+
+
+<h4 class="wp-accordion">What steps are being taken to ensure that COVID-19 vaccines are safe?&nbsp;</h4>
+
+
+
+<p class="wp-accordion-content">CDC and FDA encourage the public to report possible side effects (called adverse events) to the <a href="https://vaers.hhs.gov/reportevent.html">Vaccine Adverse Event Reporting System (VAERS)</a>. This national system collects these data to look for adverse events that are unexpected, appear to happen more often than expected, or have unusual patterns of occurrence. Learn about the <a href="https://www.cdc.gov/vaccinesafety/ensuringsafety/sideeffects/index.html">difference between a vaccine side effect and an adverse event</a>. Reports to VAERS help the CDC monitor the safety of vaccines. Safety is a top priority.</p>
+
+
+
+<p class="wp-accordion-content">Healthcare providers will be required to report certain adverse events following vaccination to VAERS. Healthcare providers also have to adhere to any revised safety reporting requirements according to FDA’s conditions of authorized use throughout the duration of any Emergency Use Authorization. These requirements would be posted on <a href="https://www.fda.gov/emergency-preparedness-and-response/mcm-legal-regulatory-and-policy-framework/emergency-use-authorization">FDA’s website.</a></p>
+
+
+
+<p class="wp-accordion-content">CDC is also implementing a new smartphone-based tool called <a href="https://www.cdc.gov/vaccines/acip/meetings/downloads/slides-2020-09/COVID-03-Shimabukuro.pdf">v-safe</a> to check-in on people’s health after they receive a COVID-19 vaccine. When you receive your vaccine, you should also receive an information sheet telling you how to enroll in v-safe. If you enroll, you will receive regular text messages directing you to surveys where you can report any problems or adverse reactions you have after receiving a COVID-19 vaccine.</p>
+
+
+
+<h2>Stay informed</h2>
+
+
+
+<ul><li>CDPH: <a href="https://www.cdph.ca.gov/Programs/CID/DCDC/Pages/COVID-19/COVID-19Vaccine.aspx">COVID-19 vaccine planning</a></li><li>CDC: <a href="https://www.cdc.gov/coronavirus/2019-ncov/vaccines/index.html">Vaccines</a></li></ul>

--- a/pages/translated-posts/vaccines-zh-hans.html
+++ b/pages/translated-posts/vaccines-zh-hans.html
@@ -1,0 +1,195 @@
+---
+layout: "page.njk"
+title: "Vaccines"
+meta: "A safe and effective COVID-19 vaccine will be one of the most important tools to end the COVID-19 pandemic.&nbsp; On this page you will find: When will a COVID-19 vaccine be here? How is California planning for COVID-19 vaccination?&nbsp; How will COVID-19 vaccines work? What are the benefits of getting vaccinated? Busting myths about vaccination [&hellip;]"
+author: "State of California"
+publishdate: "2020-12-03T12:44:25Z"
+tags: ["translate"]
+addtositemap: true
+---
+
+<p>A safe and effective COVID-19 vaccine will be one of the most important tools to end the COVID-19 pandemic.&nbsp;</p>
+
+
+
+<p>On this page you will find:</p>
+
+
+
+<ul><li><strong><a href="#When-will-a-COVID-19-vaccine-be-here">When will a COVID-19 vaccine be here?</a></strong></li><li><strong><a href="#How-is-California-planning-for-COVID-19-vaccination">How is California planning for COVID-19 vaccination?&nbsp;</a></strong></li><li><strong><a href="#How-will-COVID-19-vaccines-work">How will COVID-19 vaccines work?</a></strong></li><li><strong><a href="#What-are-the-benefits-of-getting-vaccinated">What are the benefits of getting vaccinated?</a></strong></li><li><strong><a href="#Busting-myths-about-vaccination">Busting myths about vaccination</a></strong></li><li><strong><a href="#Questions-and-answers">Questions and answers</a></strong></li></ul>
+
+
+
+<h2 id="When-will-a-COVID-19-vaccine-be-here">When will a COVID-19 vaccine be here?</h2>
+
+
+
+<p>There is currently no approved vaccine to prevent COVID-19. One or more vaccines might be available before the end of the year.&nbsp;</p>
+
+
+
+<p>At first, COVID-19 vaccines might be used under an Emergency Use Authorization (EUA) from the U.S. Food and Drug Administration (FDA). Learn more about <a href="https://www.fda.gov/emergency-preparedness-and-response/mcm-legal-regulatory-and-policy-framework/emergency-use-authorization">FDA’s Emergency Use Authorization authority</a> and watch a <a href="https://www.youtube.com/watch?v=iGkwaESsGBQ">video on what an EUA is</a>.</p>
+
+
+
+<h3><strong>Vaccine safety is a top priority</strong></h3>
+
+
+
+<p>The U.S. vaccine safety system ensures that all vaccines are as safe as possible. Learn how the federal government is working to <a href="https://www.cdc.gov/coronavirus/2019-ncov/vaccines/safety.html">ensure the safety of COVID-19 vaccines</a>.</p>
+
+
+
+<p>To ensure the COVID-19 vaccine meets safety requirements, California formed a <a href="https://www.cdph.ca.gov/Programs/CID/DCDC/Pages/COVID-19/Scientific-Safety-Review-Workgroup.aspx">Scientific Safety Review Workgroup</a> to provide recommendations to California leadership and build public confidence in vaccine safety.</p>
+
+
+
+<h3><strong>Vaccine distribution and prioritization</strong></h3>
+
+
+
+<p>California is planning to distribute and administer vaccines as quickly as possible. This will be done only after a vaccine’s safety has been reviewed and approved by top health experts.</p>
+
+
+
+<p>Initially vaccine supply will be very limited. California is making sure that these supplies are distributed and administered equitably, at first to Californians working in healthcare settings and then to others critical to our daily existence and those at highest risk of becoming infected, severely ill or spreading COVID-19.&nbsp; &nbsp;&nbsp;</p>
+
+
+
+<h2 id="How-is-California-planning-for-COVID-19-vaccination">How is California planning for COVID-19 vaccination?&nbsp;</h2>
+
+
+
+<p>California’s distribution of COVID-19 vaccines will be guided by the following principles:</p>
+
+
+
+<ol><li>The vaccine meets safety requirements.</li><li>The vaccine is distributed and administered equitably.&nbsp;</li><li>Community partners have been included in planning from the beginning for broad input and transparency.</li></ol>
+
+
+
+<p>California will be transparent, careful, and equitable in its vaccine distribution. The state will provide COVID-19 vaccine to everyone in California who wants it.</p>
+
+
+
+<h2 id="How-will-COVID-19-vaccines-work">How will COVID-19 vaccines work?</h2>
+
+
+
+<p>COVID-19 vaccines will protect us from the virus that causes COVID-19 without having to get the illness. Different vaccines work in different ways, but they all help our immune system fight infections in the future.</p>
+
+
+
+<p>It typically takes a few weeks after the last dose in a series to become fully protected. Sometimes vaccination can cause mild fever or cold-like symptoms, but these are not harmful.</p>
+
+
+
+<h2 id="What-are-the-benefits-of-getting-vaccinated">What are the benefits of getting vaccinated?</h2>
+
+
+
+<p>COVID-19 vaccines that have been authorized by FDA will have been carefully evaluated in clinical trials for their ability to protect us from COVID-19.&nbsp;</p>
+
+
+
+<p>The ability of COVID-19 vaccines to protect us from spreading the virus to others is not yet known but is being studied carefully.</p>
+
+
+
+<h2 id="Busting-myths-about-vaccination">Busting myths about vaccination</h2>
+
+
+
+<h3>COVID-19 vaccines will not give you COVID-19</h3>
+
+
+
+<p>None of the COVID-19 vaccines under development can cause COVID-19. There are several different types of vaccines in development. However, the goal for each of them is to teach our immune systems how to fight the virus that causes COVID-19. Learn more about <a href="https://www.cdc.gov/coronavirus/2019-ncov/vaccines/about-vaccines/how-they-work.html">how COVID-19 vaccines work</a>.</p>
+
+
+
+<h3>COVID-19 vaccines will not cause you to test positive on COVID-19 viral tests</h3>
+
+
+
+<p>Vaccines currently in clinical trials in the United States won’t cause you to test positive on <a href="https://www.cdc.gov/coronavirus/2019-ncov/testing/diagnostic-testing.html">viral tests</a>, which are used to see if you have a current infection.</p>
+
+
+
+<p>If your body develops an immune response, which is the goal of vaccination, there is a possibility you may test positive on some <a href="https://www.cdc.gov/coronavirus/2019-ncov/testing/serology-overview.html">antibody tests</a>. Antibody tests indicate you had a previous infection and that you may have some level of protection against the virus. Experts are currently looking at how COVID-19 vaccination may affect antibody testing results.</p>
+
+
+
+<h3>People who have gotten sick with COVID-19 may still benefit from getting vaccinated</h3>
+
+
+
+<p>Due to the severe health risks associated with COVID-19 and the fact that re-infection with COVID-19 is possible, people may be advised to get a COVID-19 vaccine even if they have been sick with COVID-19 before.</p>
+
+
+
+<p>At this time, we do not know how long someone is protected from getting sick again after recovering from COVID-19.</p>
+
+
+
+<p>We won’t know how long immunity produced by vaccination lasts until we have a vaccine and more data on how well it works.</p>
+
+
+
+<h3>Vaccination can help prevent getting sick with COVID-19</h3>
+
+
+
+<p>While many people with COVID-19 have only a mild illness, others may get a <a href="https://www.cdc.gov/coronavirus/2019-ncov/symptoms-testing/symptoms.html">severe illness</a> or even die. There is no way to know how COVID-19 will affect you, even if you are not at <a href="https://www.cdc.gov/coronavirus/2019-ncov/need-extra-precautions/index.html">increased risk of severe complications</a>. COVID-19 vaccination helps protect you without having to get the disease. Learn more about <a href="https://www.cdc.gov/coronavirus/2019-ncov/vaccines/about-vaccines/how-they-work.html">how COVID-19 vaccines work</a>.</p>
+
+
+
+<h2 id="Questions-and-answers">Questions and answers</h2>
+
+
+
+<h4 class="wp-accordion">Will I still need to wear a mask after getting a COVID-19 vaccine?&nbsp;</h4>
+
+
+
+<p class="wp-accordion-content">Yes. While experts learn more about the protection that COVID-19 vaccines provide under real-life conditions, it will be important for everyone to continue using all the tools available to us to help stop this pandemic, like wearing masks, washing hands often, and social distancing. Together, COVID-19 vaccination and recommendations for <a href="https://www.cdc.gov/coronavirus/2019-ncov/prevent-getting-sick/prevention.html">how to protect yourself and others</a> will offer the best protection from getting and spreading COVID-19. We need to understand more about the protection that COVID-19 vaccines provide before we change recommendations on mask use.</p>
+
+
+
+<h4 class="wp-accordion">How many COVID-19 vaccine doses are needed?</h4>
+
+
+
+<p class="wp-accordion-content">All but one of the COVID-19 vaccines currently in development in the United States need two shots to be effective. The other COVID-19 vaccine uses one shot.</p>
+
+
+
+<h4 class="wp-accordion">How much will the COVID-19 vaccine cost?</h4>
+
+
+
+<p class="wp-accordion-content">Vaccines purchased with U.S. taxpayer dollars will be given to the American people at no cost. Vaccination providers will be able to charge an administration fee to those who can afford to pay it or bill an insurance company.</p>
+
+
+
+<h4 class="wp-accordion">What steps are being taken to ensure that COVID-19 vaccines are safe?&nbsp;</h4>
+
+
+
+<p class="wp-accordion-content">CDC and FDA encourage the public to report possible side effects (called adverse events) to the <a href="https://vaers.hhs.gov/reportevent.html">Vaccine Adverse Event Reporting System (VAERS)</a>. This national system collects these data to look for adverse events that are unexpected, appear to happen more often than expected, or have unusual patterns of occurrence. Learn about the <a href="https://www.cdc.gov/vaccinesafety/ensuringsafety/sideeffects/index.html">difference between a vaccine side effect and an adverse event</a>. Reports to VAERS help the CDC monitor the safety of vaccines. Safety is a top priority.</p>
+
+
+
+<p class="wp-accordion-content">Healthcare providers will be required to report certain adverse events following vaccination to VAERS. Healthcare providers also have to adhere to any revised safety reporting requirements according to FDA’s conditions of authorized use throughout the duration of any Emergency Use Authorization. These requirements would be posted on <a href="https://www.fda.gov/emergency-preparedness-and-response/mcm-legal-regulatory-and-policy-framework/emergency-use-authorization">FDA’s website.</a></p>
+
+
+
+<p class="wp-accordion-content">CDC is also implementing a new smartphone-based tool called <a href="https://www.cdc.gov/vaccines/acip/meetings/downloads/slides-2020-09/COVID-03-Shimabukuro.pdf">v-safe</a> to check-in on people’s health after they receive a COVID-19 vaccine. When you receive your vaccine, you should also receive an information sheet telling you how to enroll in v-safe. If you enroll, you will receive regular text messages directing you to surveys where you can report any problems or adverse reactions you have after receiving a COVID-19 vaccine.</p>
+
+
+
+<h2>Stay informed</h2>
+
+
+
+<ul><li>CDPH: <a href="https://www.cdph.ca.gov/Programs/CID/DCDC/Pages/COVID-19/COVID-19Vaccine.aspx">COVID-19 vaccine planning</a></li><li>CDC: <a href="https://www.cdc.gov/coronavirus/2019-ncov/vaccines/index.html">Vaccines</a></li></ul>

--- a/pages/translated-posts/vaccines-zh-hant.html
+++ b/pages/translated-posts/vaccines-zh-hant.html
@@ -1,0 +1,195 @@
+---
+layout: "page.njk"
+title: "Vaccines"
+meta: "A safe and effective COVID-19 vaccine will be one of the most important tools to end the COVID-19 pandemic.&nbsp; On this page you will find: When will a COVID-19 vaccine be here? How is California planning for COVID-19 vaccination?&nbsp; How will COVID-19 vaccines work? What are the benefits of getting vaccinated? Busting myths about vaccination [&hellip;]"
+author: "State of California"
+publishdate: "2020-12-03T12:44:25Z"
+tags: ["translate"]
+addtositemap: true
+---
+
+<p>A safe and effective COVID-19 vaccine will be one of the most important tools to end the COVID-19 pandemic.&nbsp;</p>
+
+
+
+<p>On this page you will find:</p>
+
+
+
+<ul><li><strong><a href="#When-will-a-COVID-19-vaccine-be-here">When will a COVID-19 vaccine be here?</a></strong></li><li><strong><a href="#How-is-California-planning-for-COVID-19-vaccination">How is California planning for COVID-19 vaccination?&nbsp;</a></strong></li><li><strong><a href="#How-will-COVID-19-vaccines-work">How will COVID-19 vaccines work?</a></strong></li><li><strong><a href="#What-are-the-benefits-of-getting-vaccinated">What are the benefits of getting vaccinated?</a></strong></li><li><strong><a href="#Busting-myths-about-vaccination">Busting myths about vaccination</a></strong></li><li><strong><a href="#Questions-and-answers">Questions and answers</a></strong></li></ul>
+
+
+
+<h2 id="When-will-a-COVID-19-vaccine-be-here">When will a COVID-19 vaccine be here?</h2>
+
+
+
+<p>There is currently no approved vaccine to prevent COVID-19. One or more vaccines might be available before the end of the year.&nbsp;</p>
+
+
+
+<p>At first, COVID-19 vaccines might be used under an Emergency Use Authorization (EUA) from the U.S. Food and Drug Administration (FDA). Learn more about <a href="https://www.fda.gov/emergency-preparedness-and-response/mcm-legal-regulatory-and-policy-framework/emergency-use-authorization">FDA’s Emergency Use Authorization authority</a> and watch a <a href="https://www.youtube.com/watch?v=iGkwaESsGBQ">video on what an EUA is</a>.</p>
+
+
+
+<h3><strong>Vaccine safety is a top priority</strong></h3>
+
+
+
+<p>The U.S. vaccine safety system ensures that all vaccines are as safe as possible. Learn how the federal government is working to <a href="https://www.cdc.gov/coronavirus/2019-ncov/vaccines/safety.html">ensure the safety of COVID-19 vaccines</a>.</p>
+
+
+
+<p>To ensure the COVID-19 vaccine meets safety requirements, California formed a <a href="https://www.cdph.ca.gov/Programs/CID/DCDC/Pages/COVID-19/Scientific-Safety-Review-Workgroup.aspx">Scientific Safety Review Workgroup</a> to provide recommendations to California leadership and build public confidence in vaccine safety.</p>
+
+
+
+<h3><strong>Vaccine distribution and prioritization</strong></h3>
+
+
+
+<p>California is planning to distribute and administer vaccines as quickly as possible. This will be done only after a vaccine’s safety has been reviewed and approved by top health experts.</p>
+
+
+
+<p>Initially vaccine supply will be very limited. California is making sure that these supplies are distributed and administered equitably, at first to Californians working in healthcare settings and then to others critical to our daily existence and those at highest risk of becoming infected, severely ill or spreading COVID-19.&nbsp; &nbsp;&nbsp;</p>
+
+
+
+<h2 id="How-is-California-planning-for-COVID-19-vaccination">How is California planning for COVID-19 vaccination?&nbsp;</h2>
+
+
+
+<p>California’s distribution of COVID-19 vaccines will be guided by the following principles:</p>
+
+
+
+<ol><li>The vaccine meets safety requirements.</li><li>The vaccine is distributed and administered equitably.&nbsp;</li><li>Community partners have been included in planning from the beginning for broad input and transparency.</li></ol>
+
+
+
+<p>California will be transparent, careful, and equitable in its vaccine distribution. The state will provide COVID-19 vaccine to everyone in California who wants it.</p>
+
+
+
+<h2 id="How-will-COVID-19-vaccines-work">How will COVID-19 vaccines work?</h2>
+
+
+
+<p>COVID-19 vaccines will protect us from the virus that causes COVID-19 without having to get the illness. Different vaccines work in different ways, but they all help our immune system fight infections in the future.</p>
+
+
+
+<p>It typically takes a few weeks after the last dose in a series to become fully protected. Sometimes vaccination can cause mild fever or cold-like symptoms, but these are not harmful.</p>
+
+
+
+<h2 id="What-are-the-benefits-of-getting-vaccinated">What are the benefits of getting vaccinated?</h2>
+
+
+
+<p>COVID-19 vaccines that have been authorized by FDA will have been carefully evaluated in clinical trials for their ability to protect us from COVID-19.&nbsp;</p>
+
+
+
+<p>The ability of COVID-19 vaccines to protect us from spreading the virus to others is not yet known but is being studied carefully.</p>
+
+
+
+<h2 id="Busting-myths-about-vaccination">Busting myths about vaccination</h2>
+
+
+
+<h3>COVID-19 vaccines will not give you COVID-19</h3>
+
+
+
+<p>None of the COVID-19 vaccines under development can cause COVID-19. There are several different types of vaccines in development. However, the goal for each of them is to teach our immune systems how to fight the virus that causes COVID-19. Learn more about <a href="https://www.cdc.gov/coronavirus/2019-ncov/vaccines/about-vaccines/how-they-work.html">how COVID-19 vaccines work</a>.</p>
+
+
+
+<h3>COVID-19 vaccines will not cause you to test positive on COVID-19 viral tests</h3>
+
+
+
+<p>Vaccines currently in clinical trials in the United States won’t cause you to test positive on <a href="https://www.cdc.gov/coronavirus/2019-ncov/testing/diagnostic-testing.html">viral tests</a>, which are used to see if you have a current infection.</p>
+
+
+
+<p>If your body develops an immune response, which is the goal of vaccination, there is a possibility you may test positive on some <a href="https://www.cdc.gov/coronavirus/2019-ncov/testing/serology-overview.html">antibody tests</a>. Antibody tests indicate you had a previous infection and that you may have some level of protection against the virus. Experts are currently looking at how COVID-19 vaccination may affect antibody testing results.</p>
+
+
+
+<h3>People who have gotten sick with COVID-19 may still benefit from getting vaccinated</h3>
+
+
+
+<p>Due to the severe health risks associated with COVID-19 and the fact that re-infection with COVID-19 is possible, people may be advised to get a COVID-19 vaccine even if they have been sick with COVID-19 before.</p>
+
+
+
+<p>At this time, we do not know how long someone is protected from getting sick again after recovering from COVID-19.</p>
+
+
+
+<p>We won’t know how long immunity produced by vaccination lasts until we have a vaccine and more data on how well it works.</p>
+
+
+
+<h3>Vaccination can help prevent getting sick with COVID-19</h3>
+
+
+
+<p>While many people with COVID-19 have only a mild illness, others may get a <a href="https://www.cdc.gov/coronavirus/2019-ncov/symptoms-testing/symptoms.html">severe illness</a> or even die. There is no way to know how COVID-19 will affect you, even if you are not at <a href="https://www.cdc.gov/coronavirus/2019-ncov/need-extra-precautions/index.html">increased risk of severe complications</a>. COVID-19 vaccination helps protect you without having to get the disease. Learn more about <a href="https://www.cdc.gov/coronavirus/2019-ncov/vaccines/about-vaccines/how-they-work.html">how COVID-19 vaccines work</a>.</p>
+
+
+
+<h2 id="Questions-and-answers">Questions and answers</h2>
+
+
+
+<h4 class="wp-accordion">Will I still need to wear a mask after getting a COVID-19 vaccine?&nbsp;</h4>
+
+
+
+<p class="wp-accordion-content">Yes. While experts learn more about the protection that COVID-19 vaccines provide under real-life conditions, it will be important for everyone to continue using all the tools available to us to help stop this pandemic, like wearing masks, washing hands often, and social distancing. Together, COVID-19 vaccination and recommendations for <a href="https://www.cdc.gov/coronavirus/2019-ncov/prevent-getting-sick/prevention.html">how to protect yourself and others</a> will offer the best protection from getting and spreading COVID-19. We need to understand more about the protection that COVID-19 vaccines provide before we change recommendations on mask use.</p>
+
+
+
+<h4 class="wp-accordion">How many COVID-19 vaccine doses are needed?</h4>
+
+
+
+<p class="wp-accordion-content">All but one of the COVID-19 vaccines currently in development in the United States need two shots to be effective. The other COVID-19 vaccine uses one shot.</p>
+
+
+
+<h4 class="wp-accordion">How much will the COVID-19 vaccine cost?</h4>
+
+
+
+<p class="wp-accordion-content">Vaccines purchased with U.S. taxpayer dollars will be given to the American people at no cost. Vaccination providers will be able to charge an administration fee to those who can afford to pay it or bill an insurance company.</p>
+
+
+
+<h4 class="wp-accordion">What steps are being taken to ensure that COVID-19 vaccines are safe?&nbsp;</h4>
+
+
+
+<p class="wp-accordion-content">CDC and FDA encourage the public to report possible side effects (called adverse events) to the <a href="https://vaers.hhs.gov/reportevent.html">Vaccine Adverse Event Reporting System (VAERS)</a>. This national system collects these data to look for adverse events that are unexpected, appear to happen more often than expected, or have unusual patterns of occurrence. Learn about the <a href="https://www.cdc.gov/vaccinesafety/ensuringsafety/sideeffects/index.html">difference between a vaccine side effect and an adverse event</a>. Reports to VAERS help the CDC monitor the safety of vaccines. Safety is a top priority.</p>
+
+
+
+<p class="wp-accordion-content">Healthcare providers will be required to report certain adverse events following vaccination to VAERS. Healthcare providers also have to adhere to any revised safety reporting requirements according to FDA’s conditions of authorized use throughout the duration of any Emergency Use Authorization. These requirements would be posted on <a href="https://www.fda.gov/emergency-preparedness-and-response/mcm-legal-regulatory-and-policy-framework/emergency-use-authorization">FDA’s website.</a></p>
+
+
+
+<p class="wp-accordion-content">CDC is also implementing a new smartphone-based tool called <a href="https://www.cdc.gov/vaccines/acip/meetings/downloads/slides-2020-09/COVID-03-Shimabukuro.pdf">v-safe</a> to check-in on people’s health after they receive a COVID-19 vaccine. When you receive your vaccine, you should also receive an information sheet telling you how to enroll in v-safe. If you enroll, you will receive regular text messages directing you to surveys where you can report any problems or adverse reactions you have after receiving a COVID-19 vaccine.</p>
+
+
+
+<h2>Stay informed</h2>
+
+
+
+<ul><li>CDPH: <a href="https://www.cdph.ca.gov/Programs/CID/DCDC/Pages/COVID-19/COVID-19Vaccine.aspx">COVID-19 vaccine planning</a></li><li>CDC: <a href="https://www.cdc.gov/coronavirus/2019-ncov/vaccines/index.html">Vaccines</a></li></ul>


### PR DESCRIPTION
Added a few missing pagenames (for pages we have translations for).

Still missing `get-tested` and `vaccines`.