### PR TITLE
remove inline style

### DIFF
--- a/pages/_includes/dashboard.njk
+++ b/pages/_includes/dashboard.njk
@@ -175,7 +175,7 @@
         <div class="row d-flex justify-content-md-center">
 
             <div class="toggle-group-container cases-group">
-            <div  id="cases-county-graph" class="toggle-group-element" style="display:none;">
+            <div  id="cases-county-graph" class="toggle-group-element">
                 <div class='tableauPlaceholder' id="casesChartCounty"></div>
             </div>
             <div id="cases-state-graph" class="toggle-group-element">


### PR DESCRIPTION
This looks like an innocuous cleanup change but there is something more sinister going on. 

- We are passing height and width values to tableau when we ask it to display a chart but this is not enough to fully control layout. If a chart is loaded but not displayed tableau will get confused about layout modes to choose causing fallback to mobile view. 
- We are also seeing a bug in Firefox where loading a chart when not displayed causes tableau to fail to set the active worksheet on the active workbook?!? This will break county search. 

I conferred with Jim to make sure this code change won't wreck some other important bug fix. It was put in place to help with the flashing of unwanted county chart which can happen on load. Since we have had that bug since launch but the layout and FF problems have been raised as high priority we will remove this display:none