### PR TITLE
change how we are calculating stuff

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -45,22 +45,6 @@ const eleventy = (done) => {
     log('Note: Building site in dev mode. Try *npm run start* if you need a full build.');
   }
 
-//Special data location
-const defaultConfig = {
-  filesDataLoc: 'https://files.covid19.ca.gov/data/reviewed/'
-}
-const stagingConfig =  {
-  filesDataLoc: 'https://files.covid19.ca.gov/data/to-review/'
-}
-  
-const jsConfig = (process.env.NODE_ENV === 'staging' || process.env.NODE_ENV == "development") ? stagingConfig : defaultConfig;
-  // Download equity dash top boxes
-  download(`${jsConfig.filesDataLoc}equitydash/equitytopboxdatav2.json`, './pages/_buildoutput/equitytopboxdataV2.json', error => {
-    if (error) {
-      console.error(error);
-    }
-  });
-
   // Download the files sitemap for 11ty to use
   download('https://files.covid19.ca.gov/sitemap.xml', './pages/_buildoutput/fileSitemap.xml', error => {
     if (error) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8675,6 +8675,12 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "dev": true
+    },
     "node-gyp": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "imagemin-pngquant": "^9.0.1",
     "imagemin-webp": "^6.0.0",
     "md5": "^2.3.0",
+    "node-fetch": "^2.6.1",
     "node-sass": "^4.14.1",
     "npm-run-all": "^4.1.5",
     "onchange": "^7.0.2",

--- a/pages/_data/equityTopBoxes.js
+++ b/pages/_data/equityTopBoxes.js
@@ -1,52 +1,68 @@
-const data = require('../_buildoutput/equitytopboxdataV2.json');
-const demographics=data.Demographics;
+const fetch = require('node-fetch')
 
-const output = [
-  {
-    "cases_per_100K_statewide":1871.4,
-    "death_rate_per_100K_statewide":45.5,
-    "cases_per_100K_latino":2879.1,
-    "cases_per_100K_pacific_islanders": 4024,
-    "case_rate_vs_statewide_percent_latino":53,
-    "case_rate_vs_statewide_percent_pacific_islanders":115,
-    "case_rate_vs_statewide_percent_low_income":36,
-    "case_rate_per_100K_low_income":40,
-    "death_rate_vs_statewide_percent_black":24,
-    "death_rate_per_100K_black":56.2
+module.exports = function() {
+  let dataDomain = 'https://files.covid19.ca.gov/data/reviewed/';
+  if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'staging') {
+    dataDomain = 'https://files.covid19.ca.gov/data/to-review/';
   }
-];
+  return new Promise((resolve, reject) => {
+    
+    fetch(dataDomain+'equitydash/equitytopboxdatav2.json')
+    .then(res => res.json())
+    .then(json => {
 
-const roundNumber = (number, fractionDigits=3) => {
-  const roundscale = Math.pow(10,fractionDigits);
-  return Math.round(Number.parseFloat(number)*roundscale)/roundscale;
+      const data = json;          
+      const demographics=data.Demographics;
+      let output = [
+        {
+          "cases_per_100K_statewide":0,
+          "death_rate_per_100K_statewide":0,
+          "cases_per_100K_latino":0,
+          "cases_per_100K_pacific_islanders": 0,
+          "case_rate_vs_statewide_percent_latino":0,
+          "case_rate_vs_statewide_percent_pacific_islanders":0,
+          "case_rate_vs_statewide_percent_low_income":0,
+          "case_rate_per_100K_low_income":0,
+          "death_rate_vs_statewide_percent_black":0,
+          "death_rate_per_100K_black":0
+        }
+      ];
+
+      const roundNumber = (number, fractionDigits=3) => {
+        const roundscale = Math.pow(10,fractionDigits);
+        return Math.round(Number.parseFloat(number)*roundscale)/roundscale;
+      }
+
+      const totalPopulation = demographics.reduce((a,c)=> c.POPULATION+a,0);
+      const totalDeaths = demographics.reduce((a,c)=> c.DEATHS+a,0);
+      const totalCaseRate = roundNumber(data.LowIncome[0].STATE_CASE_RATE_PER_100K,0);
+      const totalDeathRate = totalDeaths/totalPopulation*100000;
+
+      //use updated values
+      output[0].death_rate_per_100K_statewide = roundNumber(totalDeathRate,1);
+      output[0].cases_per_100K_statewide = totalCaseRate
+
+      const raceLatino = demographics.find(x=>x.RACE_ETHNICITY==='Latino');
+      output[0].cases_per_100K_latino = roundNumber(raceLatino.CASE_RATE,1);
+      output[0].case_rate_vs_statewide_percent_latino = roundNumber(compare(totalCaseRate,raceLatino.CASE_RATE),0);
+
+      const raceNHPI = demographics.find(x=>x.RACE_ETHNICITY==='Native Hawaiian and other Pacific Islander');
+      output[0].cases_per_100K_pacific_islanders = roundNumber(raceNHPI.CASE_RATE,1);
+      output[0].case_rate_vs_statewide_percent_pacific_islanders = roundNumber(compare(totalCaseRate,raceNHPI.CASE_RATE),0);
+
+      const raceBlack = demographics.find(x=>x.RACE_ETHNICITY==='African American');
+      output[0].death_rate_per_100K_black = roundNumber(raceBlack.DEATH_RATE,1);
+      output[0].death_rate_vs_statewide_percent_black = roundNumber((raceBlack.DEATH_RATE/totalDeathRate)*100-100,0);
+
+      output[0].case_rate_vs_statewide_percent_low_income = roundNumber(compare(totalCaseRate,data.LowIncome[0].CASE_RATE_PER_100K),0);
+      output[0].case_rate_per_100K_low_income = roundNumber(data.LowIncome[0].CASE_RATE_PER_100K,0);
+
+      resolve(output);
+    });
+  });
+};
+
+function compare(statewide,subset) {
+  let diff = statewide - subset;
+  return (Math.abs(diff) / statewide) * 100;
 }
-
-const totalPopulation = demographics.reduce((a,c)=> c.POPULATION+a,0);
-const totalCases = demographics.reduce((a,c)=> c.CASES+a,0);
-const totalDeaths = demographics.reduce((a,c)=> c.DEATHS+a,0);
-const totalCaseRate = totalCases/totalPopulation*100000;
-const totalDeathRate = totalDeaths/totalPopulation*100000;
-
-//use updated values
-output[0].death_rate_per_100k_statewide = roundNumber(totalDeathRate,1);
-output[0].cases_per_100k_statewide = roundNumber(totalCaseRate,1);
-
-const raceLatino = demographics.find(x=>x.RACE_ETHNICITY==='Latino');
-output[0].cases_per_100k_latino = roundNumber(raceLatino.CASE_RATE,1);
-output[0].case_rate_vs_statewide_percent_latino = roundNumber((raceLatino.CASE_RATE/totalCaseRate)*100-100,0);
-
-const raceNHPI = demographics.find(x=>x.RACE_ETHNICITY==='Native Hawaiian and other Pacific Islander');
-output[0].cases_per_100k_pacific_islanders = roundNumber(raceNHPI.CASE_RATE,1);
-output[0].case_rate_vs_statewide_percent_pacific_islanders = roundNumber((raceNHPI.CASE_RATE/totalCaseRate)*100-100,0);
-
-const raceBlack = demographics.find(x=>x.RACE_ETHNICITY==='African American');
-output[0].death_rate_per_100k_black = roundNumber(raceBlack.DEATH_RATE,1);
-output[0].death_rate_vs_statewide_percent_black = roundNumber((raceBlack.DEATH_RATE/totalDeathRate)*100-100,0);
-
-let lowIncomeDiff = data.LowIncome[0].STATE_CASE_RATE_PER_100K - data.LowIncome[0].CASE_RATE_PER_100K;
-let lowIncomePercent = (Math.abs(lowIncomeDiff) / data.LowIncome[0].CASE_RATE_PER_100K) * 100;
-output[0].case_rate_vs_statewide_percent_low_income = roundNumber(lowIncomePercent,0);
-output[0].case_rate_per_100K_low_income = roundNumber(data.LowIncome[0].CASE_RATE_PER_100K,0);
-
-module.exports = output;
-

--- a/pages/_data/equityTopBoxes.js
+++ b/pages/_data/equityTopBoxes.js
@@ -64,5 +64,5 @@ module.exports = function() {
 
 function compare(statewide,subset) {
   let diff = statewide - subset;
-  return (Math.abs(diff) / statewide) * 100;
+  return (diff / statewide) * 100;
 }

--- a/pages/wordpress-posts/equity.html
+++ b/pages/wordpress-posts/equity.html
@@ -3,7 +3,7 @@ layout: "page.njk"
 title: "California’s commitment to health equity"
 meta: "All Californians—regardless of where they live, their working environment, their social supports, or how they identify⁠—deserve a healthy life. COVID-19 has highlighted existing inequities in health. Many of these inequities are the result of structural racism. One form this takes is the unequal distribution of and access to health care resources. Committed to a California [&hellip;]"
 author: "State of California"
-publishdate: "2020-12-05T02:24:39Z"
+publishdate: "2020-12-05T02:50:23Z"
 tags: ["do-not-crawl","staging-only"]
 addtositemap: false
 ---
@@ -159,6 +159,7 @@ addtositemap: false
 </div>
 
 <!--{% endif %}-->
+
                             <div class="eq-cases">
                               <p class="text-xs">Cases per 100K people:</p> 
                               <p class="text-xs mb-0"><strong>{{data.case_rate_per_100K_low_income|formatNumber(tags)}}</strong> income &lt;$40K <br>


### PR DESCRIPTION
I think this fixes the data in the top boxes but this should be reviewed

Fetch the data for the top box info in the js file that provides it to 11ty
Remove the request from gulpfile
We now have a clean statewide rate provided in the income_cumulative query, use that everywhere
I will uncomment the same thing in WordPress so ignore that change