### PR TITLE
CCG-776 Fixed tooltips in firefox. Removed some console logging.

### DIFF
--- a/src/js/equity-dash/charts/data-completeness/draw.js
+++ b/src/js/equity-dash/charts/data-completeness/draw.js
@@ -120,7 +120,7 @@ function drawBars(svg, x, y, yAxis, stackedData, color, data, tooltip, translati
       });
       tooltip.style("visibility", "visible");
       tooltip.style("left",'90px');
-      tooltip.style("top",`${event.offsetY + 100}px`)
+      tooltip.style("top",`${event.layerY+40}px`)
     })
     .on("mouseout", function(d) {
       d3.select(this).transition();

--- a/src/js/equity-dash/charts/relative-percentage-by-100k/draw-chart.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-100k/draw-chart.js
@@ -23,7 +23,7 @@ export default function drawBars(stackedData, data, statewideRatePer100k) {
 
   // console.log('100k', translationsObj, chartBreakpointValues, appliedSuppressionStatus);
 
-  console.log('selected', selectedMetric);
+  // console.log('selected', selectedMetric);
   
   svg.selectAll("g").remove();
   svg.selectAll("rect").remove();
@@ -90,7 +90,7 @@ export default function drawBars(stackedData, data, statewideRatePer100k) {
       tooltip.html(`<div class="chart-tooltip"><div >${caption}</div></div>`);
       tooltip.style("visibility", "visible");
       tooltip.style("left", "90px");
-      tooltip.style("top", `${event.offsetY + 100}px`);
+      tooltip.style("top", `${event.layerY+10}px`);
     })
     .on("mouseout", function (d) {
       d3.select(this).transition();

--- a/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart-second.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart-second.js
@@ -71,7 +71,7 @@ export default function drawSecondBars({
       //     <div>unused_caption1 </div>`);
       // tooltip.style("visibility", "visible");
       // tooltip.style("left", "90px");
-      // tooltip.style("top", `${event.offsetY + 100}px`);
+      // tooltip.style("top", `${event.layerY}px`);
     })
     .on("mouseout", function (d) {
       d3.select(this).transition();

--- a/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart.js
@@ -58,7 +58,7 @@ export default function drawBars({
       tooltip.html(`<div class="chart-tooltip"><div>${caption}</div></div>`);
       tooltip.style("visibility", "visible");
       tooltip.style("left", "90px");
-      tooltip.style("top", `${event.offsetY + 100}px`);
+      tooltip.style("top", `${event.layerY+10}px`);
     })
     .on("mouseout", function (d) {
       d3.select(this).transition();
@@ -101,7 +101,7 @@ export default function drawBars({
       </div>`);
       tooltip.style("visibility", "visible");
       tooltip.style("left", "90px");
-      tooltip.style("top", `${event.offsetY + 100}px`);
+      tooltip.style("top", `${event.layerY+10}px`);
     })
     .on("mouseout", function (d) {
       d3.select(this).transition();

--- a/src/js/equity-dash/charts/relative-percentage-by-pop/index.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-pop/index.js
@@ -340,7 +340,7 @@ class CAGOVEquityREPop extends window.HTMLElement {
   }
 
   resetTooltip() {
-    console.log("reset tooltip");
+    // console.log("reset tooltip");
     // this.querySelector(".tooltip-***").innerHTML = this.getDescription();
   }
 

--- a/src/js/equity-dash/county-buttons/buttons.js
+++ b/src/js/equity-dash/county-buttons/buttons.js
@@ -5,7 +5,7 @@ class CAGovCountyButtons extends window.HTMLElement {
     
     let searchElement = document.querySelector('cagov-county-search');
     searchElement.addEventListener('county-selected', function (e) {
-      // console.log("County-selected event: " , e.detail);
+      console.log("County-selected event: " , e.detail);
       if (e.detail.reset) {
         this.innerHTML = '';
       }
@@ -22,7 +22,7 @@ class CAGovCountyButtons extends window.HTMLElement {
       event.preventDefault();
       if(event.target.classList.contains('js-toggle-county')) {
         let clickedCounty = event.target.textContent;
-        console.log("Issuing county-selected for button");
+        // console.log("Issuing county-selected for button");
 
         if(!event.target.classList.contains('active')) {
           let emissionEvent = new window.CustomEvent('county-selected', {


### PR DESCRIPTION
Note: event.offsetY/X works differently in Firefox than Chrome.  

event.layerX/Y is a better choice and more closely corresponds to mouse position for element repositioning.