### PR TITLE
Task/ccg 481 kk feedback footer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1644,11 +1644,6 @@
         "awesomplete-es6": "^1.2.2"
       }
     },
-    "@cagov/pagerating": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@cagov/pagerating/-/pagerating-2.0.0.tgz",
-      "integrity": "sha512-an/RfMic4xlynp18V4owsGjYlB5++RBVCqbCAvOCmIdOXCeoKzJN1nWhEnleMgbxjOAwveAcfwQMHhf21oxjbA=="
-    },
     "@cagov/step-list": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@cagov/step-list/-/step-list-1.0.11.tgz",
@@ -8650,7 +8645,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "gulp": {
       "version": "4.0.2",
@@ -9825,7 +9821,8 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
       "integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "is-expression": {
       "version": "3.0.0",
@@ -13113,6 +13110,7 @@
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
       "integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -13127,6 +13125,7 @@
           "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
           "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-docker": "^2.0.0"
           }
@@ -13135,7 +13134,8 @@
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
           "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -17029,7 +17029,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "side-channel": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "@11ty/eleventy": "^0.11.1",
     "@cagov/accordion": "^1.0.6",
     "@cagov/lookup": "^1.0.2",
-    "@cagov/pagerating": "^2.0.0",
     "@cagov/step-list": "^1.0.11",
     "@webcomponents/webcomponentsjs": "^2.5.0",
     "awesomplete-es6": "^1.2.2",

--- a/pages/_includes/footer.njk
+++ b/pages/_includes/footer.njk
@@ -23,6 +23,14 @@ ga('tracker3.send', 'pageview');
 	data-thanks-comments="{{text.thank_you_for_your_comments}}"
 	data-submit="{{text.submit}}"
 	data-required-field="{{text.this_field_required}}"
+	data-characterLimit="{{text.character_limit}}"
+	data-anythingToAdd="{{text.anything_to_add}}"
+	data-positiveSurveyUrl="{{text.positive_survey_url}}"
+	data-takeTheSurvey="{{text.take_the_survey}}"
+	data-anyOtherFeedback="{{text.any_other_feedback}}"
+	data-negativeSurveyUrl="{{text.negative_survey_url}}"
+	data-takeOurSurvey="{{text.take_our_survey}}"
+
 	></cagov-pagefeedback>	
 </pagerating-section>
 

--- a/pages/_includes/footer.njk
+++ b/pages/_includes/footer.njk
@@ -13,7 +13,7 @@ ga('tracker3.send', 'pageview');
 <script async defer src='https://www.google-analytics.com/analytics.js'></script>
 
 <pagerating-section>
-	<cwds-pagerating 
+	<cagov-pagefeedback 
 	data-endpoint-url="https://api.alpha.ca.gov/WasHelpful"
 	data-question="{{text.is_this_page_useful}}"
 	data-yes="{{text.answer_yes}}"
@@ -23,7 +23,7 @@ ga('tracker3.send', 'pageview');
 	data-thanks-comments="{{text.thank_you_for_your_comments}}"
 	data-submit="{{text.submit}}"
 	data-required-field="{{text.this_field_required}}"
-	></cwds-pagerating>	
+	></cagov-pagefeedback>	
 </pagerating-section>
 
 <footer-section>

--- a/src/css/_buttons.scss
+++ b/src/css/_buttons.scss
@@ -484,9 +484,19 @@ button.clear {
   }
   &:focus {outline: 2px solid $yellow !important;}
 }
-
+// lighter blue button
+.button-lightestblue {
+  @include action-button;
+  background-color: $lightestblue;
+  color: $darkblue !important;
+  &:hover, &:focus {
+    background-color: $orange;
+    color: $darkblue !important;
+  }
+  &:focus {outline: 2px solid $yellow !important;}
+}
 .bd-4px {
-border-radius: 0.25rem !important;
+  border-radius: 0.25rem !important;
 }
 
 

