### PR TITLE
Bug/2020 12 17 suppression

### DIFF
--- a/pages/wordpress-posts/equity.html
+++ b/pages/wordpress-posts/equity.html
@@ -3,7 +3,7 @@ layout: "page.njk"
 title: "California’s commitment to health equity"
 meta: "All Californians—regardless of where they live, their working environment, their social supports, or how they identify⁠—deserve a healthy life. COVID-19 has highlighted existing inequities in health. Many of these inequities are the result of structural racism. One form this takes is the unequal distribution of and access to health care resources. Committed to a California [&hellip;]"
 author: "State of California"
-publishdate: "2020-12-17T20:26:05Z"
+publishdate: "2020-12-17T20:59:02Z"
 tags: ["do-not-crawl","staging-only"]
 addtositemap: false
 ---

--- a/pages/wordpress-posts/equity.html
+++ b/pages/wordpress-posts/equity.html
@@ -3,8 +3,8 @@ layout: "page.njk"
 title: "California’s commitment to health equity"
 meta: "All Californians—regardless of where they live, their working environment, their social supports, or how they identify⁠—deserve a healthy life. COVID-19 has highlighted existing inequities in health. Many of these inequities are the result of structural racism. One form this takes is the unequal distribution of and access to health care resources. Committed to a California [&hellip;]"
 author: "State of California"
-publishdate: "2020-12-16T23:19:29Z"
-tags: ["do-not-crawl"]
+publishdate: "2020-12-17T19:24:59Z"
+tags: ["do-not-crawl","staging-only"]
 addtositemap: false
 ---
 
@@ -308,6 +308,12 @@ addtositemap: false
             <li data-label="missing-data-caption-line-delimiter"><br></li>
             <li data-label="chartToolTip1-caption">placeholder_DEMOGRAPHIC_SET_CATEGORY people make up <span class="highlight-data"> placeholder_METRIC_TOTAL_PERCENTAGE</span> of placeholder_SelectedMetric in placeholderForDynamicLocation
             and <span class="highlight-data"> placeholder_POPULATION_PERCENTAGE </span> of the placeholderForDynamicLocation population</li>
+<li data-label="data-missing-applied-suppression-total--tests">Data is not shown because there are fewer than 11 tests in this group.</li>
+            <li data-label="data-missing-applied-suppression-total--cases">Data is not shown because there are fewer than 11 cases in this group.</li>
+            <li data-label="data-missing-applied-suppression-total--deaths">Data is not shown because there are fewer than 11 deaths in this group.</li>
+            <li data-label="data-missing-applied-suppression-population--tests">Data is not shown because there are fewer than 20,000 tests people in this county.</li>
+            <li data-label="data-missing-applied-suppression-population--cases">Data is not shown because there are fewer than 20,000 cases people in this county.</li>
+            <li data-label="data-missing-applied-suppression-population--deaths">Data is not shown because there are fewer than 20,000 deaths people in this county.</li>
         </ul>
       </cagov-chart-re-pop>
     </div>
@@ -563,6 +569,10 @@ addtositemap: false
     </div>
   </div>
 </div>
+
+
+
+<script type="text/javascript" language="javascript" src="//ethn.io/45907.js" async="true" charset="utf-8"></script>
 
 
 

--- a/pages/wordpress-posts/equity.html
+++ b/pages/wordpress-posts/equity.html
@@ -3,7 +3,7 @@ layout: "page.njk"
 title: "California’s commitment to health equity"
 meta: "All Californians—regardless of where they live, their working environment, their social supports, or how they identify⁠—deserve a healthy life. COVID-19 has highlighted existing inequities in health. Many of these inequities are the result of structural racism. One form this takes is the unequal distribution of and access to health care resources. Committed to a California [&hellip;]"
 author: "State of California"
-publishdate: "2020-12-17T19:24:59Z"
+publishdate: "2020-12-17T20:26:05Z"
 tags: ["do-not-crawl","staging-only"]
 addtositemap: false
 ---
