### PR TITLE
Repaired korean translation of equity page.

### DIFF
--- a/pages/translated-posts/equity-ko.html
+++ b/pages/translated-posts/equity-ko.html
@@ -148,7 +148,7 @@ addtositemap: false
             <li data-label="chartToolTip2-caption">placeholder_DEMOGRAPHIC_SET_CATEGORY 계층이 차지하는 비중은 캘리포니아 인구의<span class="highlight-data"> placeholder_POPULATION_PERCENTAGE</span> 및 placeholder_Selected주 전역 메트릭의 <span class="highlight-data"> placeholder_METRIC_TOTAL_PERCENTAGE</span>입니다</li>
         </ul>       </cagov-chart-re-pop>     </div>
     <div class="col">       <cagov-chart-re-100k class="chart d-none">          <ul>
-          <li data-label="chartTitle--cases">placeholder역학 조사 지역 내 인종과 민족 별 100,000명 당 사례 건수</li>
+          <li data-label="chartTitle--cases">placeholderForDynamicLocation 조사 지역 내 인종과 민족 별 100,000명 당 사례 건수</li>
           <li data-label="chartTitle--deaths">placeholderForDynamicLocation 내 인종과 민족 별 1십만명 당 사망 건수</li>
           <li data-label="chartTitle--tests">placeholderForDynamicLocation 내 인종과 민족 별 1십만명 당 검사 건수</li>
           <li data-label="chartDescription--cases">각 인종과 민족을 대상으로 인구 규모로 조정한 사례 건수를 비교하십시오.</li>
@@ -158,9 +158,9 @@ addtositemap: false
           <li data-label="chartLegend--cases">100,000명 당 사례 건수</li>
           <li data-label="chartLegend--deaths">100,000명 당 사망 건수</li>
           <li data-label="chartLegend--tests">100,000명 당 검사 건수</li>
-          <li data-label="chartFilterLegendPfxCounty--cases">placeholder역학 조사 지역 내 100,000명 당 사례 건수: </li>
-          <li data-label="chartFilterLegendPfxCounty--deaths">placeholder역학 조사 지역 내 100,000명 당 사망 건수: </li>
-          <li data-label="chartFilterLegendPfxCounty--tests">placeholder역학 조사 지역 내 100,000명 당 검사 건수: </li>
+          <li data-label="chartFilterLegendPfxCounty--cases">placeholderForDynamicLocation 조사 지역 내 100,000명 당 사례 건수: </li>
+          <li data-label="chartFilterLegendPfxCounty--deaths">placeholderForDynamicLocation 조사 지역 내 100,000명 당 사망 건수: </li>
+          <li data-label="chartFilterLegendPfxCounty--tests">placeholderForDynamicLocation 조사 지역 내 100,000명 당 검사 건수: </li>
           <li data-label="chartFilterLegendPfxState--cases">100,000명 당 주 전역 사례 건수: </li>
           <li data-label="chartFilterLegendPfxState--deaths">100,000명 당 주 전역 사망 건수: </li>
           <li data-label="chartFilterLegendPfxState--tests">100,000명 당 주 전역 검사 건수: </li>
@@ -183,7 +183,7 @@ addtositemap: false
       <ul>
         <li data-label="y-axis-label">검사 양성 반응율</li>
         <li data-label="data1-legend">주 전역 양성 반응율</li>
-        <li data-label="data1-legend-local">placeholder역학 조사 지역 내 양성 반응율</li>
+        <li data-label="data1-legend-local">placeholderForDynamicLocation 조사 지역 내 양성 반응율</li>
         <li data-label="data2-legend">건강 형평성 사분위수 양성 반응율</li>
         <li data-label="missing-data-caption">건강 형평성 메트릭은 인구수가 106,000명 미만인 카운티에는 적용되지 않습니다.</li>
       </ul>


### PR DESCRIPTION
The symbolic word placeholderForDynamicLocation got translated in several spots to placeholder역학  (with no space). I think 역학 translates to "dynamics".  Changing it back.
