### PR TITLE
proper file path for commit info

### DIFF
--- a/.github/workflows/eleventy_build.yml
+++ b/.github/workflows/eleventy_build.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Save Commit Context
         uses: finnp/create-file-action@master
         env:
-            FILE_NAME: "commit-info.json"
+            FILE_NAME: "./docs/commit-info.json"
             FILE_DATA: ${{ toJson(github.event.commits) }}
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
didn't work last time.  adding the "docs" prefix 