### PR TITLE
Inhibiting initial display of county map on state dashboard.

### DIFF
--- a/pages/_includes/dashboard.njk
+++ b/pages/_includes/dashboard.njk
@@ -115,7 +115,7 @@
         <div class="row d-flex justify-content-md-center">
 
             <div class="toggle-group-container cases-group">
-            <div  id="cases-county-graph" class="toggle-group-element">
+            <div  id="cases-county-graph" class="toggle-group-element" style="display:none;">
                 <div class='tableauPlaceholder' id="casesChartCounty"></div>
             </div>
             <div id="cases-state-graph" class="toggle-group-element">


### PR DESCRIPTION
Charts on state dashboard are currently displaying one on top of another (Statewide on top of County) since a tableau timeout is causing an error which shadows some code. I'm inhibiting initial display of the county map to prevent this visual glitch.