### PR TITLE
CCG-868. Workaround for date on equity. Instead of WP date, use yesterday's date.

### DIFF
--- a/pages/_includes/page.njk
+++ b/pages/_includes/page.njk
@@ -54,6 +54,8 @@
                 {{ "today" | formatDate2(true,tags) }}
               {%- elseif page | engSlug === "state-dashboard" -%}
                 {{ (tableauCovidMetrics[0].DATE + "T19:00:00Z") | formatDate2(true,tags,1) }}
+              {%- elseif page | engSlug === "equity" -%}
+                {{ "today" | formatDate2(true,tags,-1) }}
               {%- else -%}
                 {{ publishdate | formatDate2(true,tags) }}
               {%- endif -%}


### PR DESCRIPTION
Temp fix while we come up with something better. Given daily updates, the typical date is going to be yesterday, since the data is processed overnight on yesterday's data.