### PR TITLE
More readable footnotes with localized dates.

### DIFF
--- a/pages/wordpress-posts/equity.html
+++ b/pages/wordpress-posts/equity.html
@@ -376,9 +376,7 @@ addtositemap: false
 </cagov-chart-d3-lines>
 </div>
 
-
-
-<p class="chart-data-label">Note: 7-day average of positivity rate with 7-day lag, for the tracts in Healthy Places Index (HPI) health equity quartile. Health equity quartile positivity is defined as the positivity rate in the lowest 25% of Healthy Places Index census tracts in the county. Last date shown: <span data-replacement="d3-lines-report-date">XX</span></p>
+<p class="chart-data-label">Note: Data shown is a 7-day average of positivity rate for the with a 7-day lag for the week ending <span data-replacement="d3-lines-report-date"></span>. Health equity quartile positivity is defined as the positivity rate in the lowest 25% of Healthy Places Index census tracts in the county.</p>
 
 
 
@@ -404,7 +402,7 @@ addtositemap: false
       <ul>
         <li data-label="title">Reporting by race and ethnicity in California</li>
         <li data-label="special-note">Data reporting keeps improving. Since January, the reporting on age and gender of cases is up to 99.2% completeness. The same can be done for this data.</li>
-        <li data-label="footnote">Note: Data shown is cumulative for the last 30 days and updated daily. Sexual orientation and gender identity are not collected for tests. Numbers between 1 and 10 are not shown to protect patient privacy.  Last update: <span data-replacement="data-completeness-report-date">XX</span></li>
+        <li data-label="footnote">Note: Data shown is cumulative for the 30 days ending <span data-replacement="data-completeness-report-date"></span>. Sexual orientation and gender identity are not collected for tests. Numbers between 1 and 10 are not shown to protect patient privacy.</li>
         <li data-label="tab-label">Reporting by <span data-replace="metric-filter"></span> in <span data-replace="location"></span></li>
         <li data-label="data-missing">Data missing</li>
         <li data-label="data-reported">Data reported</li>
@@ -447,8 +445,6 @@ addtositemap: false
 
 <div class="mb-2 mt-2"></div>
 
-
-
 <cagov-chart-d3-bar class="chart d-none"><ul>
     <li data-label="sectionTitle">Factors that increase risk of infection and severe illness</li>
     <li data-label="sectionDescription">Californians in crowded housing or transportation, and with less access to paid leave and other worker protections, have a higher risk of infection of COVID-19. Social determinants of health, such as food insecurity, lack of health insurance, and housing instability can increase the risk of poor outcomes. These social determinants of health are often the result of structural racism.</li>
@@ -461,7 +457,7 @@ addtositemap: false
     <li data-label="chartButtonIncome">Income</li>
     <li data-label="chartButtonHousing">Crowded housing</li>
     <li data-label="chartButtonHealthcare">Access to health insurance</li>
-    <li data-label="footnote">Note: Data comes from the American Community Survey and is statewide. It does not reflect individual counties. Data shown is cumulative for the last 7 days and updated daily. Last update: <span data-replacement="d3-bar-report-date">XX</span></li>
+    <li data-label="footnote">Note: Data comes from the American Community Survey and is statewide. It does not reflect individual counties. Data shown is cumulative for the 7 days ending <span data-replacement="d3-bar-report-date"></span>.</li>
    <li data-label="casesPer100KPeople">Cases per 100K people</li>
    <li data-label="statewideCaseRate">Statewide case rate:</li>
    <li data-label="ariaBarLabel">placeholderCaseRate cases per 100K people. placeholderRateDiff30 change since previous week</li>

--- a/pages/wordpress-posts/equity.html
+++ b/pages/wordpress-posts/equity.html
@@ -378,7 +378,7 @@ addtositemap: false
 
 
 
-<p class="chart-data-label">Note: 7-day average of positivity rate with 7-day lag, for the tracts in Healthy Places Index (HPI) health equity quartile. Health equity quartile positivity is defined as the positivity rate in the lowest 25% of Healthy Places Index census tracts in the county.</p>
+<p class="chart-data-label">Note: 7-day average of positivity rate with 7-day lag, for the tracts in Healthy Places Index (HPI) health equity quartile. Health equity quartile positivity is defined as the positivity rate in the lowest 25% of Healthy Places Index census tracts in the county. Last date shown: <span data-replacement="d3-lines-report-date">XX</span></p>
 
 
 
