### PR TITLE
Added missing captions to translated Equity page files that were missed last translation pass.

### DIFF
--- a/pages/translated-posts/equity-ar.html
+++ b/pages/translated-posts/equity-ar.html
@@ -165,6 +165,10 @@ addtositemap: false
           <li data-label="chartFilterLegendPfxState--deaths">حالات وفاة على نطاق الولاية لكل 100 ألف شخص: </li>
           <li data-label="chartFilterLegendPfxState--tests">اختبارات على نطاق الولاية لكل 100 ألف شخص: </li>
           <li data-label="chartToolTip-caption"><span class="highlight-data">placeholderDEMO_CAT</span> يعاني الأفراد من <span class="highlight-data">placeholderMETRIC_100K</span> placeholderFilterScope لكل 100 ألف شخص من نفس الجنس والعرق.</li>
+          <li data-label="applied-suppression-total">لحماية خصوصية الأشخاص، لا نعرض أي بيانات يرجع ذلك إلى وجود حالات أو اختبارات
+              قليلة جدًا في هذه المجموعة.</li>
+          <li data-label="applied-suppression-population">لحماية خصوصية الأشخاص، لا نعرض أي بيانات يرجع ذلك إلى وجود أقل من 20.000
+              في هذه المجموعة. </li>
         </ul>       </cagov-chart-re-100k>     </div>
   </div>
 </div>

--- a/pages/translated-posts/equity-es.html
+++ b/pages/translated-posts/equity-es.html
@@ -165,6 +165,10 @@ addtositemap: false
           <li data-label="chartFilterLegendPfxState--deaths">Decesos estatales por cada 100 mil: </li>
           <li data-label="chartFilterLegendPfxState--tests">Pruebas estatales por cada 100 mil: </li>
           <li data-label="chartToolTip-caption"><span class="highlight-data">placeholderDEMO_CAT</span> personas tienen <span class="highlight-data">placeholderMETRIC_100K</span> placeholderFilterScope por cada 100 mil personas de la misma raza y grupo étnico.</li>
+          <li data-label="applied-suppression-total">Para proteger la privacidad de las personas, no mostramos ningún dato. Esto
+              es porque hay muy pocos casos o pruebas en este grupo.</li>
+          <li data-label="applied-suppression-population">Para proteger la privacidad de las personas, no mostramos ningún dato.
+              Esto es porque en este grupo hay menos de 20,000 personas en este grupo.</li>
         </ul>       </cagov-chart-re-100k>     </div>
   </div>
 </div>

--- a/pages/translated-posts/equity-ko.html
+++ b/pages/translated-posts/equity-ko.html
@@ -165,6 +165,10 @@ addtositemap: false
           <li data-label="chartFilterLegendPfxState--deaths">100,000명 당 주 전역 사망 건수: </li>
           <li data-label="chartFilterLegendPfxState--tests">100,000명 당 주 전역 검사 건수: </li>
           <li data-label="chartToolTip-caption"><span class="highlight-data">placeholderDEMO_CAT</span> 해당 계층의 경우 동일한 인종과 민족 100,000명에 대한 <span class="highlight-data">placeholderMETRIC_100K</span> placeholder필터링 범위가 있습니다.</li>
+          <li data-label="applied-suppression-total">개인 정보 보호를 위해 어떠한 데이터도 표시하지 않고 있습니다. 그 이유는 해당 그룹 내 사례 또는 검사 건수가 너무 적기 때문입니다.
+            </li>
+          <li data-label="applied-suppression-population">개인 정보 보호를 위해 어떠한 데이터도 표시하지 않고 있습니다. 그 이유는 해당 그룹 내 인원수가 20,000명 미만이기
+              때문입니다.</li>
         </ul>       </cagov-chart-re-100k>     </div>
   </div>
 </div>

--- a/pages/translated-posts/equity-tl.html
+++ b/pages/translated-posts/equity-tl.html
@@ -165,6 +165,10 @@ addtositemap: false
           <li data-label="chartFilterLegendPfxState--deaths">Pagkamatay sa buong estado sa bawat 100k: </li>
           <li data-label="chartFilterLegendPfxState--tests">Pagsusuri sa buong estado sa bawat 100k: </li>
           <li data-label="chartToolTip-caption"><span class="highlight-data">placeholderDEMO_CAT</span> tao ang <span class="highlight-data">placeholderMETRIC_100K</span> placeholderFilterScope para sa 100k tao ng parehong lahi at etnisidad.</li>
