### PR TITLE
add robots which disallows in staging

### DIFF
--- a/pages/_data/envconfig.js
+++ b/pages/_data/envconfig.js
@@ -7,8 +7,6 @@ const stagingConfig =  {
 }
 
 module.exports = function() {
-  console.log('hello world')
-  console.log(process.env.NODE_ENV)
   if(process.env.NODE_ENV=='staging') {
     return stagingConfig;
   }

--- a/pages/manual-content/robots.njk
+++ b/pages/manual-content/robots.njk
@@ -4,4 +4,8 @@ eleventyExcludeFromCollections: true
 ---
 {% if env.staging %}User-agent: *
 Disallow: /
+{% else %}
+User-agent: *
+Allow: /
+Sitemap: https://covid19.ca.gov/sitemap.xml
 {% endif %}

--- a/pages/manual-content/robots.njk
+++ b/pages/manual-content/robots.njk
@@ -1,0 +1,7 @@
+---
+permalink: /robots.txt
+eleventyExcludeFromCollections: true
+---
+{% if env.staging %}User-agent: *
+Disallow: /
+{% endif %}

--- a/pages/rootcopy/robots.txt
+++ b/pages/rootcopy/robots.txt
@@ -1,3 +1,0 @@
-User-agent: *
-Allow: /
-Sitemap: https://covid19.ca.gov/sitemap.xml


### PR DESCRIPTION
Problem: staging is showing up in google search results possibly because there was a recent accidental link left back to staging in production

This PR adds robots.txt which sets disallow everywhere if the site is built in staging mode

Will need to follow up in google search tool to see if we need to remove things already indexed