@@ -404,7 +404,7 @@ addtositemap: false
       <ul>
         <li data-label="title">Reporting by race and ethnicity in California</li>
         <li data-label="special-note">Data reporting keeps improving. Since January, the reporting on age and gender of cases is up to 99.2% completeness. The same can be done for this data.</li>
-        <li data-label="footnote">Note: Data shown is cumulative for the last 30 days and updated daily. Sexual orientation and gender identity are not collected for tests. Numbers between 1 and 10 are not shown to protect patient privacy.</li>
+        <li data-label="footnote">Note: Data shown is cumulative for the last 30 days and updated daily. Sexual orientation and gender identity are not collected for tests. Numbers between 1 and 10 are not shown to protect patient privacy.  Last update: <span data-replacement="data-completeness-report-date">XX</span></li>
         <li data-label="tab-label">Reporting by <span data-replace="metric-filter"></span> in <span data-replace="location"></span></li>
         <li data-label="data-missing">Data missing</li>
         <li data-label="data-reported">Data reported</li>
@@ -461,7 +461,7 @@ addtositemap: false
     <li data-label="chartButtonIncome">Income</li>
     <li data-label="chartButtonHousing">Crowded housing</li>
     <li data-label="chartButtonHealthcare">Access to health insurance</li>
-    <li data-label="footnote">Note: Data comes from the American Community Survey and is statewide. It does not reflect individual counties. Data shown is cumulative for the last 7 days and updated daily.</li>
+    <li data-label="footnote">Note: Data comes from the American Community Survey and is statewide. It does not reflect individual counties. Data shown is cumulative for the last 7 days and updated daily. Last update: <span data-replacement="d3-bar-report-date">XX</span></li>
    <li data-label="casesPer100KPeople">Cases per 100K people</li>
    <li data-label="statewideCaseRate">Statewide case rate:</li>
    <li data-label="ariaBarLabel">placeholderCaseRate cases per 100K people. placeholderRateDiff30 change since previous week</li>

