### PR TITLE
Removing alert

### DIFF
--- a/pages/_includes/dashboard.njk
+++ b/pages/_includes/dashboard.njk
@@ -24,7 +24,6 @@
 
 
 <div class="bg-lightblue py-5">
-    <div class="alert alert-warning col-lg-8 mx-auto" role="alert"><h4 class="alert-heading">Note</h4><p>This note has been updated. The previous note included a breakdown of cases reported related to a newly implemented auto processing feature. This was an estimate based on an initial review of the data. Since then, the California Department of Public Health further reviewed and validated the data. As a result, there are a total of 15,337 cases from today's 53,711 positive cases that come from prior days and were processed for reporting today.</p></div>
     <div class="container py-2">
         <div class="row pb-4">
             <div class="col-lg-10 mx-auto">


### PR DESCRIPTION
Due to data updating, removing note about yesterday's data.

Tagging @carterm for this one since he's not working on health equity things. Carter: this is removing the alert box at the top of the state dashboard page. It should be straightforward and can go straight to production.