### PR TITLE
Error checking to prevent error in which clicking to the left/right of tabs triggers an invalid update.

### DIFF
--- a/src/js/equity-dash/charts/relative-percentage-by-100k/index.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-100k/index.js
@@ -208,15 +208,18 @@ class CAGOVEquityRE100K extends window.HTMLElement {
     metricFilter.addEventListener(
       "filter-selected",
       function (e) {
-        this.selectedMetricDescription = e.detail.clickedFilterText.toLowerCase();
-        let metricKey = "chartMetricName--" + e.detail.filterKey;
-        if (metricKey in this.translationsObj) {
-          this.selectedMetricDescription = this.translationsObj[metricKey];
+        if (e.detail.filterKey != undefined) {
+          // console.log("filter selected",e.detail.filterKey);
+          this.selectedMetricDescription = e.detail.clickedFilterText.toLowerCase();
+          let metricKey = "chartMetricName--" + e.detail.filterKey;
+          if (metricKey in this.translationsObj) {
+            this.selectedMetricDescription = this.translationsObj[metricKey];
+          }
+          this.selectedMetric = e.detail.filterKey;
+          this.retrieveData(this.dataUrl, this.dataStatewideRateUrl);
+          this.resetDescription();
+          this.resetTitle();
         }
-        this.selectedMetric = e.detail.filterKey;
-        this.retrieveData(this.dataUrl, this.dataStatewideRateUrl);
-        this.resetDescription();
-        this.resetTitle();
       }.bind(this),
       false
     );

--- a/src/js/equity-dash/charts/relative-percentage-by-pop/index.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-pop/index.js
@@ -362,12 +362,14 @@ class CAGOVEquityREPop extends window.HTMLElement {
     metricFilter.addEventListener(
       "filter-selected",
       function (e) {
-        this.selectedMetricDescription = e.detail.clickedFilterText;
-        this.selectedMetric = e.detail.filterKey;
-        if (this.alldata) {
-          this.render();
-          this.resetDescription();
-          this.resetTitle();
+        if (e.detail.filterKey != undefined) {
+          this.selectedMetricDescription = e.detail.clickedFilterText;
+          this.selectedMetric = e.detail.filterKey;
+          if (this.alldata) {
+            this.render();
+            this.resetDescription();
+            this.resetTitle();
+          }
         }
       }.bind(this),
       false

--- a/src/js/equity-dash/search/filters.js
+++ b/src/js/equity-dash/search/filters.js
@@ -5,17 +5,18 @@ class CAGovChartFilterButtons extends window.HTMLElement {
       event.preventDefault();
       let clickedFilterText = event.target.textContent;
       let clickedFilterKey = event.target.dataset.key;
-
-      if(!event.target.classList.contains('active')) {
-        let emissionEvent = new window.CustomEvent('filter-selected', {
-          detail: {
-            filterKey: clickedFilterKey,
-            clickedFilterText: clickedFilterText
-          }
-        });
-        this.resetActive();
-        event.target.classList.add('active')
-        this.dispatchEvent(emissionEvent); // this event fire is last because charts look at active class on filter to get new text
+      if (clickedFilterKey != undefined) {
+        if(!event.target.classList.contains('active')) {
+          let emissionEvent = new window.CustomEvent('filter-selected', {
+            detail: {
+              filterKey: clickedFilterKey,
+              clickedFilterText: clickedFilterText
+            }
+          });
+          this.resetActive();
+          event.target.classList.add('active')
+          this.dispatchEvent(emissionEvent); // this event fire is last because charts look at active class on filter to get new text
+        }
       }
     })
 


### PR DESCRIPTION
The entire div that holds the buttons on the equity page (cases/tests/deaths) generates click events, but only the buttons have valid data. Clicking to the left/right of the buttons triggered an invalid chart display. 

Checking that there is valid data before triggering a page re-display.