@@ -309,11 +309,12 @@ addtositemap: false
             <li data-label="chartToolTip1-caption">placeholder_DEMOGRAPHIC_SET_CATEGORY people make up <span class="highlight-data"> placeholder_METRIC_TOTAL_PERCENTAGE</span> of placeholder_SelectedMetric in placeholderForDynamicLocation
             and <span class="highlight-data"> placeholder_POPULATION_PERCENTAGE </span> of the placeholderForDynamicLocation population</li>
 <li data-label="data-missing-applied-suppression-total--tests">Data is not shown because there are fewer than 11 tests in this group.</li>
+            <li data-label="data-missing-applied-suppression-total--tests">Data is not shown because there are fewer than 11 tests in this group.</li>
             <li data-label="data-missing-applied-suppression-total--cases">Data is not shown because there are fewer than 11 cases in this group.</li>
             <li data-label="data-missing-applied-suppression-total--deaths">Data is not shown because there are fewer than 11 deaths in this group.</li>
-            <li data-label="data-missing-applied-suppression-population--tests">Data is not shown because there are fewer than 20,000 tests people in this county.</li>
-            <li data-label="data-missing-applied-suppression-population--cases">Data is not shown because there are fewer than 20,000 cases people in this county.</li>
-            <li data-label="data-missing-applied-suppression-population--deaths">Data is not shown because there are fewer than 20,000 deaths people in this county.</li>
+            <li data-label="data-missing-applied-suppression-population--tests">Data is not shown because there are fewer than 20,000 people in this county.</li>
+            <li data-label="data-missing-applied-suppression-population--cases">Data is not shown because there are fewer than 20,000 people in this county.</li>
+            <li data-label="data-missing-applied-suppression-population--deaths">Data is not shown because there are fewer than 20,000 people in this county.</li>
         </ul>
       </cagov-chart-re-pop>
     </div>

--- a/pages/wordpress-posts/equity.html
+++ b/pages/wordpress-posts/equity.html
@@ -312,9 +312,9 @@ addtositemap: false
             <li data-label="data-missing-applied-suppression-total--tests">Data is not shown because there are fewer than 11 tests in this group.</li>
             <li data-label="data-missing-applied-suppression-total--cases">Data is not shown because there are fewer than 11 cases in this group.</li>
             <li data-label="data-missing-applied-suppression-total--deaths">Data is not shown because there are fewer than 11 deaths in this group.</li>
-            <li data-label="data-missing-applied-suppression-population--tests">Data is not shown because there are fewer than 20,000 people in this county.</li>
-            <li data-label="data-missing-applied-suppression-population--cases">Data is not shown because there are fewer than 20,000 people in this county.</li>
-            <li data-label="data-missing-applied-suppression-population--deaths">Data is not shown because there are fewer than 20,000 people in this county.</li>
+            <li data-label="data-missing-applied-suppression-population--tests">Data is not shown because there are fewer than 20,000 people in this group.</li>
+            <li data-label="data-missing-applied-suppression-population--cases">Data is not shown because there are fewer than 20,000 people in this group.</li>
+            <li data-label="data-missing-applied-suppression-population--deaths">Data is not shown because there are fewer than 20,000 people in this group.</li>
         </ul>
       </cagov-chart-re-pop>
     </div>

--- a/pages/wordpress-posts/equity.html
+++ b/pages/wordpress-posts/equity.html
@@ -3,7 +3,7 @@ layout: "page.njk"
 title: "California’s commitment to health equity"
 meta: "All Californians—regardless of where they live, their working environment, their social supports, or how they identify⁠—deserve a healthy life. COVID-19 has highlighted existing inequities in health. Many of these inequities are the result of structural racism. One form this takes is the unequal distribution of and access to health care resources. Committed to a California [&hellip;]"
 author: "State of California"
-publishdate: "2020-12-17T20:59:02Z"
+publishdate: "2020-12-17T21:00:14Z"
 tags: ["do-not-crawl","staging-only"]
 addtositemap: false
 ---
@@ -345,6 +345,13 @@ addtositemap: false
             <li data-label="applied-suppression-total">To protect people’s privacy, we’re not showing any data. This is because there are either too few cases or tests in this group.</li>
             <li data-label="applied-suppression-population">To protect people’s privacy, we’re not showing any data. This is because there are less than 20,000 people in this group.</li>
             <li data-label="missing-data-caption-line-delimiter"><br></li>
