### PR TITLE
Ccg 1287/bug event tracking prefixes

### DIFF
--- a/pages/_includes/main.njk
+++ b/pages/_includes/main.njk
@@ -242,7 +242,7 @@
 						<ul class="arrow-links">
 						{%- for item in items %}
 						<li>    
-							<a class="link-arrow-white" href="{{ item._url }}">
+							<a class="link-arrow-white js-event-hm-wtk" href="{{ item._url }}">
 								<div class="link-arrow-label">{{ item.text | safe }}</div>
 								<cagov-arrow></cagov-arrow>
 							</a>
@@ -270,7 +270,7 @@
 		<div class="faq trigger">
 			<div class="arrow-links">
 			<article>    
-				<a class="link-arrow-blue" href="{{item["URL"]}}">
+				<a class="link-arrow-blue js-event-hm-wtk" href="{{item["URL"]}}">
 				<div class="link-arrow-label">
 					{{item["Link Title"]}}
 				</div>

--- a/src/js/menu/template.js
+++ b/src/js/menu/template.js
@@ -13,33 +13,22 @@ export default function (data, dataset) {
           </button>
         </form>
       </div>
-
-      <!-- 
       <div class="expanded-menu-section mobile-only">
         <strong class="expanded-menu-section-header">
-          <a class="expanded-menu-section-header-link expanded-menu-close-mobile" href="#">
-             <svg class="expanded-menu-close-mobile-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17 18"><path d="M7.7,0.4L0.4,7.9c-0.6,0.6-0.6,1.5,0,2.1l7.3,7.5c0.6,0.6,1.5,0.6,2.1,0c0.6-0.6,0.6-1.5,0-2.1L5,10.5h10.6 c0.8,0,1.5-0.7,1.5-1.5c0-0.8-0.7-1.5-1.5-1.5H5l4.8-4.9c0.3-0.3,0.4-0.7,0.4-1.1c0-0.4-0.1-0.8-0.4-1.1C9.2-0.1,8.3-0.1,7.7,0.4z"></path></svg>
-          </a> 
-        </strong>
-      </div> 
-      -->
-
-      <div class="expanded-menu-section mobile-only">
-        <strong class="expanded-menu-section-header">
-          <a class="expanded-menu-section-header-link" href="/">${dataset.labelHome}</a>
+          <a class="expanded-menu-section-header-link js-event-hm-menu" href="/">${dataset.labelHome}</a>
         </strong>
       </div>
       ${data.sections.map(section => {
         return `<div class="expanded-menu-col section-${section.title.toLowerCase().replace(/ /g,'-')}">
           <div class="expanded-menu-section">
             <strong class="expanded-menu-section-header">
-              <a class="expanded-menu-section-header-link js-expandable-mobile" href="#">${section.title}</a>
+              <a class="expanded-menu-section-header-link js-expandable-mobile js-event-hm-menu" href="#">${section.title}</a>
               <span class="expanded-menu-section-header-arrow js-expandable-mobile"><svg class="expanded-menu-section-header-arrow-svg" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><path d="M16,5.1c0,0.4-0.1,0.7-0.4,0.9l-6.7,6.7C8.7,13,8.4,13.1,8,13.1c-0.4,0-0.7-0.1-0.9-0.4L0.4,6C0.1,5.8,0,5.5,0,5.1	c0-0.4,0.1-0.7,0.4-0.9l0.8-0.8C1.4,3.1,1.7,3,2.1,3C2.4,3,2.8,3.1,3,3.4l5,5l5-5C13.2,3.1,13.6,3,13.9,3c0.4,0,0.7,0.1,0.9,0.4
     l0.8,0.8C15.9,4.4,16,4.7,16,5.1z"></path></svg></span>
             </strong>
             <div class="expanded-menu-dropdown">
               ${section.links.map(link => {
-                return `<a class="expanded-menu-dropdown-link" href="${link.url}">${link.name}</a>`;
+                return `<a class="expanded-menu-dropdown-link js-event-hm-menu" href="${link.url}">${link.name}</a>`;
               }).join(' ')}
             </div>
           </div>

--- a/src/js/tracking-you/index.js
+++ b/src/js/tracking-you/index.js
@@ -35,7 +35,6 @@ export default function setupAnalytics() {
       eventString ==> eventLabel
   */
   function reportGA(eventAction, eventLabel, eventCategory = 'click') {
-    console.log("ReportGA", eventCategory, eventAction, eventLabel);
     if(typeof(ga) !== 'undefined') {
       ga('send', 'event', eventCategory, eventAction, eventLabel);
       ga('tracker2.send', 'event', eventCategory, eventAction, eventLabel);
@@ -158,7 +157,6 @@ export default function setupAnalytics() {
   // Note this generates a function for use by an event listener.
   const linkHandler = (href, eventAction, eventLabel, follow = true) => (event) => {
     // Fire off reports to Google Analytics.
-    console.log("linkhandler",eventAction,eventLabel);
     reportGA(eventAction, eventLabel);
     // we are using beacon by default, if it's available
     // window.ga('send', 'event', 'click', eventAction, eventLabel, { transport: 'beacon' });
@@ -228,11 +226,13 @@ export default function setupAnalytics() {
         link.addEventListener('click', linkHandler(link.href, 'homepage-video', videoUrl, false));
       });
       // Report clicks on links in the menu.
-      document.querySelectorAll('a.expanded-menu-dropdown-link, a.expanded-menu-section-header-link').forEach(link => {
-        link.addEventListener('click', linkHandler(link.href, 'homepage-menu', link.href));
-      });
+      document.querySelector('cagov-navoverlay').addEventListener('click', function(event) {
+        if(event.target.classList.contains('js-event-hm-menu')) {
+          linkHandler(window.location.pathname, 'homepage-menu', event.target.textContent.trim());
+        }
+      })
       // Report clicks on Want to Know section.
-      document.querySelectorAll('a.faq-item-link').forEach(link => {
+      document.querySelectorAll('.js-event-hm-wtk').forEach(link => {
         link.addEventListener('click', linkHandler(link.href, 'homepage-want to know', link.href));
       });
       // Report clicks on footer links.

--- a/src/js/tracking-you/index.js
+++ b/src/js/tracking-you/index.js
@@ -228,7 +228,7 @@ export default function setupAnalytics() {
       // Report clicks on links in the menu.
       document.querySelector('cagov-navoverlay').addEventListener('click', function(event) {
         if(event.target.classList.contains('js-event-hm-menu')) {
-          linkHandler(window.location.pathname, 'homepage-menu', event.target.textContent.trim());
+          reportGA('click', 'homepage-menu', event.target.textContent.trim());
         }
       })
       // Report clicks on Want to Know section.


### PR DESCRIPTION
Problem: Britt noticed that the homepage want to know click events stopped tracking clicks.

Cause: The event handler was no longer looking at a class that in use

Solution: We can fix this by following the convention of using class hooks with the js- prefix for event hooks. We shouldn't attach style rules to these classes, only use js-whatever for javascript. Then it will be easier to notice if event hooks are being changed when devs are modifying HTML.

Changes:
- Switched class references to use js- prefixed classnames for the events which were very specific in the homepage event tracking'
- changed the classes to match on the page and in component
- Removed commented out code

I documented the js- prefix convention in the event tracking wiki: https://github.com/cagov/covid19/wiki/Tracking-Events