### PR TITLE
Task/ccg 1195 data link callout

### DIFF
--- a/pages/_includes/dashboard.njk
+++ b/pages/_includes/dashboard.njk
@@ -246,7 +246,7 @@
                         <p>California has collected a wide range of data to inform its response to COVID-19. We've developed tools to process and analyze this data. These data and tools are available to the public.</p>
 
                         <div class="mt-3 text-center">
-                            <a href="#learn-more" class="link-arrow-white">
+                            <a href="/data-and-tools/" class="link-arrow-white">
                                 <div class="link-arrow-label">View all data and tools</div><cagov-arrow></cagov-arrow>
                             </a>
                         </div>

--- a/pages/_includes/dashboard.njk
+++ b/pages/_includes/dashboard.njk
@@ -238,12 +238,24 @@
 
         </div>
 
-        <div class="text-center">
-        
-            <a href="/data-and-tools/" class="link-arrow-blue mb-4">
-            <div class="link-arrow-label">Explore more data</div>
-            <cagov-arrow></cagov-arrow>
-            </a>  
+        <div class="bg-darkblue py-5 full-bleed mb-5">
+            <div class="container py-2">
+                <div class="row pb-4">
+                    <div class="col-lg-10 mx-auto color-white">
+                        <h2 class="text-center color-orange" id="reopening-equitably">More data and tools</h2>
+                        <p>California has collected a wide range of data to inform its response to COVID-19. We've developed tools to process and analyze this data. These data and tools are available to the public.</p>
+
+                        <div class="mt-3 text-center">
+                            <a href="#learn-more" class="link-arrow-white">
+                                <div class="link-arrow-label">View all data and tools</div><cagov-arrow></cagov-arrow>
+                            </a>
+                        </div>
+
+
+                    </div>
+                </div>
+
+            </div><!--END container-->
         </div>
 
         <div class="row d-flex justify-content-md-center">


### PR DESCRIPTION
Adding more dramatic styling to link to data and tools page

As part of or right after the state dashboard 2 launch we need to address all this content being here instead of under usual editorial control in WordPress