--- a/src/js/equity-dash/charts/data-completeness/index.js
+++ b/src/js/equity-dash/charts/data-completeness/index.js
@@ -11,7 +11,12 @@ class CAGOVEquityMissingness extends window.HTMLElement {
     // Use component function, which loads getTranslations and then appends that function with additional translation functions.
     this.translationsObj = this.getTranslations(this);
     // console.log("trans objs",this.translationsObj);
+
+    this.updateDate = "YY";
+
     this.innerHTML = template(this.translationsObj);
+
+
 
     // Settings and initial values
     this.chartOptions = {
@@ -168,6 +173,13 @@ class CAGOVEquityMissingness extends window.HTMLElement {
     this.querySelector(".chart-title").innerHTML = this.translationsObj['tab-label'] ? this.translationsObj['tab-label'] : null;
     this.querySelector('.chart-title span[data-replace="metric-filter"]').innerHTML = this.getFilterText().toLowerCase();
     this.querySelector('.chart-title span[data-replace="location"]').innerHTML = this.getLocation();
+  }
+
+  resetUpdateDate() {
+    this.querySelectorAll('span[data-replacement="data-completeness-report-date"]').forEach(elem => {
+      // console.log("Got completeness date span");
+      elem.innerHTML = this.updateDate;
+    });
   }
 
   getFilterText() {
@@ -400,6 +412,16 @@ class CAGOVEquityMissingness extends window.HTMLElement {
     this.resetTitle();
     let data = this.formatDataSet(this.alldata[this.selectedMetric]);
     this.drawSvg(data);
+
+    // fetch date for footnote
+    // console.log("rendering",this.selectedMetric,this.alldata);
+    if (this.selectedMetric in this.alldata && 'cases' in this.alldata[this.selectedMetric]) {
+      this.updateDate = this.alldata[this.selectedMetric].cases.REPORT_DATE; // localize?
+    } else {
+      this.updateDate = 'Unknown';
+    }
+    // console.log("Update Date",this.updateDate);
+    this.resetUpdateDate();
   }
 
   retrieveData(url) {

--- a/src/js/equity-dash/charts/data-completeness/index.js
+++ b/src/js/equity-dash/charts/data-completeness/index.js
@@ -3,6 +3,7 @@ import drawBars from "./draw.js";
 import getTranslations from './../../get-strings-list.js';
 import getScreenResizeCharts from './../../get-window-size.js';
 import rtlOverride from "./../../rtl-override.js";
+import reformatReadableDate from "../../readable-date.js";
 
 class CAGOVEquityMissingness extends window.HTMLElement {
   connectedCallback() {
@@ -12,7 +13,7 @@ class CAGOVEquityMissingness extends window.HTMLElement {
     this.translationsObj = this.getTranslations(this);
     // console.log("trans objs",this.translationsObj);
 
-    this.updateDate = "YY";
+    this.updateDate = "";
 
     this.innerHTML = template(this.translationsObj);
 
@@ -416,7 +417,7 @@ class CAGOVEquityMissingness extends window.HTMLElement {
     // fetch date for footnote
     // console.log("rendering",this.selectedMetric,this.alldata);
     if (this.selectedMetric in this.alldata && 'cases' in this.alldata[this.selectedMetric]) {
-      this.updateDate = this.alldata[this.selectedMetric].cases.REPORT_DATE; // localize?
+      this.updateDate = reformatReadableDate( this.alldata[this.selectedMetric].cases.REPORT_DATE );
     } else {
       this.updateDate = 'Unknown';
     }

--- a/src/js/equity-dash/charts/data-completeness/template.js
+++ b/src/js/equity-dash/charts/data-completeness/template.js
@@ -18,7 +18,7 @@ export default function template(translationsObj) {
 
         <div class="row">
           <div class="col-lg-9 col-md-9 col-sm-12 mx-auto px-0">
-            <p class="chart-data-label col-lg-10 px-0">${translationsObj["footnote"]}</p>
+            <p class="chart-data-label col-lg-10 mx-auto">${translationsObj["footnote"]}</p>
           </div>
         </div>
 

--- a/src/js/equity-dash/charts/healthy-places-index/index.js
+++ b/src/js/equity-dash/charts/healthy-places-index/index.js
@@ -174,6 +174,16 @@ class CAGOVChartD3Lines extends window.HTMLElement {
     component.dims = this.chartBreakpointValues !== undefined ? this.chartBreakpointValues : this.chartOptions.desktop; // Patch error until we can investigate it
     let data = alldata.county_positivity_all_nopris;
     let data2 = alldata.county_positivity_low_hpi;
+
+    // console.log("got line data", data2);
+    let updateDate = data2[data2.length-1].DATE;
+    // using document since the footnote lies outside this element
+    document.querySelectorAll('span[data-replacement="d3-lines-report-date"]').forEach(elem => {
+      // console.log("Got date span");
+      elem.innerHTML = updateDate;
+    });
+
+
     // console.log("Overall Data ", data);
     // console.log("Equity Data2 ", data2);
     let missing_eq_data =

--- a/src/js/equity-dash/charts/healthy-places-index/index.js
+++ b/src/js/equity-dash/charts/healthy-places-index/index.js
@@ -7,6 +7,7 @@ import getTranslations from "./../../get-strings-list.js";
 import getScreenResizeCharts from "./../../get-window-size.js";
 import { chartOverlayBox, chartOverlayBoxClear } from "../../chart-overlay-box.js";
 import rtlOverride from "./../../rtl-override.js";
+import reformatReadableDate from "../../readable-date.js";
 
 class CAGOVChartD3Lines extends window.HTMLElement {
   connectedCallback() {
@@ -175,8 +176,7 @@ class CAGOVChartD3Lines extends window.HTMLElement {
     let data = alldata.county_positivity_all_nopris;
     let data2 = alldata.county_positivity_low_hpi;
 
-    // console.log("got line data", data2);
-    let updateDate = data2[data2.length-1].DATE;
+    let updateDate =  reformatReadableDate( data2[data2.length-1].DATE );
     // using document since the footnote lies outside this element
     document.querySelectorAll('span[data-replacement="d3-lines-report-date"]').forEach(elem => {
       // console.log("Got date span");

--- a/src/js/equity-dash/charts/social-determinants/index.js
+++ b/src/js/equity-dash/charts/social-determinants/index.js
@@ -3,6 +3,7 @@ import {writeXAxis, writeXAxisLabel, rewriteLegend, writeLegend, writeBars, rewr
 import getTranslations from '../../get-strings-list.js';
 import getScreenResizeCharts from './../../get-window-size.js';
 import rtlOverride from "./../../rtl-override.js";
+import reformatReadableDate from "../../readable-date.js";
 
 class CAGOVChartD3Bar extends window.HTMLElement {
   connectedCallback () {
@@ -125,9 +126,7 @@ class CAGOVChartD3Bar extends window.HTMLElement {
       datacrowding.sort(sortedOrder).reverse()
       datahealthcare.sort(sortedOrder).reverse()
 
-      let updateDate = dataincome[0].DATE; // localize?
-      // console.log("Update Date",updateDate);
-
+      let updateDate = reformatReadableDate( dataincome[0].DATE ); // localized readable date
 
       let y = d3.scaleLinear()
         .domain([0, d3.max(dataincome, d => d.CASE_RATE_PER_100K)]).nice()

--- a/src/js/equity-dash/charts/social-determinants/index.js
+++ b/src/js/equity-dash/charts/social-determinants/index.js
@@ -124,7 +124,11 @@ class CAGOVChartD3Bar extends window.HTMLElement {
       dataincome.sort(sortedOrder).reverse()
       datacrowding.sort(sortedOrder).reverse()
       datahealthcare.sort(sortedOrder).reverse()
-  
+
+      let updateDate = dataincome[0].DATE; // localize?
+      // console.log("Update Date",updateDate);
+
+
       let y = d3.scaleLinear()
         .domain([0, d3.max(dataincome, d => d.CASE_RATE_PER_100K)]).nice()
         .range([this.chartBreakpointValues.height - this.chartBreakpointValues.margin.bottom, this.chartBreakpointValues.margin.top])
@@ -133,8 +137,13 @@ class CAGOVChartD3Bar extends window.HTMLElement {
         .domain(d3.range(dataincome.length))
         .range([this.chartBreakpointValues.margin.left, this.chartBreakpointValues.width - this.chartBreakpointValues.margin.right])
         .padding(0.1)
-
       this.innerHTML = template(this.translationsObj);
+      // console.log("ran template", this.innerHTML);
+      this.querySelectorAll('span[data-replacement="d3-bar-report-date"]').forEach(elem => {
+        // console.log("Got date span");
+        elem.innerHTML = updateDate;
+      });
+
       this.tooltip = this.querySelector('.tooltip-container'); // @TODO: Q: where did the class go? tooltip is coming back null.
       writeBars(this, this.svg, dataincome, x, y, this.chartBreakpointValues.width, this.tooltip);
       writeBarLabels(this.svg, dataincome, x, y, this.chartBreakpointValues.sparkline);

--- a/src/js/equity-dash/readable-date.js
+++ b/src/js/equity-dash/readable-date.js
@@ -1,0 +1,25 @@
+// Date converter for use on chart footnotes.
+// Converts a string (typically from Snowflake) 
+// in the form YYYY-MM-DD
+// into a readable localized date, such as 
+//    December 12, 2020
+// or 
+//    12 de diciembre de 2020
+
+export default function reformatReadableDate(dateStr) {
+    // convert YYYY-MM-DD string to Date object
+    const tokens = dateStr.split('-')
+    if (tokens.length != 3) {
+        console.log("reformatReadableDate expecting YYYY-MM-DD, got " + dateStr);
+        return dateStr; // unknown format, use existing string
+    }
+    const yyyy = +tokens[0];
+    const mm = +tokens[1];
+    const dd = +tokens[2];
+    const theDate = new Date(yyyy,mm-1,dd);
+    const readableDate = 
+         theDate.toLocaleString( document.documentElement.lang, 
+         { month: "long", day: 'numeric', year:'numeric' });
+    // console.log(dateStr + " --> " + readableDate);
+    return readableDate;
+}


### PR DESCRIPTION
More readable chart footnotes with dates, based on Michael's feedback.

Resuable localized date formatter converts "YYYY-MM-DD" into "December 12, 2020" or "12 de diciembre de 2020" etc.

Fixed centering on missingness footnote.

When this is approved, I will incorporate the equity.html fixes into WP and merge with master.
