### PR TITLE
CCG-640 - add missing data message boxes to relative percentage charts.

### DIFF
--- a/src/js/equity-dash/chart-overlay-box.js
+++ b/src/js/equity-dash/chart-overlay-box.js
@@ -24,9 +24,22 @@ function chartOverlayBox(svg,        // svg to change to 50% opacity
       .text(caption)
 }
 
+function chartOverlayFade(svg,        // svg to change to 50% opacity
+                          chartClass, // chart's class
+                          boxClass,   // custom class name for this box
+                          chartDims  // dict that contains width and height
+                          ) {
+      // 250 is current width of chart-overlaybox-container
+      let boxWidth = 250;
+      let boxHeight = boxWidth/2;
+
+      d3.selectAll("." + boxClass).remove();
+      svg.style("opacity",.5);
+}
+
 function chartOverlayBoxClear(svg, boxClass) {
     // clears previous box, if any and resets opacity of svg
     d3.selectAll("." + boxClass).remove();
     svg.style("opacity",1);
 }
-export {chartOverlayBox, chartOverlayBoxClear};
+export {chartOverlayBox, chartOverlayFade, chartOverlayBoxClear};

--- a/src/js/equity-dash/charts/relative-percentage-by-100k/draw-chart.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-100k/draw-chart.js
@@ -1,3 +1,5 @@
+import { chartOverlayBox, chartOverlayBoxClear } from "../../chart-overlay-box.js";
+
 export default function drawBars(stackedData, data, statewideRatePer100k) {
   // console.log("Draw bars this.dimensions",this.dimensions);
   // using object context for most of the params
@@ -15,6 +17,10 @@ export default function drawBars(stackedData, data, statewideRatePer100k) {
   let filterString = this.filterString(statewideRatePer100k);
   let legendString = this.legendString();
   let translationsObj = this.translationsObj;
+  let chartBreakpointValues = this.chartBreakpointValues;
+  let appliedSuppressionStatus = this.appliedSuppressionStatus;
+
+  console.log('100k', translationsObj, chartBreakpointValues, appliedSuppressionStatus);
 
   svg.selectAll("g").remove();
   svg.selectAll("rect").remove();
@@ -87,6 +93,19 @@ export default function drawBars(stackedData, data, statewideRatePer100k) {
     });
 
   // svg.append("g").call(xAxis);
+
+  let is_debugging_infobox = false;
+  let boxClass = "chartOverlay-cagov-chart-re-100k";
+  if (appliedSuppressionStatus !== null || is_debugging_infobox) {
+    chartOverlayBox(svg,                      
+                  "cagov-chart-re-100k",      // class of chart
+                  boxClass,                   // class of box
+                  chartBreakpointValues,      // dimensions dict (contains width,height)
+                  translationsObj[appliedSuppressionStatus] ? translationsObj[appliedSuppressionStatus] : '' // caption
+                  )
+  } else {
+    chartOverlayBoxClear(svg, boxClass);
+  }
 
   // Bar labels.
   svg
@@ -303,4 +322,5 @@ export default function drawBars(stackedData, data, statewideRatePer100k) {
     .attr("class", "legend-label")
     .attr("dy", "0.35em")
     .text(legendString);
+
 }

--- a/src/js/equity-dash/charts/relative-percentage-by-100k/index.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-100k/index.js
@@ -3,6 +3,7 @@ import drawBars from "./draw-chart.js";
 import termCheck from "../race-ethnicity-config.js";
 import getTranslations from "../../get-strings-list.js";
 import getScreenResizeCharts from "./../../get-window-size.js";
+import { chartOverlayBox, chartOverlayBoxClear } from "../../chart-overlay-box.js";
 
 class CAGOVEquityRE100K extends window.HTMLElement {
   connectedCallback() {
@@ -225,62 +226,30 @@ class CAGOVEquityRE100K extends window.HTMLElement {
   }
 
   checkAppliedDataSuppression(data) {
+    let appliedSuppressionStatus = null;
+    let groups = data.map((item) => item.DEMOGRAPHIC_SET_CATEGORY);
+
     let suppressionAllocations = {
       None: 0,
       Total: 0,
       Population: 0,
+      CountySuppressed: false,
+      TotalSuppression: 0,
     };
 
-    let appliedSuppressionStatus = null;
-
     data.map((item) => {
-      suppressionAllocations[item.APPLIED_SUPPRESSION] =
-        suppressionAllocations[item.APPLIED_SUPPRESSION] + 1;
+      suppressionAllocations[item.APPLIED_SUPPRESSION] = suppressionAllocations[item.APPLIED_SUPPRESSION] + 1;
+      if (item.APPLIED_SUPPRESSION !== "None") {      
+        suppressionAllocations['TotalSuppression'] = suppressionAllocations['TotalSuppression'] + 1;
+      }
     });
 
-    if (suppressionAllocations["Population"] === data.length) {
-      appliedSuppressionStatus = 'applied-suppression-population';
-    } else if (suppressionAllocations["Total"] === data.length) {
+    if (groups.length === suppressionAllocations.TotalSuppression) {
+      suppressionAllocations.CountySuppressed = true;
       appliedSuppressionStatus = 'applied-suppression-total';
     }
-   
-    return {
-      status: appliedSuppressionStatus
-    }
-  }
-
-  getMessages(key) {
-    // Read messages from mark up.
-    // let messagesByType = {
-    //   appliedSuppressionNone: null,
-    //   appliedSuppressionTotal: this.translationsObj["applied-suppression-total"],
-    //   appliedSuppressionPopulation: this.translationsObj["applied-suppression-population"],
-    // };
-
-    // Get the current message as requested for this type.
-    // let message = messagesByType[type];
-    return null;
-  }
-
-  getMessageBox(data) {
-    let suppressionStatus = this.checkAppliedDataSuppression(data);
-    let message = null;
-    if (suppressionStatus === null) {
-      // Do nothing
-    } else if (suppressionStatus === 'applied-suppression-total') {
-      // Generate a message box
-      message = this.getMessages('applied-suppression-total');
-    }
-
-    // @TODO Read the data, check all APPLIED_SUPPRESSION === "Total"
-
-    // If a message is found
-    // if (message !== null) {
-        // Get message box d3 constructor (or CSS box overlay?)
-        // Format message (break into lines) - with a utility function
-        // Generate message box to pass to d3 rendered.
-    // }
-    return null;
+    console.log(suppressionAllocations);
+    return appliedSuppressionStatus;
   }
 
   render() {
@@ -330,6 +299,8 @@ class CAGOVEquityRE100K extends window.HTMLElement {
     // Remap data object
     data = sortableData.concat(nullSortData); 
     
+
+    this.appliedSuppressionStatus = this.checkAppliedDataSuppression(data);
     // ordering this array by the order they are in in data
     // need to inherit this as a mapping of all possible values to desired display values becuase these differ in some tables
 

--- a/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart-second.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart-second.js
@@ -1,3 +1,5 @@
+import { chartOverlayFade, chartOverlayBoxClear } from "../../chart-overlay-box.js";
+
 export default function drawSecondBars({
   svg,
   x1,
@@ -14,11 +16,26 @@ export default function drawSecondBars({
   translationsObj,
   legendScope = ``,
   legendScopeStatewide = ``,
+  appliedSuppressionStatus,
+  chartBreakpointValues
 }) {
   
   svg.selectAll("g").remove();
   svg.selectAll("rect").remove();
   svg.selectAll("text").remove();
+
+  let is_debugging_infobox = false;
+  let boxClass = "chartOverlay-svg-holder-second";
+
+  if ( appliedSuppressionStatus !== null || is_debugging_infobox) {
+    chartOverlayFade(svg,                      
+                    "cagov-chart-re-pop",       // class of chart
+                    boxClass,                   // class of box
+                    chartBreakpointValues,      // dimensions dict (contains width,height)
+                    )
+    } else {
+      chartOverlayBoxClear(svg, boxClass);
+    }  
 
   // End of bar labels, METRIC total (yellow)
   svg

--- a/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart.js
@@ -1,3 +1,5 @@
+import { chartOverlayBox, chartOverlayBoxClear } from "../../chart-overlay-box.js";
+
 export default function drawBars({
   component,
   svg,
@@ -15,22 +17,17 @@ export default function drawBars({
   legendScope = ``,
   selectedMetric,
   translationsObj,
-  messageBox
+  appliedSuppressionStatus,
+  chartBreakpointValues
 }) {
   svg.selectAll("g").remove();
   svg.selectAll("rect").remove();
   svg.selectAll("text").remove();
 
-  // svg.
-  //   append(messageBox);
-
-  if (messageBox !== null) {
-    svg.append("g").call(messageBox);
-  }
-
   //yellow bars
   svg
     .append("g")
+    .attr('class', 'svg-first-section')
     .selectAll("g")
     .data(stackedData1)
     .enter()
@@ -273,4 +270,20 @@ export default function drawBars({
     .attr("class", "legend-label")
     .attr("dy", "0.35em")
     .text('% ' + legendStrings[1]);
+
+
+  let is_debugging_infobox = false;
+  let boxClass = "chartOverlay-svg-first-section";
+
+  if ( appliedSuppressionStatus !== null || is_debugging_infobox) {
+    chartOverlayBox(svg,                      
+                    "cagov-chart-re-pop",       // class of chart
+                    boxClass,                   // class of box
+                    chartBreakpointValues,      // dimensions dict (contains width,height)
+                    translationsObj[appliedSuppressionStatus] ? translationsObj[appliedSuppressionStatus] : ''
+                    )
+    } else {
+      chartOverlayBoxClear(svg, boxClass);
+    }  
+
 }

--- a/src/js/equity-dash/charts/relative-percentage-by-pop/index.scss
+++ b/src/js/equity-dash/charts/relative-percentage-by-pop/index.scss
@@ -17,12 +17,16 @@ cagov-chart-re-pop {
   // }
 
   .svg-holder-second {
-    border-top: solid 2px #000;
+    border-top: solid 1px #000;
     margin-top: 10px;
     padding-top: 30px;
     svg {
       width: 100%;
     }
+  }
+
+  .chart-overlaybox-container {
+    top: 23%;
   }
 
   // .bars {


### PR DESCRIPTION
Add message boxes to relative percentage charts. 
Needs review with Alpine, Inyo & Nevada counties to double-check our settings & text strings.

@jbum There were some issues with positioning of the text box for the charts, the chart on the left is two svg's stacked. I added a 'faded svg only' to your code to be used in that situation. 