### PR TITLE
remove inline style

### DIFF
--- a/pages/_includes/dashboard.njk
+++ b/pages/_includes/dashboard.njk
@@ -175,7 +175,7 @@
         <div class="row d-flex justify-content-md-center">
 
             <div class="toggle-group-container cases-group">
-            <div  id="cases-county-graph" class="toggle-group-element" style="display:none;">
+            <div  id="cases-county-graph" class="toggle-group-element">
                 <div class='tableauPlaceholder' id="casesChartCounty"></div>
             </div>
             <div id="cases-state-graph" class="toggle-group-element">


### PR DESCRIPTION
PR to preprod: https://github.com/cagov/covid19/pull/2891

The inline style on this element makes tableu layout the county cases chart incorrectly and also causes tableau to fail to populate the active worksheet (only in Firefox) which breaks the county switch in that browser. 