--- a/src/css/_page-rating.scss
+++ b/src/css/_page-rating.scss
@@ -8,19 +8,7 @@ pagerating-section {
 		@include desktop {
 			padding: 3rem
 		}
-		@include tablet {
-			&-grid {
-				display: inline-flex;
-				&-col:first-child {
-					padding-right: 2rem;
-					border-right: 2px solid rgba(255, 255, 255, 0.25);
-				}
-				&-col:last-child {
-					padding-left: 2rem
-				}
-			}
-
-		}
+	
 		&-label {
 			color: #fff;
 			// cursor: pointer;
@@ -78,9 +66,7 @@ pagerating-section {
 			padding: 1rem;
 			font-family: "Roboto", sans-serif;
 			color:$darkblue;
-			@include tablet {
-				width: 20rem;
-			}
+			
 			&:focus {
 				box-shadow: 0 0 0 2px $orange;
 			}
@@ -92,13 +78,12 @@ pagerating-section {
 		}
 
 		&-error {
-			position: absolute;
+			position: relative;
 			top: 100%;
 			left: 0;
-			background:$orange;
-			color: $darkblue;
-			padding: 0.5rem;
-			display: none
+			display: none;
+			font-weight: 300;
+			text-align: left;
 		}
 
 	} // end .feedback-form 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,6 +1,6 @@
 import '@cagov/step-list';
 import '@cagov/accordion';
-import '@cagov/pagerating';
+import './pagerating/index.js';
 import './survey/index.js';
 import './feature-detect/webp.js';
 import './arrow/index.js';

--- a/src/js/pagerating/index.js
+++ b/src/js/pagerating/index.js
@@ -20,9 +20,28 @@ class CAGOVPageFeedback extends window.HTMLElement {
     let requiredField = this.dataset.requiredField
       ? this.dataset.requiredField
       : "This field is required";
-      let characterLimit = this.dataset.characterLimit
+    let characterLimit = this.dataset.characterLimit
       ? this.dataset.characterLimit
       : "You have reached your character limit."
+    let anythingToAdd = this.dataset.anythingToAdd
+      ? this.dataset.anythingToAdd
+      : "If you have anything to add,"
+    let positiveSurveyUrl = this.dataset.positiveSurveyUrl
+      ? this.dataset.positiveSurveyUrl
+      : "https://ethn.io/85017"
+    let takeTheSurvey = this.dataset.takeTheSurvey
+      ? this.dataset.takeTheSurvey
+      : "take the survey"
+    let anyOtherFeedback = this.dataset.anyOtherFeedback
+      ? this.dataset.anyOtherFeedback
+      : "If you have any other feedback about this website,"
+    let negativeSurveyUrl = this.dataset.negativeSurveyUrl
+      ? this.dataset.negativeSurveyUrl
+      : "https://ethn.io/77745"
+    let takeOurSurvey = this.dataset.takeOurSurvey
+      ? this.dataset.takeOurSurvey
+      : "take our survey"
+
     this.endpointUrl = this.dataset.endpointUrl;
     let html = ratingsTemplate(
       question,
@@ -33,7 +52,13 @@ class CAGOVPageFeedback extends window.HTMLElement {
       thanksComments,
       submit,
       requiredField,
-      characterLimit
+      characterLimit,
+      anythingToAdd,
+      positiveSurveyUrl,
+      takeTheSurvey,
+      anyOtherFeedback,
+      negativeSurveyUrl,
+      takeOurSurvey
     );
     this.innerHTML = html;
     this.applyListeners();

--- a/src/js/pagerating/index.js
+++ b/src/js/pagerating/index.js
@@ -1,0 +1,130 @@
+import ratingsTemplate from "./template.js";
+
+class CAGOVPageFeedback extends window.HTMLElement {
+  connectedCallback() {
+    let question = this.dataset.question
+      ? this.dataset.question
+      : "Did you find what you were looking for?";
+    let yes = this.dataset.yes ? this.dataset.yes : "Yes";
+    let no = this.dataset.no ? this.dataset.no : "No";
+    let commentPrompt = this.dataset.commentPrompt
+      ? this.dataset.commentPrompt
+      : "What was the problem?";
+    let thanksFeedback = this.dataset.thanksFeedback
+      ? this.dataset.thanksFeedback
+      : "Thank you for your feedback!";
+    let thanksComments = this.dataset.thanksComments
+      ? this.dataset.thanksComments
+      : "Thank you for your comments!";
+    let submit = this.dataset.submit ? this.dataset.submit : "Submit";
+    let requiredField = this.dataset.requiredField
+      ? this.dataset.requiredField
+      : "This field is required";
+    this.endpointUrl = this.dataset.endpointUrl;
+    let html = ratingsTemplate(
+      question,
+      yes,
+      no,
+      commentPrompt,
+      thanksFeedback,
+      thanksComments,
+      submit,
+      requiredField
+    );
+    this.innerHTML = html;
+    this.applyListeners();
+  }
+
+  applyListeners() {
+    this.wasHelpful = "";
+    this.querySelector(".js-add-feedback").addEventListener(
+      "focus",
+      (event) => {
+        this.querySelector(".js-feedback-submit").style.display = "block";
+      }
+    );
+    let feedback = this.querySelector(".js-add-feedback");
+    feedback.addEventListener("keyup", function (event) {
+      if (feedback.value.length > 15) {
+        feedback.setAttribute("rows", "3");
+      } else {
+        feedback.setAttribute("rows", "1");
+      }
+    });
+
+    feedback.addEventListener("keydown", function (event) {
+      if (feedback.value.length > 600) {
+        document.querySelector(".feedback-limit-error").style.display = "block";
+      } else {
+        document
+          .querySelector(".feedback-limit-error")
+          .removeAttribute("style");
+      }
+    });
+
+    feedback.addEventListener("blur", (event) => {
+      if (feedback.value.length !== 0) {
+        this.querySelector(".js-feedback-submit").style.display = "block";
+      }
+    });
+    this.querySelector(".js-feedback-yes").addEventListener(
+      "click",
+      (event) => {
+        this.querySelector(".js-feedback-form").style.display = "none";
+        this.querySelector(".js-feedback-thanks").style.display = "block";
+        this.wasHelpful = "yes";
+        this.dispatchEvent(
+          new CustomEvent("ratedPage", {
+            detail: this.wasHelpful,
+          })
+        );
+      }
+    );
+    this.querySelector(".js-feedback-no").addEventListener("click", (event) => {
+      this.querySelector("#feedback-form").classList.remove("d-none");
+      this.querySelector("#yes-no").classList.add("d-none");
+      this.querySelector(".js-feedback-form").style.display = "none";
+      this.querySelector(".js-feedback-thanks").style.display = "block";
+      this.wasHelpful = "no";
+      this.dispatchEvent(
+        new CustomEvent("ratedPage", {
+          detail: this.wasHelpful,
+        })
+      );
+    });
+    this.querySelector(".js-feedback-submit").addEventListener(
+      "click",
+      (event) => {
+        if (feedback.value.length > 600) {
+          document.querySelector(".feedback-limit-error").style.display =
+            "block";
+        }
+        else {
+          this.querySelector(".feedback-form-add").style.display = "none";
+          this.querySelector(".feedback-thanks-add").style.display = "block";
+          // this.querySelector('.feedback-error').removeAttribute("style");
+          document
+            .querySelector(".feedback-limit-error")
+            .removeAttribute("style");
+
+          let postData = {};
+          postData.url = window.location.href;
+          postData.helpful = this.wasHelpful;
+          postData.comments = feedback.value;
+          postData.userAgent = navigator.userAgent;
+
+          fetch(this.endpointUrl, {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify(postData),
+          })
+            .then((response) => response.json())
+            .then((data) => console.log(data));
+        }
+      }
+    );
+  }
+}
+window.customElements.define("cagov-pagefeedback", CAGOVPageFeedback);

--- a/src/js/pagerating/index.js
+++ b/src/js/pagerating/index.js
@@ -20,6 +20,9 @@ class CAGOVPageFeedback extends window.HTMLElement {
     let requiredField = this.dataset.requiredField
       ? this.dataset.requiredField
       : "This field is required";
+      let characterLimit = this.dataset.characterLimit
+      ? this.dataset.characterLimit
+      : "You have reached your character limit."
     this.endpointUrl = this.dataset.endpointUrl;
     let html = ratingsTemplate(
       question,
@@ -29,7 +32,8 @@ class CAGOVPageFeedback extends window.HTMLElement {
       thanksFeedback,
       thanksComments,
       submit,
-      requiredField
+      requiredField,
+      characterLimit
     );
     this.innerHTML = html;
     this.applyListeners();

--- a/src/js/pagerating/template.js
+++ b/src/js/pagerating/template.js
@@ -1,4 +1,4 @@
-export default function (question, yes, no, commentPrompt, thanksFeedback, thanksComments, submit, requiredField, characterLimit) {
+export default function (question, yes, no, commentPrompt, thanksFeedback, thanksComments, submit, requiredField, characterLimit, anythingToAdd, positiveSurveyUrl, takeTheSurvey, anyOtherFeedback, negativeSurveyUrl, takeOurSurvey) {
   return /*html*/`<div class="feedback-form">
     <div class="feedback-form-grid">
 				<div class="feedback-form-grid-col" id="yes-no">
@@ -8,7 +8,7 @@ export default function (question, yes, no, commentPrompt, thanksFeedback, thank
             <button class="button-lightestblue ml-3 js-feedback-no" id="feedback-no" aria-labelledby="feedback-rating">${no}</button>
           </div>
           <div class="feedback-form-thanks js-feedback-thanks" role="alert"><span class="font-size-1-5em bold mb-3">${thanksComments}</span>
-          <br><span class="text-300">If you have anything to add, <a href="https://ethn.io/85017" class="color-secondary color-secondary-hover">take the survey.</a></span></div>
+          <br><span class="text-300">${anythingToAdd} <a href="${positiveSurveyUrl}" class="color-secondary color-secondary-hover">${takeTheSurvey}.</a></span></div>
         </div>
         <div class="col-md-6 mx-auto d-none" id="feedback-form">
           <div class="feedback-form-add text-center">
@@ -22,7 +22,7 @@ export default function (question, yes, no, commentPrompt, thanksFeedback, thank
           </div>
           <div class="feedback-form-thanks feedback-thanks-add" role="alert">
             <span class="font-size-1-5em bold">${thanksFeedback}</span>
-            <p class="text-300  mt-3">If you have any other feedback about this website, <a href="https://ethn.io/77745" class="color-secondary color-secondary-hover">take our survey.</a></p>
+            <p class="text-300  mt-3">${anyOtherFeedback} <a href="${negativeSurveyUrl}" class="color-secondary color-secondary-hover">${takeOurSurvey}.</a></p>
           </div>
 				</div>
 		  </div>

--- a/src/js/pagerating/template.js
+++ b/src/js/pagerating/template.js
@@ -1,4 +1,4 @@
-export default function (question, yes, no, commentPrompt, thanksFeedback, thanksComments, submit, requiredField) {
+export default function (question, yes, no, commentPrompt, thanksFeedback, thanksComments, submit, requiredField, characterLimit) {
   return /*html*/`<div class="feedback-form">
     <div class="feedback-form-grid">
 				<div class="feedback-form-grid-col" id="yes-no">
@@ -7,7 +7,7 @@ export default function (question, yes, no, commentPrompt, thanksFeedback, thank
             <button class="button-lightestblue mr-2 js-feedback-yes" id="feedback-yes" aria-labelledby="feedback-rating">${yes}</button>
             <button class="button-lightestblue ml-3 js-feedback-no" id="feedback-no" aria-labelledby="feedback-rating">${no}</button>
           </div>
-          <div class="feedback-form-thanks js-feedback-thanks" role="alert"><span class="font-size-1-5em bold mb-3">${thanksComment}</span>
+          <div class="feedback-form-thanks js-feedback-thanks" role="alert"><span class="font-size-1-5em bold mb-3">${thanksComments}</span>
           <br><span class="text-300">If you have anything to add, <a href="https://ethn.io/85017" class="color-secondary color-secondary-hover">take the survey.</a></span></div>
         </div>
         <div class="col-md-6 mx-auto d-none" id="feedback-form">
@@ -16,7 +16,7 @@ export default function (question, yes, no, commentPrompt, thanksFeedback, thank
             <div class="feedback-form-add-grid d-block">
               <textarea name="add-feedback" class="js-add-feedback feedback-form-textarea" id="add-feedback" rows="1"></textarea>
               <div class="feedback-form-error feedback-error color-yellow" role="alert">${requiredField}</div>
-              <div class="feedback-form-error feedback-limit-error color-yellow" role="alert">You have reached your character limit.</div>
+              <div class="feedback-form-error feedback-limit-error color-yellow" role="alert">${characterLimit}</div>
             </div>
             <button class="button-lightestblue mt-4 mx-auto js-feedback-submit" type="submit" id="feedback-submit">${submit}</button>
           </div>

--- a/src/js/pagerating/template.js
+++ b/src/js/pagerating/template.js
@@ -1,0 +1,30 @@
+export default function (question, yes, no, commentPrompt, thanksFeedback, thanksComments, submit, requiredField) {
+  return /*html*/`<div class="feedback-form">
+    <div class="feedback-form-grid">
+				<div class="feedback-form-grid-col" id="yes-no">
+          <div class="js-feedback-form">
+            <label class="feedback-form-label font-size-1-5em" id="feedback-rating">${question}</label>
+            <button class="button-lightestblue mr-2 js-feedback-yes" id="feedback-yes" aria-labelledby="feedback-rating">${yes}</button>
+            <button class="button-lightestblue ml-3 js-feedback-no" id="feedback-no" aria-labelledby="feedback-rating">${no}</button>
+          </div>
+          <div class="feedback-form-thanks js-feedback-thanks" role="alert"><span class="font-size-1-5em bold mb-3">${thanksComment}</span>
+          <br><span class="text-300">If you have anything to add, <a href="https://ethn.io/85017" class="color-secondary color-secondary-hover">take the survey.</a></span></div>
+        </div>
+        <div class="col-md-6 mx-auto d-none" id="feedback-form">
+          <div class="feedback-form-add text-center">
+            <label class="feedback-form-label font-size-1-5em" for="add-feedback">${commentPrompt}</label>
+            <div class="feedback-form-add-grid d-block">
+              <textarea name="add-feedback" class="js-add-feedback feedback-form-textarea" id="add-feedback" rows="1"></textarea>
+              <div class="feedback-form-error feedback-error color-yellow" role="alert">${requiredField}</div>
+              <div class="feedback-form-error feedback-limit-error color-yellow" role="alert">You have reached your character limit.</div>
+            </div>
+            <button class="button-lightestblue mt-4 mx-auto js-feedback-submit" type="submit" id="feedback-submit">${submit}</button>
+          </div>
+          <div class="feedback-form-thanks feedback-thanks-add" role="alert">
+            <span class="font-size-1-5em bold">${thanksFeedback}</span>
+            <p class="text-300  mt-3">If you have any other feedback about this website, <a href="https://ethn.io/77745" class="color-secondary color-secondary-hover">take our survey.</a></p>
+          </div>
+				</div>
+		  </div>
+    </div>`
+}


### PR DESCRIPTION
This is the update to the page feedback component in the footer created by Konstantin

We have abandoned the published component because that was a universal widget that could have been used on other sites. Now we have something that reads in ethnio urls and is only appropriate for use on the covid site.

- Translated strings come from WordPress, in the common-page-labels post which has been published to staging
- Those strings are used in the njk template and fed into the component as data attributes

- The component still collects info typed into a form field on the page that is shown if you say you did not find what you need
- This info goes to the Azure CosmosDB as it did in the last version of the component
- Links to different ethnio surveys are presented based on whether you said you found what you wanted or not