### PR TITLE
Copy edit for R/E charts

### DIFF
--- a/pages/wordpress-posts/equity.html
+++ b/pages/wordpress-posts/equity.html
@@ -295,9 +295,9 @@ addtositemap: false
             <li data-label="chartLegend1State--tests">of testing statewide</li>
             <li data-label="chartLegend2State">of state population</li>
             <li data-label="chartLegend2County">of county population</li>
-            <li data-label="chartDescription--cases">Compare the percentage of each race and ethnicity’s share of cases in placeholderForDynamicLocation to their percentage of placeholderForDynamicLocation’s population.</li>
-            <li data-label="chartDescription--deaths">Compare the percentage of each race and ethnicity’s share of COVID-19 deaths in placeholderForDynamicLocation to their percentage of placeholderForDynamicLocation’s population.</li>
-            <li data-label="chartDescription--tests">Compare the percentage of each race and ethnicity’s share of tests in placeholderForDynamicLocation to their percentage of placeholderForDynamicLocation’s population.</li>
+            <li data-label="chartDescription--cases">Compare each race and ethnicity’s share of cases in placeholderForDynamicLocation to their percentage of placeholderForDynamicLocation’s population.</li>
+            <li data-label="chartDescription--deaths">Compare each race and ethnicity’s share of COVID-19 deaths in placeholderForDynamicLocation to their percentage of placeholderForDynamicLocation’s population.</li>
+            <li data-label="chartDescription--tests">Compare each race and ethnicity’s share of tests in placeholderForDynamicLocation to their percentage of placeholderForDynamicLocation’s population.</li>
             <li data-label="chartLineDiff">change since previous month</li>
             <li data-label="county-label">County</li>
             <li data-label="chartMetricName--tests">testing</li>


### PR DESCRIPTION
This addresses the last tiny nitpick on CCG-813 by removing the redundant phrase "the percentage of" in each of the left-side R/E chart summaries. Edit approved by Michael!

(Also, this is my first code edit/PR in this repo, so if I did this weird or this was the wrong file for this content, please let me know!)