+<li data-label="data-missing-applied-suppression-total--tests">Data is not shown because there are fewer than 11 tests in this group.</li>
+            <li data-label="data-missing-applied-suppression-total--tests">Data is not shown because there are fewer than 11 tests in this group.</li>
+            <li data-label="data-missing-applied-suppression-total--cases">Data is not shown because there are fewer than 11 cases in this group.</li>
+            <li data-label="data-missing-applied-suppression-total--deaths">Data is not shown because there are fewer than 11 deaths in this group.</li>
+            <li data-label="data-missing-applied-suppression-population--tests">Data is not shown because there are fewer than 20,000 people in this group.</li>
+            <li data-label="data-missing-applied-suppression-population--cases">Data is not shown because there are fewer than 20,000 people in this group.</li>
+            <li data-label="data-missing-applied-suppression-population--deaths">Data is not shown because there are fewer than 20,000 people in this group.</li>
         </ul>
       </cagov-chart-re-100k>
     </div>

--- a/src/js/equity-dash/charts/data-completeness/draw.js
+++ b/src/js/equity-dash/charts/data-completeness/draw.js
@@ -27,6 +27,20 @@ function drawBars(svg, x, y, yAxis, stackedData, color, data, tooltip, translati
     .attr("width", d => x(1) - x(0))
     .attr("height", "10px")
 
+    // This is the logic for rendering the alternative message for the tooltip which can be placed here, except there is a lot of UX to also connect because this bar was not previously made to be interactive.
+    // if (d.data.PERCENT_COMPLETE === null) {
+    //   console.log("NULL");
+    //   let tooltipCheck = translations.chartTooltip({
+    //     metric: d.data.METRIC,
+    //     highlightData: percentMissing,
+    //     complete: false,
+    //     suppression: true,
+    //   });
+    //   console.log('tooltip check', tooltipCheck);
+    //   return tooltipCheck;
+    // }
+
+
   // Render the bars with their connected tooltips.
   svg
     .append("g")
@@ -77,11 +91,9 @@ function drawBars(svg, x, y, yAxis, stackedData, color, data, tooltip, translati
     .on("mouseover focus", function(event, d) {
       d3.select(this).transition();
       tooltip.html(() => {
-        // @TODO Handle if PERCENT_COMPLETE is null.
         if (d.data.PERCENT_COMPLETE === null) {
-
-          return ``; // Return nothing, no tooltip. 
-
+          // Return nothing.
+          return ``;
         } else {
           let percentNotMissing = d.data.NOT_MISSING
           ? parseFloat(d.data.NOT_MISSING * 100).toFixed(1) + "%"

--- a/src/js/equity-dash/charts/data-completeness/draw.js
+++ b/src/js/equity-dash/charts/data-completeness/draw.js
@@ -80,7 +80,7 @@ function drawBars(svg, x, y, yAxis, stackedData, color, data, tooltip, translati
         // @TODO Handle if PERCENT_COMPLETE is null.
         if (d.data.PERCENT_COMPLETE === null) {
 
-          return `<div>CHECKING NOT NOT COMMIT</div>`;
+          return ``; // Return nothing, no tooltip. 
 
         } else {
           let percentNotMissing = d.data.NOT_MISSING

--- a/src/js/equity-dash/charts/data-completeness/index.js
+++ b/src/js/equity-dash/charts/data-completeness/index.js
@@ -4,6 +4,7 @@ import getTranslations from './../../get-strings-list.js';
 import getScreenResizeCharts from './../../get-window-size.js';
 import rtlOverride from "./../../rtl-override.js";
 import { reformatReadableDate } from "../../readable-date.js";
+import { false } from "tap";
 
 class CAGOVEquityMissingness extends window.HTMLElement {
   connectedCallback() {
@@ -329,17 +330,25 @@ class CAGOVEquityMissingness extends window.HTMLElement {
         metric = 'tests',
         highlightData = 0,
         complete = true,
+        suppression = false,
       }) => {
         let location = this.getLocation();
         let dataType = this.getFilterText().toLowerCase();
         let tooltipHTML = translations['chart-tooltip-complete'];
+
+
         if (!complete) {
           tooltipHTML = translations['chart-tooltip-missing'];
         }
+
         tooltipHTML = tooltipHTML.replace('<span data-replace="metric">tests</span>', `<span data-replace="metric">${metric}</span>`);
         tooltipHTML = tooltipHTML.replace('<span data-replace="highlight-data"></span>', `<span data-replace="highlight-data">${highlightData}</span>`);
         tooltipHTML = tooltipHTML.replace('<span data-replace="location">California</span>', `<span data-replace="location">${location}</span>`);
         tooltipHTML = tooltipHTML.replace('<span data-replace="data-type">race and ethnicity</span>', `<span data-replace="data-type">${dataType}</span>`);
+
+        if (suppression) {
+          tooltipHTML = translations['data-missing-applied-suppression-total'];
+        }
         return `<div class="chart-tooltip"><div>${tooltipHTML}</div></div>`;
       }
     return translations;

--- a/src/js/equity-dash/charts/relative-percentage-by-100k/draw-chart.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-100k/draw-chart.js
@@ -19,9 +19,12 @@ export default function drawBars(stackedData, data, statewideRatePer100k) {
   let translationsObj = this.translationsObj;
   let chartBreakpointValues = this.chartBreakpointValues;
   let appliedSuppressionStatus = this.appliedSuppressionStatus;
+  let selectedMetric = this.selectedMetric;
 
   // console.log('100k', translationsObj, chartBreakpointValues, appliedSuppressionStatus);
 
+  console.log('selected', selectedMetric);
+  
   svg.selectAll("g").remove();
   svg.selectAll("rect").remove();
   svg.selectAll("text").remove();
@@ -53,13 +56,16 @@ export default function drawBars(stackedData, data, statewideRatePer100k) {
         d.data.METRIC_VALUE_PER_100K
           ? parseFloat(d.data.METRIC_VALUE_PER_100K).toFixed(0)
           : 0,
-        filterScope // .toLowerCase()
+        filterScope,
+        d // .toLowerCase()
       );
-      if (d.APPLIED_SUPPRESSION === "Population") {
-        caption = ``
-      } else if (d.APPLIED_SUPPRESSION === "Total") {
-        caption = ``
+
+      if (d.data.APPLIED_SUPPRESSION === "Total") {
+        caption = translationsObj['data-missing-applied-suppression-total' + "--" + selectedMetric.toLowerCase()] || '';
+      } else if (d.data.APPLIED_SUPPRESSION === "Population") {
+        caption = translationsObj['data-missing-applied-suppression-population'+ "--" + selectedMetric.toLowerCase()] || '';
       }
+
       return `<div class="chart-tooltip"><div>${caption}</div></div>`;
     })
 
@@ -71,7 +77,8 @@ export default function drawBars(stackedData, data, statewideRatePer100k) {
         d.data.METRIC_VALUE_PER_100K
           ? parseFloat(d.data.METRIC_VALUE_PER_100K).toFixed(0)
           : 0,
-        filterScope // .toLowerCase()
+        filterScope,
+        d // .toLowerCase()
       );
       if (d.APPLIED_SUPPRESSION === "Population") {
         caption = ``

--- a/src/js/equity-dash/charts/relative-percentage-by-100k/index.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-100k/index.js
@@ -127,7 +127,13 @@ class CAGOVEquityRE100K extends window.HTMLElement {
       return filterTxt;
     };
 
-    this.toolTipCaption = function (a, b, c) {
+    this.toolTipCaption = function (a, b, c, d) {
+      if (d.data.APPLIED_SUPPRESSION === "Total") {
+        return this.translationsObj['data-missing-applied-suppression-total' + "--" + this.selectedMetric.toLowerCase()] || '';
+      } else if (d.data.APPLIED_SUPPRESSION === "Population") {
+        return this.translationsObj['data-missing-applied-suppression-population'+ "--" + this.selectedMetric.toLowerCase()] || '';
+      }
+
       let templateStr = this.translationsObj["chartToolTip-caption"];
       let caption = templateStr
         .replace("placeholderDEMO_CAT", a)

--- a/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart-second.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart-second.js
@@ -116,10 +116,22 @@ export default function drawSecondBars({
         .append("text")
         .attr("class", "change-from-month-labels")
         .attr("y", (d) => y(d.DEMOGRAPHIC_SET_CATEGORY) + 27)
-        .attr("x", (d) => x2(1) + 20)
+        .attr("x", (d) => {
+          if (d.APPLIED_SUPPRESSION === "Population" || d.APPLIED_SUPPRESSION === "Total")  {
+            return x2(1);
+          } else {
+            return x2(1) + 20
+          }
+        })
         .attr("height", y.bandwidth())
 
         .html((d) => {
+          if (d.APPLIED_SUPPRESSION === "Population")  {
+            return `${translationsObj['data-missing-applied-suppression-total'] || ''}`;
+          } else if (d.APPLIED_SUPPRESSION === "Total")  {
+            return `${translationsObj['data-missing-applied-suppression-population'] || ''}`;
+          }
+
           if (!d.METRIC_VALUE_PERCENTAGE_DELTA_FROM_30_DAYS_AGO) {
             return `<tspan class="highlight-data">0%</tspan> ${translationsObj.chartLineDiff}`;
           } else {
@@ -144,6 +156,10 @@ export default function drawSecondBars({
         .attr("y", (d) => y(d.DEMOGRAPHIC_SET_CATEGORY) + 15)
         .attr("x", (d) => x2(1))
         .html((d) => {
+          if (d.APPLIED_SUPPRESSION === "Population" || d.APPLIED_SUPPRESSION === "Total")  {
+            return ``;
+          }
+          
           if (
             !d.METRIC_VALUE_PERCENTAGE_DELTA_FROM_30_DAYS_AGO ||
             Math.abs(d.METRIC_VALUE_PERCENTAGE_DELTA_FROM_30_DAYS_AGO) < 0.05

--- a/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart-second.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart-second.js
@@ -127,9 +127,9 @@ export default function drawSecondBars({
 
         .html((d) => {
           if (d.APPLIED_SUPPRESSION === "Population")  {
-            return `${translationsObj['data-missing-applied-suppression-total'] || ''}`;
+            return `${translationsObj['data-missing-applied-suppression-population' + "--" + selectedMetric.toLowerCase()] || ''}`;
           } else if (d.APPLIED_SUPPRESSION === "Total")  {
-            return `${translationsObj['data-missing-applied-suppression-population'] || ''}`;
+            return `${translationsObj['data-missing-applied-suppression-total' + "--" + selectedMetric.toLowerCase()] || ''}`;
           }
 
           if (!d.METRIC_VALUE_PERCENTAGE_DELTA_FROM_30_DAYS_AGO) {

--- a/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart.js
@@ -184,13 +184,14 @@ export default function drawBars({
 
         .html((d) => {
           if (d.APPLIED_SUPPRESSION === "Population")  {
-            return `${translationsObj['data-missing-applied-suppression-population' + "--" + selectedMetric.toLowerCase()] || ''}`;
+            return `<tspan class="withheld-label">${translationsObj['data-missing-applied-suppression-population' + "--" + selectedMetric.toLowerCase()] || ''}</tspan>`;
           } else if (d.APPLIED_SUPPRESSION === "Total")  {
-            return `${translationsObj['data-missing-applied-suppression-total' + "--" + selectedMetric.toLowerCase()] || ''}`;
+            return `<tspan class="withheld-label">${translationsObj['data-missing-applied-suppression-total' + "--" + selectedMetric.toLowerCase()] || ''}</tspan>`;
           }
+
           if (!d.METRIC_VALUE_PERCENTAGE_DELTA_FROM_30_DAYS_AGO) {
             return `<tspan class="highlight-data">0%</tspan> ${translationsObj.chartLineDiff}`;
-          }else {
+          } else {
             return `<tspan class="highlight-data">${parseFloat(
               d.METRIC_VALUE_PERCENTAGE_DELTA_FROM_30_DAYS_AGO
             ).toFixed(1)}%</tspan> ${translationsObj.chartLineDiff}`;

--- a/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart.js
@@ -184,9 +184,9 @@ export default function drawBars({
 
         .html((d) => {
           if (d.APPLIED_SUPPRESSION === "Population")  {
-            return `${translationsObj['data-missing-applied-suppression-total' + "--" + selectedMetric.toLowerCase()] || ''}`;
-          } else if (d.APPLIED_SUPPRESSION === "Total")  {
             return `${translationsObj['data-missing-applied-suppression-population' + "--" + selectedMetric.toLowerCase()] || ''}`;
+          } else if (d.APPLIED_SUPPRESSION === "Total")  {
+            return `${translationsObj['data-missing-applied-suppression-total' + "--" + selectedMetric.toLowerCase()] || ''}`;
           }
           if (!d.METRIC_VALUE_PERCENTAGE_DELTA_FROM_30_DAYS_AGO) {
             return `<tspan class="highlight-data">0%</tspan> ${translationsObj.chartLineDiff}`;

--- a/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart.js
@@ -24,7 +24,7 @@ export default function drawBars({
   svg.selectAll("rect").remove();
   svg.selectAll("text").remove();
 
-  //yellow bars
+  // Yellow bars
   svg
     .append("g")
     .attr('class', 'svg-first-section')
@@ -69,7 +69,7 @@ export default function drawBars({
       tooltip.style("visibility", "hidden");
     });
 
-  //blue bars
+  // Blue bars
   svg
     .append("g")
     .selectAll("g")
@@ -160,23 +160,6 @@ export default function drawBars({
           }
         )
         .attr("text-anchor", "end");
-
-        // enter
-        // .append("text")
-        // .attr("class", (d) => "bars" + ((d.METRIC_TOTAL_PERCENTAGE === null) ? " bars-unknown" : ""))
-        // .attr("y", (d) => y(d.DEMOGRAPHIC_SET_CATEGORY) + 8)
-        // .attr("x", (d) => x1(100) + 5)
-        // .attr("height", y.bandwidth())
-        // .text((d) => {
-        //   if (d.METRIC_TOTAL_PERCENTAGE !== null) {
-        //   d.METRIC_TOTAL_PERCENTAGE
-        //     ? parseFloat(d.METRIC_TOTAL_PERCENTAGE).toFixed(1) + "%"
-        //     : 0 + "%";
-        //   } else {
-        //     return 'MASKED'd.APPLIED_SUPPRESSION;
-        //   }
-        // }
-        // )
     });
 
   // % Change since previous month labels
@@ -190,13 +173,24 @@ export default function drawBars({
         .append("text")
         .attr("class", "change-from-month-labels")
         .attr("y", (d) => y(d.DEMOGRAPHIC_SET_CATEGORY) + 47)
-        .attr("x", (d) => x2(1) + 20)
+        .attr("x", (d) => {
+          if (d.APPLIED_SUPPRESSION === "Population" || d.APPLIED_SUPPRESSION === "Total")  {
+            return x2(1);
+          } else {
+            return x2(1) + 20
+          }
+        })
         .attr("height", y.bandwidth())
 
         .html((d) => {
+          if (d.APPLIED_SUPPRESSION === "Population")  {
+            return `${translationsObj['data-missing-applied-suppression-total' + "--" + selectedMetric.toLowerCase()] || ''}`;
+          } else if (d.APPLIED_SUPPRESSION === "Total")  {
+            return `${translationsObj['data-missing-applied-suppression-population' + "--" + selectedMetric.toLowerCase()] || ''}`;
+          }
           if (!d.METRIC_VALUE_PERCENTAGE_DELTA_FROM_30_DAYS_AGO) {
             return `<tspan class="highlight-data">0%</tspan> ${translationsObj.chartLineDiff}`;
-          } else {
+          }else {
             return `<tspan class="highlight-data">${parseFloat(
               d.METRIC_VALUE_PERCENTAGE_DELTA_FROM_30_DAYS_AGO
             ).toFixed(1)}%</tspan> ${translationsObj.chartLineDiff}`;
@@ -218,6 +212,10 @@ export default function drawBars({
         .attr("y", (d) => y(d.DEMOGRAPHIC_SET_CATEGORY) + 35)
         .attr("x", (d) => x2(1))
         .html((d) => {
+          if (d.APPLIED_SUPPRESSION === "Population" || d.APPLIED_SUPPRESSION === "Total")  {
+            return ``;
+          }
+
           if (
             !d.METRIC_VALUE_PERCENTAGE_DELTA_FROM_30_DAYS_AGO ||
             Math.abs(d.METRIC_VALUE_PERCENTAGE_DELTA_FROM_30_DAYS_AGO) < 0.05
@@ -247,7 +245,6 @@ export default function drawBars({
     .attr("width", 15)
     .attr("height", 15)
     .attr("fill", "#FFCF44");
-    
     
   svg
     .append("rect")

--- a/src/js/equity-dash/charts/relative-percentage-by-pop/index.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-pop/index.js
@@ -267,7 +267,6 @@ class CAGOVEquityREPop extends window.HTMLElement {
   }
 
   getToolTipCaption1(d, selectedMetric) {
-    console.log("Caption", d);
     if (d.data.APPLIED_SUPPRESSION === "Total") {
       return this.translationsObj['data-missing-applied-suppression-total' + "--" + this.selectedMetric.toLowerCase()] || '';
     } else if (d.data.APPLIED_SUPPRESSION === "Population") {

--- a/src/js/equity-dash/charts/relative-percentage-by-pop/index.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-pop/index.js
@@ -267,6 +267,13 @@ class CAGOVEquityREPop extends window.HTMLElement {
   }
 
   getToolTipCaption1(d, selectedMetric) {
+    console.log("Caption", d);
+    if (d.data.APPLIED_SUPPRESSION === "Total") {
+      return this.translationsObj['data-missing-applied-suppression-total' + "--" + this.selectedMetric.toLowerCase()] || '';
+    } else if (d.data.APPLIED_SUPPRESSION === "Population") {
+      return this.translationsObj['data-missing-applied-suppression-population'+ "--" + this.selectedMetric.toLowerCase()] || '';
+    }
+
     let templateStr = this.translationsObj['chartToolTip1-caption'];
     const nomKey = 'chartMetricName--'+selectedMetric;
     let metricNom = selectedMetric;
@@ -284,7 +291,14 @@ class CAGOVEquityREPop extends window.HTMLElement {
     return caption;
   }
 
+  // @TODO Is this used? Looks like it's not.
   getToolTipCaption2(d, selectedMetric) {
+    if (d.APPLIED_SUPPRESSION === "Total") {
+      return translationsObj['data-missing-applied-suppression-total'] || '';
+    } else if (d.APPLIED_SUPPRESSION === "Population") {
+      return translationsObj['data-missing-applied-suppression-population'] || '';
+    }
+
     let templateStr = this.translationsObj['chartToolTip2-caption'];
     let caption = templateStr
                     .replace('placeholderForDynamicLocation',this.getLocation())
@@ -327,6 +341,7 @@ class CAGOVEquityREPop extends window.HTMLElement {
   }
 
   resetTooltip() {
+    console.log("reset tooltip");
     // this.querySelector(".tooltip-***").innerHTML = this.getDescription();
   }
 

--- a/src/js/equity-dash/charts/relative-percentage-by-pop/index.scss
+++ b/src/js/equity-dash/charts/relative-percentage-by-pop/index.scss
@@ -30,6 +30,10 @@ cagov-chart-re-pop {
     left: 20%;
   }
 
+  .withheld-label {
+    font-size: 0.85em;
+  }
+
   // .bars {
   //   font-weight: bold;
   //   font-size: 0.95rem;


### PR DESCRIPTION
This resolves an incorrect labelling issues for the Relative Percentage by Population chart.
* adds new labels for bars for situations where 'total' and 'population' data withholding/applied suppression are applied (situations with fewer than 11 deaths or populations with less than 20,000 people)
* adds css class to set the size of the label.

Note: This does not have text area sizing & we may need to address this with design for translated content or reduce the length of the text.

equity.html page has been updated already to connect to this code & strings for different cases, deaths and tests set up.
