### PR TITLE
CCG-59 Fixed text alignment issue in Firefox. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 docs
 temp
 pages/_buildoutput
+.nyc_output/

--- a/src/js/equity-dash/charts/healthy-places-index/index.js
+++ b/src/js/equity-dash/charts/healthy-places-index/index.js
@@ -413,7 +413,7 @@ class CAGOVChartD3Lines extends window.HTMLElement {
         return i * 20 - 10;
       })
       .attr("text-anchor", "start")
-      .attr("alignment-baseline", "hanging");
+      .attr("dominant-baseline", "hanging");
   }
 
   rewriteLegend(svg, legendLabels) {

--- a/src/js/equity-dash/charts/social-determinants/draw.js
+++ b/src/js/equity-dash/charts/social-determinants/draw.js
@@ -58,7 +58,7 @@ function writeLegend(svg, legendLabels, width, legendPositions) {
     .attr('x', 50)
     .attr('y', legendPositions.y)
     .attr('text-anchor', 'start')
-    .attr('alignment-baseline', 'hanging');
+    .attr('dominant-baseline', 'hanging');
 }
 
 function writeBars(component, svg, data, x, y, width, tooltip) {


### PR DESCRIPTION
Note: Firefox has a more restrictive use than Chrome of which tags can take alignment-baseline, but can use dominant-baseline for the same purpose.

Added vestigal testing directory to .gitignore.
