### PR TITLE
CCG-816 Using yAxis label translations for data-completeness graph. Other cosmetic fixes.

### DIFF
--- a/src/js/equity-dash/charts/data-completeness/draw.js
+++ b/src/js/equity-dash/charts/data-completeness/draw.js
@@ -243,7 +243,7 @@ function drawBars(svg, x, y, yAxis, stackedData, color, data, tooltip, translati
 
   svg
     .append("rect")
-    .attr("x", 115)
+    .attr("x", 135) // widened for spanish/tagalog
     .attr("y", -20)
     .attr("width", 15)
     .attr("height", 15)
@@ -259,7 +259,7 @@ function drawBars(svg, x, y, yAxis, stackedData, color, data, tooltip, translati
 
   svg
     .append("text")
-    .attr("x", 135)
+    .attr("x", 155) // widened for spanish/tagalog
     .attr("y", -12)
     .attr("dy", "0.35em")
     .attr("class", "legend-label")

--- a/src/js/equity-dash/charts/data-completeness/index.js
+++ b/src/js/equity-dash/charts/data-completeness/index.js
@@ -10,6 +10,7 @@ class CAGOVEquityMissingness extends window.HTMLElement {
     // Get translations.
     // Use component function, which loads getTranslations and then appends that function with additional translation functions.
     this.translationsObj = this.getTranslations(this);
+    // console.log("trans objs",this.translationsObj);
     this.innerHTML = template(this.translationsObj);
 
     // Settings and initial values
@@ -332,6 +333,7 @@ class CAGOVEquityMissingness extends window.HTMLElement {
   }
 
   drawSvg(data) {
+    // console.log("Chart data",data);
     let stackedData = d3.stack().keys(this.chartOptions.subgroups)(data);
     let domains = this.getDomains(data); // Get list of data domains for this dataset.
 
@@ -366,7 +368,9 @@ class CAGOVEquityMissingness extends window.HTMLElement {
       g
         .attr("class", "bar-label")
         .attr("transform", "translate(5," + labelOffset + ")") // Relative positioning of label.
-        .call(d3.axisLeft(this.y).tickSize(0))
+        .call(d3.axisLeft(this.y)
+          .tickSize(0)
+          .tickFormat(i => this.translationsObj.displayOrder[i]))
         .call((g) => g.selectAll(".domain").remove());
 
     this.tooltip = d3

--- a/src/js/equity-dash/charts/data-completeness/template.js
+++ b/src/js/equity-dash/charts/data-completeness/template.js
@@ -1,6 +1,9 @@
 import css from './index.scss';
 
 export default function template(translationsObj) {
+  // inhibit special note if it is missing (as it currently is for some translations)
+  const inhibitNote = ('special-note' in translationsObj)? 
+                      '' : 'style="display:none;"' ;
   return /*html*/`<div class="py-2">
     <div class="container">
       <div class="col-lg-12 bg-white py-4">
@@ -19,7 +22,7 @@ export default function template(translationsObj) {
           </div>
         </div>
 
-        <div class="row">
+        <div class="row" ${inhibitNote}>
           <div class="col-lg-9 col-md-9 col-sm-12 mx-auto px-0">
             <div class="special-note mt-1 mb-1"><p>${translationsObj["special-note"]}</p></div>
           </div>

--- a/src/js/equity-dash/charts/healthy-places-index/index.js
+++ b/src/js/equity-dash/charts/healthy-places-index/index.js
@@ -395,7 +395,7 @@ class CAGOVChartD3Lines extends window.HTMLElement {
   }
 
   writeLegendLabels(legendLabels, legend) {
-    console.log("write legend width",this.chartBreakpointValues.width);
+    // console.log("write legend width",this.chartBreakpointValues.width);
     legend
       .selectAll("text")
       .data(legendLabels)


### PR DESCRIPTION
Translating y-domain ticks for yAxis on data-completeness graph.
Inhibiting display of special-note markup if the note has not yet been translated or is missing.
Also removed a console.log statement.
