### PR TITLE
Adding rel="external" to news links

### DIFF
--- a/pages/_includes/news-feed-home.html
+++ b/pages/_includes/news-feed-home.html
@@ -6,7 +6,7 @@
       <div class="news-grid">
         {%- for i in range(0, 3) %}
           <article class="news-item trigger">
-            <a class="news-item-link" href="{{ collections.covidGuidance[i].data.url }}">
+            <a class="news-item-link" href="{{ collections.covidGuidance[i].data.url }}" rel="external">
               <!-- <figure class="news-item-photo">
                 <img class="news-item-photo-img" src="img/news-photo1.jpg" alt="Governor Newsom Signs Executive Order on Actions in Response to COVID-19  6.22.20">
               </figure> -->

--- a/pages/_includes/news.11ty.js
+++ b/pages/_includes/news.11ty.js
@@ -16,7 +16,7 @@ class News {
         return `<div class="card border-0 border-bottom rounded-0" lang="en-US">
         <div class="card-body pl-0" lang="en-US">
           <h2 class="card-title lead" lang="en-US">
-            <a href="${item.data.url}" lang="en-US" hreflang="en-US">${
+            <a href="${item.data.url}" lang="en-US" hreflang="en-US" rel="external">${
           item.data.title
         }</a>
           </h2>


### PR DESCRIPTION
The news feed is full of links to other sites.  These need to be annotated as external to prevent SEO confusion, and let robots know that those links aren't ours to maintain.

Attempts to resolve...
https://digital-ca-gov.atlassian.net/browse/CCG-1031