### PR TITLE
CCG-908: Reduced caption size on intermediate sizes (520-768). 

### DIFF
--- a/src/js/equity-dash/charts/social-determinants/draw.js
+++ b/src/js/equity-dash/charts/social-determinants/draw.js
@@ -2,19 +2,24 @@ let labelMap = new Map();
 labelMap.set("below $40K","0 - $40K");
 labelMap.set("above $120K","$120K+");
 
+function fixRangeHyphens(label) {
+  return label.replace(" - ","–"); // use n-dashes instead of space-hyphen-space
+}
+
 function writeXAxis(data, height, margin, x) {
+  console.log("Write x axis",data);
   let xAxis = g => g
     .attr("transform", `translate(0,${height - (margin.bottom - 5)})`)
     .call(d3.axisBottom(x).tickFormat(i => {
       if(labelMap.get(data[i].SOCIAL_TIER)) {
-        return labelMap.get(data[i].SOCIAL_TIER);
+        return fixRangeHyphens(labelMap.get(data[i].SOCIAL_TIER));
       }
-      return data[i].SOCIAL_TIER;
+      return fixRangeHyphens(data[i].SOCIAL_TIER);
     }).tickSize(0))
-    .style('font-weight','bold')
     .call(g => g.select(".domain").remove())
   return xAxis;
 }
+
 function writeXAxisLabel(component, svg, label) {
   svg.selectAll("g.x-label").remove()
   svg.append("g")

--- a/src/js/equity-dash/charts/social-determinants/index.scss
+++ b/src/js/equity-dash/charts/social-determinants/index.scss
@@ -21,13 +21,18 @@ cagov-chart-d3-bar {
   .bar-label tspan.bold {
     font-weight: bold;
   }
+  .tick text {
+    font-size: 0.85rem;
+    font-weight: bold;
+  }
 
   @media (max-width: 768px) {
     .chart-title {
       margin: 50px 20px 20px 20px;
     }
     .tick text {
-      font-size: 0.7rem !important;
+      font-size: 0.55rem !important;
+      font-weight: 500;
     }
     .xaxis-label {
       font-size: 0.75rem !important;
@@ -37,11 +42,11 @@ cagov-chart-d3-bar {
     }
 }
 
-  @media (max-width: 440px) {
+  @media (max-width: 520px) {
     
       .tick text {
         font-size: 0.5rem !important;
-        font-weight: 600;
+        font-weight: 500;
       }
       .bar-label tspan {
         font-size: 0.6rem !important;


### PR DESCRIPTION
Also reduced overall font-weight at smaller sizes, and using n-dashes instead of space-hyphen-space to reduce caption size.

This fixes caption overlap in the 500-600 width range on Firefox and Safari.
