### PR TITLE
CCG-808 Enlarged hover target areas for Pop, 100k and Missingness (skinny bar charts).

### DIFF
--- a/src/js/equity-dash/charts/data-completeness/draw.js
+++ b/src/js/equity-dash/charts/data-completeness/draw.js
@@ -42,7 +42,7 @@ function drawBars(svg, x, y, yAxis, stackedData, color, data, tooltip, translati
 
 
   // Render the bars with their connected tooltips.
-  svg
+  let bar = svg
     .append("g")
     .selectAll("g")
     // Enter in the stack data = loop key per key = group per group.
@@ -57,13 +57,20 @@ function drawBars(svg, x, y, yAxis, stackedData, color, data, tooltip, translati
     .data(d => {
       return d;
     })
-    .enter()
-    .append("rect")
+    .enter();
+  bar.append("rect")
     .attr("x", d => x(d[0]))
     .attr("y", d => y(d.data.METRIC))
     .attr("width", d => x(d[1]) - x(d[0]))
-    .attr("height", "10px")
+    .attr("height", "10px");
 
+  // larger transparent overlay for tooltip hover
+  bar.append("rect")
+    .attr("x", d => x(d[0]))
+    .attr("y", d => y(d.data.METRIC)-10)
+    .attr("width", d => x(d[1]) - x(d[0]))
+    .attr("height", "30px")
+    .attr("fill", "transparent")  // use rgb(255,0,0,0.5) for debugging
     .attr("tabindex", "0")
     .attr("aria-label", (d, i) => {
       let percentNotMissing = d.data.NOT_MISSING
@@ -120,7 +127,7 @@ function drawBars(svg, x, y, yAxis, stackedData, color, data, tooltip, translati
       });
       tooltip.style("visibility", "visible");
       tooltip.style("left",'90px');
-      tooltip.style("top",`${event.layerY+40}px`)
+      tooltip.style("top",`${event.layerY+60}px`)
     })
     .on("mouseout", function(d) {
       d3.select(this).transition();

--- a/src/js/equity-dash/charts/relative-percentage-by-100k/draw-chart.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-100k/draw-chart.js
@@ -30,7 +30,7 @@ export default function drawBars(stackedData, data, statewideRatePer100k) {
   svg.selectAll("text").remove();
   svg.selectAll("path").remove();
 
-  svg
+  let bar = svg
     .append("g")
     .selectAll("g")
     // Enter in the stack data = loop key per key = group per group
@@ -42,13 +42,22 @@ export default function drawBars(stackedData, data, statewideRatePer100k) {
 
     // enter a second time = loop subgroup per subgroup to add all rectangles
     .data((d) => d)
-    .enter()
-    .append("rect")
+    .enter();
+  
+  bar.append("rect")
     .attr("x", (d) => x(d[0]))
     .attr("y", (d) => y(d.data.DEMOGRAPHIC_SET_CATEGORY))
     .attr("width", (d) => x(d[1]) - x(d[0]))
-    .attr("height", "10px")
+    .attr("height", "10px");
 
+
+  // large transparent area for tooltip hover area
+  bar.append("rect")
+    .attr("x", (d) => x(d[0]))
+    .attr("y", (d) => y(d.data.DEMOGRAPHIC_SET_CATEGORY)-10)
+    .attr("width", (d) => x(d[1]) - x(d[0]))
+    .attr("height", "30px")
+    .attr("fill", "transparent")  // use rgb(255,0,0,0.5) for debugging
     .attr("tabindex", "0")
     .attr("aria-label", (d, i) => {
       let caption = component.toolTipCaption(
@@ -68,7 +77,6 @@ export default function drawBars(stackedData, data, statewideRatePer100k) {
 
       return `<div class="chart-tooltip"><div>${caption}</div></div>`;
     })
-
     .on("mouseover focus", function (event, d) {
       d3.select(this).transition();
 

--- a/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart-second.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart-second.js
@@ -63,7 +63,6 @@ export default function drawSecondBars({
 
      // jbum: event handlers appear to be unused
     .on("mouseover focus", function (event, d) {
-      console.log("mo 3");
       d3.select(this).transition();
 
       // Rephrase as "X people make up XX% of cases statewide and XX% of California's population"

--- a/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart-second.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart-second.js
@@ -38,7 +38,7 @@ export default function drawSecondBars({
     }  
 
   // End of bar labels, METRIC total (yellow)
-  svg
+  let bars = svg
     .append("g")
     .selectAll("g")
     .data(stackedData1)
@@ -50,6 +50,7 @@ export default function drawSecondBars({
     // enter a second time = loop subgroup per subgroup to add yellow bars
     .data((d) => d)
     .enter()
+
     .append("rect")
     .attr("x", (d) => x1(d[0]))
     .attr("y", (d) => y(d.data.DEMOGRAPHIC_SET_CATEGORY))
@@ -62,7 +63,7 @@ export default function drawSecondBars({
 
      // jbum: event handlers appear to be unused
     .on("mouseover focus", function (event, d) {
-      console.log("Got focus");
+      console.log("mo 3");
       d3.select(this).transition();
 
       // Rephrase as "X people make up XX% of cases statewide and XX% of California's population"
@@ -79,6 +80,13 @@ export default function drawSecondBars({
       //.style("fill", "skyblue");
       tooltip.style("visibility", "hidden");
     });
+  // bars.append("rect")
+  //   .attr("x", (d) => x1(d[0]))
+  //   .attr("y", (d) => y(d.data.DEMOGRAPHIC_SET_CATEGORY)-5)
+  //   .attr("width", (d) => (x1(d[1]) - x1(d[0])/2))
+  //   .attr("height", "20px")
+  //   .attr("fill", "rgb(255,0,0,0.5)")
+  //   ;
 
   // svg.append("g").call(xAxis);
 

--- a/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart.js
@@ -24,52 +24,7 @@ export default function drawBars({
   svg.selectAll("rect").remove();
   svg.selectAll("text").remove();
 
-  // Yellow bars
-  svg
-    .append("g")
-    .attr('class', 'svg-first-section')
-    .selectAll("g")
-    .data(stackedData1)
-    .enter()
-    .append("g")
-    .attr("fill", (d) => color1(d.key))
-    .selectAll("rect")
-
-    // enter a second time = loop subgroup per subgroup to add yellow bars
-    .data((d) => d)
-    .enter()
-    .append("rect")
-    .attr("x", (d) => x1(d[0]))
-    .attr("y", (d) => y(d.data.DEMOGRAPHIC_SET_CATEGORY))
-    .attr("width", (d) => x1(d[1]) - x1(d[0]))
-    .attr("height", "10px")
-    .attr("tabindex", "0")
-    .attr("aria-label", (d, i) => {
-      let caption = component.getToolTipCaption1(d, selectedMetric);
-      return `<div class="chart-tooltip">
-      <div>${caption}</div>
-      </div>`}
-    )
-    
-    .on("mouseover focus", function (event, d) {
-      d3.select(this).transition();
-      // Rephrase as "X people make up XX% of cases statewide and XX% of California's population"
-      let caption = component.getToolTipCaption1(d, selectedMetric);
-      tooltip.html(`<div class="chart-tooltip"><div>${caption}</div></div>`);
-      tooltip.style("visibility", "visible");
-      tooltip.style("left", "90px");
-      tooltip.style("top", `${event.layerY+10}px`);
-    })
-    .on("mouseout", function (d) {
-      d3.select(this).transition();
-      //.attr("fill", d => color(d.key));
-      //.style("fill", "skyblue");
-      
-      // @TODO Hover off is too quick 
-      tooltip.style("visibility", "hidden");
-    });
-
-  // Blue bars
+  // Blue bars rendered first, to go under hover area
   svg
     .append("g")
     .selectAll("g")
@@ -91,14 +46,50 @@ export default function drawBars({
     .attr("tabindex", "0")
     .attr("aria-label", (d, i) => `<div class="chart-tooltip">
     <div >unused_caption1</div>`)
+    ;
 
+  // Yellow bars rendered second
+  let bar = svg
+    .append("g")
+    .attr('class', 'svg-first-section')
+    .selectAll("g")
+    .data(stackedData1)
+    .enter()
+    .append("g")
+    .attr("fill", (d) => color1(d.key))
+    .selectAll("rect")
+
+    // enter a second time = loop subgroup per subgroup to add yellow bars
+    .data((d) => d)
+    .enter();
+
+  bar .append("rect")
+    .attr("x", (d) => x1(d[0]))
+    .attr("y", (d) => y(d.data.DEMOGRAPHIC_SET_CATEGORY))
+    .attr("width", (d) => x1(d[1]) - x1(d[0]))
+    .attr("height", "10px")
+    .attr("tabindex", "0")
+    .attr("aria-label", (d, i) => {
+      let caption = component.getToolTipCaption1(d, selectedMetric);
+      return `<div class="chart-tooltip">
+      <div>${caption}</div>
+      </div>`}
+    );
+
+  // transparent hover area for tooltip
+  bar.append("rect")
+    .attr("x", (d) => x1(d[0]))
+    .attr("y", (d) => y(d.data.DEMOGRAPHIC_SET_CATEGORY)-5)
+    .attr("width", (d) => x1(d[1]) - x1(d[0]))
+    .attr("height", "40px")
+    .attr("fill", "transparent")  // use rgb(255,0,0,0.5) for debugging
+ 
     .on("mouseover focus", function (event, d) {
+      console.log("mo 1");
       d3.select(this).transition();
-      // switching to use same tooltip for both (it's less confusing)
-      let caption2 = component.getToolTipCaption1(d, selectedMetric);
-      tooltip.html(`<div class="chart-tooltip">
-        <div >${caption2}</div>
-      </div>`);
+      // Rephrase as "X people make up XX% of cases statewide and XX% of California's population"
+      let caption = component.getToolTipCaption1(d, selectedMetric);
+      tooltip.html(`<div class="chart-tooltip"><div>${caption}</div></div>`);
       tooltip.style("visibility", "visible");
       tooltip.style("left", "90px");
       tooltip.style("top", `${event.layerY+10}px`);
@@ -107,8 +98,53 @@ export default function drawBars({
       d3.select(this).transition();
       //.attr("fill", d => color(d.key));
       //.style("fill", "skyblue");
+      
+      // @TODO Hover off is too quick 
       tooltip.style("visibility", "hidden");
     });
+
+  // Blue bars
+  // svg
+  //   .append("g")
+  //   .selectAll("g")
+  //   .data(stackedData2)
+  //   .enter()
+  //   .append("g")
+  //   .attr("fill", (d) => color2(d.key))
+  //   .selectAll("rect")
+
+  //   // enter a second time = loop subgroup per subgroup to add blue bars
+  //   .data((d) => d)
+  //   .enter()
+  //   .append("rect")
+  //   .attr("x", (d) => x2(d[0]))
+  //   .attr("y", (d) => y(d.data.DEMOGRAPHIC_SET_CATEGORY) + 20)
+  //   .attr("width", (d) => x2(d[1]) - x2(d[0]))
+  //   .attr("height", "10px")
+
+  //   .attr("tabindex", "0")
+  //   .attr("aria-label", (d, i) => `<div class="chart-tooltip">
+  //   <div >unused_caption1</div>`)
+  //   ;
+    // .on("mouseover focus", function (event, d) {
+    //   console.log("mo 2");
+    //   d3.select(this).transition();
+    //   // switching to use same tooltip for both (it's less confusing)
+    //   let caption2 = component.getToolTipCaption1(d, selectedMetric);
+    //   tooltip.html(`<div class="chart-tooltip">
+    //     <div >${caption2}</div>
+    //   </div>`);
+    //   tooltip.style("visibility", "visible");
+    //   tooltip.style("left", "90px");
+    //   tooltip.style("top", `${event.layerY+10}px`);
+    // })
+    // .on("mouseout", function (d) {
+    //   d3.select(this).transition();
+    //   //.attr("fill", d => color(d.key));
+    //   //.style("fill", "skyblue");
+    //   tooltip.style("visibility", "hidden");
+    // })
+
 
   // svg.append("g").call(xAxis);
 

--- a/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart.js
@@ -67,25 +67,23 @@ export default function drawBars({
     .attr("x", (d) => x1(d[0]))
     .attr("y", (d) => y(d.data.DEMOGRAPHIC_SET_CATEGORY))
     .attr("width", (d) => x1(d[1]) - x1(d[0]))
-    .attr("height", "10px")
-    .attr("tabindex", "0")
-    .attr("aria-label", (d, i) => {
-      let caption = component.getToolTipCaption1(d, selectedMetric);
-      return `<div class="chart-tooltip">
-      <div>${caption}</div>
-      </div>`}
-    );
+    .attr("height", "10px");
 
-  // transparent hover area for tooltip
+  // Larger Transparent hover area for tooltip
   bar.append("rect")
     .attr("x", (d) => x1(d[0]))
     .attr("y", (d) => y(d.data.DEMOGRAPHIC_SET_CATEGORY)-5)
     .attr("width", (d) => x1(d[1]) - x1(d[0]))
     .attr("height", "40px")
     .attr("fill", "transparent")  // use rgb(255,0,0,0.5) for debugging
- 
+    .attr("tabindex", "0")
+    .attr("aria-label", (d, i) => {
+      let caption = component.getToolTipCaption1(d, selectedMetric);
+      return `<div class="chart-tooltip">
+      <div>${caption}</div>
+      </div>`}
+    )
     .on("mouseover focus", function (event, d) {
-      console.log("mo 1");
       d3.select(this).transition();
       // Rephrase as "X people make up XX% of cases statewide and XX% of California's population"
       let caption = component.getToolTipCaption1(d, selectedMetric);
@@ -103,50 +101,6 @@ export default function drawBars({
       tooltip.style("visibility", "hidden");
     });
 
-  // Blue bars
-  // svg
-  //   .append("g")
-  //   .selectAll("g")
-  //   .data(stackedData2)
-  //   .enter()
-  //   .append("g")
-  //   .attr("fill", (d) => color2(d.key))
-  //   .selectAll("rect")
-
-  //   // enter a second time = loop subgroup per subgroup to add blue bars
-  //   .data((d) => d)
-  //   .enter()
-  //   .append("rect")
-  //   .attr("x", (d) => x2(d[0]))
-  //   .attr("y", (d) => y(d.data.DEMOGRAPHIC_SET_CATEGORY) + 20)
-  //   .attr("width", (d) => x2(d[1]) - x2(d[0]))
-  //   .attr("height", "10px")
-
-  //   .attr("tabindex", "0")
-  //   .attr("aria-label", (d, i) => `<div class="chart-tooltip">
-  //   <div >unused_caption1</div>`)
-  //   ;
-    // .on("mouseover focus", function (event, d) {
-    //   console.log("mo 2");
-    //   d3.select(this).transition();
-    //   // switching to use same tooltip for both (it's less confusing)
-    //   let caption2 = component.getToolTipCaption1(d, selectedMetric);
-    //   tooltip.html(`<div class="chart-tooltip">
-    //     <div >${caption2}</div>
-    //   </div>`);
-    //   tooltip.style("visibility", "visible");
-    //   tooltip.style("left", "90px");
-    //   tooltip.style("top", `${event.layerY+10}px`);
-    // })
-    // .on("mouseout", function (d) {
-    //   d3.select(this).transition();
-    //   //.attr("fill", d => color(d.key));
-    //   //.style("fill", "skyblue");
-    //   tooltip.style("visibility", "hidden");
-    // })
-
-
-  // svg.append("g").call(xAxis);
 
   svg.append("g").call(yAxis);
 


### PR DESCRIPTION
After drawing a bar, we draw a second bar on top of it which is transparent, but 20 pixels thicker, and is used for both the aria label and the hover-area for tooltips.  

In the case of the pop chart (which has two bars per item), we use a single large hover area over both of the skinny bars.