+          <li data-label="applied-suppression-total">Para protektahan ang privacy ng mga tao, hindi kami magpapakita ng anumang
+              data. Ito ay dahil may masyadong kaunting kaso o pagsusuri sa grupong ito.</li>
+          <li data-label="applied-suppression-population">Para protektahan ang privacy ng mga tao, hindi kami magpapakita ng
+              anumang data. Ito ay dahil wala pang 20,000 tao ang nasa grupong ito.</li>
         </ul>       </cagov-chart-re-100k>     </div>
   </div>
 </div>

--- a/pages/translated-posts/equity-vi.html
+++ b/pages/translated-posts/equity-vi.html
@@ -165,6 +165,10 @@ addtositemap: false
           <li data-label="chartFilterLegendPfxState--deaths">Số ca tử vong trên 100 nghìn người của toàn tiểu bang: </li>
           <li data-label="chartFilterLegendPfxState--tests">Số người xét nghiệm trên 100 nghìn người của toàn tiểu bang: </li>
           <li data-label="chartToolTip-caption"><span class="highlight-data">placeholderDEMO_CAT</span> những người có <span class="highlight-data">placeholderMETRIC_100K</span> placeholderFilterScope trên 100 nghìn người thuộc cùng chủng tộc và sắc tộc.</li>
+          <li data-label="applied-suppression-total">Để bảo vệ quyền riêng tư của mọi người, chúng tôi sẽ không hiển thị bất kỳ dữ
+              liệu nào. Nguyên nhân là vì có quá ít ca mắc hoặc ca xét nghiệm trong nhóm này.</li>
+          <li data-label="applied-suppression-population">Để bảo vệ quyền riêng tư của mọi người, chúng tôi sẽ không hiển thị bất
+              kỳ dữ liệu nào. Nguyên nhân là vì có ít hơn 20,000 người trong nhóm này.</li>
         </ul>       </cagov-chart-re-100k>     </div>
   </div>
 </div>

--- a/pages/translated-posts/equity-zh-hans.html
+++ b/pages/translated-posts/equity-zh-hans.html
@@ -165,6 +165,8 @@ addtositemap: false
           <li data-label="chartFilterLegendPfxState--deaths">全州每100k人中的死亡数： </li>
           <li data-label="chartFilterLegendPfxState--tests">全州每100k人中的检测数： </li>
           <li data-label="chartToolTip-caption"><span class="highlight-data">placeholderDEMO_CAT</span> people have <span class="highlight-data">placeholderMETRIC_100K</span> placeholderFilterScope for 100k people of the same race and ethnicity.</li>
+          <li data-label="applied-suppression-total">为保护民众隐私，恕不显示任何数据。这是因为这一群体的病例数或检测数过少。</li>
+          <li data-label="applied-suppression-population">为保护民众隐私，恕不显示任何数据。这是因为这一群体的人数少于20,000。</li>
         </ul>       </cagov-chart-re-100k>     </div>
   </div>
 </div>

--- a/pages/translated-posts/equity-zh-hant.html
+++ b/pages/translated-posts/equity-zh-hant.html
@@ -165,6 +165,8 @@ addtositemap: false
           <li data-label="chartFilterLegendPfxState--deaths">全州每100k人中的死亡數： </li>
           <li data-label="chartFilterLegendPfxState--tests">全州每100k人中的檢測數： </li>
           <li data-label="chartToolTip-caption"><span class="highlight-data">placeholderDEMO_CAT</span> people have <span class="highlight-data">placeholderMETRIC_100K</span> placeholderFilterScope for 100k people of the same race and ethnicity.</li>
+          <li data-label="applied-suppression-total">為保護民眾隱私，恕不顯示任何數據。這是因為這一群體的病例數或檢測數過少。</li>
+          <li data-label="applied-suppression-population">為保護民眾隱私，恕不顯示任何數據。這是因為這一群體的人數少於20,000。</li>
         </ul>       </cagov-chart-re-100k>     </div>
   </div>
 </div>


### PR DESCRIPTION
This fixes a problem in which an informational message about low-population counties doesn't show up on the right side for translated pages.