### PR TITLE
CCG-1112 Stacking legends. Other mobile fixes.

### DIFF
--- a/src/js/equity-dash/charts/healthy-places-index/index.js
+++ b/src/js/equity-dash/charts/healthy-places-index/index.js
@@ -56,10 +56,10 @@ class CAGOVChartD3Lines extends window.HTMLElement {
       },
       retina: {
         width: 320,
-        height: 600,
+        height: 450,
         margin: { top: 30, right: 20, bottom: 40, left: 30 },
         legendPosition: {
-          x: 160,
+          x: 100,
           y: 18
         }
       },

--- a/src/js/equity-dash/charts/healthy-places-index/template.js
+++ b/src/js/equity-dash/charts/healthy-places-index/template.js
@@ -5,7 +5,7 @@ export default function template(translationsObj) {
     <div class="container">
       <div class="col-lg-12 bg-white py-4">
         <div class="row">
-          <div class="col-lg-12 col-md-9 col-sm-12 mx-auto px-3">
+          <div class="col-lg-12 col-md-12 col-sm-12 mx-auto px-3">
             <div class="svg-holder">
             </div>
           </div>

--- a/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart.js
@@ -228,15 +228,10 @@ export default function drawBars({
         });
     });
 
+  // stack legends if space is too tight
+  const stackLegends = chartBreakpointValues.chartSectionOne.width < 400;
+  const stackGapY = 24
   // Legend
-  svg
-    .append("rect")
-    .attr("x", 190)
-    .attr("y", -20)
-    .attr("width", 15)
-    .attr("height", 15)
-    .attr("fill", "#FFCF44");
-    
   svg
     .append("rect")
     .attr("x", 0)
@@ -246,12 +241,14 @@ export default function drawBars({
     .attr("fill", "#92C5DE");
 
   svg
-    .append("text")
-    .attr("x", 210)
-    .attr("y", -12)
-    .attr("class", "legend-label")
-    .attr("dy", "0.35em")
-    .text('% ' + legendStrings[0]);
+    .append("rect")
+    .attr("x", stackLegends? 0 : 190)
+    .attr("y", stackLegends? stackGapY-20 : -20)
+    .attr("width", 15)
+    .attr("height", 15)
+    .attr("fill", "#FFCF44");
+    
+
   svg
     .append("text")
     .attr("x", 20)
@@ -259,6 +256,14 @@ export default function drawBars({
     .attr("class", "legend-label")
     .attr("dy", "0.35em")
     .text('% ' + legendStrings[1]);
+
+    svg
+    .append("text")
+    .attr("x", stackLegends? 20 : 210)
+    .attr("y", stackLegends? stackGapY-12 : -12)
+    .attr("class", "legend-label")
+    .attr("dy", "0.35em")
+    .text('% ' + legendStrings[0]);
 
 
   let is_debugging_infobox = false;


### PR DESCRIPTION
Stacking legends on pop chart vertically when width of chart is < 400 to avoid text cropping on mobile.
Positioning fix to avoid legend cropping on line chart.
Better proportions on line chart on retina.