### PR TITLE
Ccg 1362/bug in messaging

### DIFF
--- a/pages/_includes/footer.njk
+++ b/pages/_includes/footer.njk
@@ -18,7 +18,7 @@ ga('tracker3.send', 'pageview');
 	data-question="{{text.is_this_page_useful}}"
 	data-yes="{{text.answer_yes}}"
 	data-no="{{text.answer_no}}"
-	data-comment-prompt="{{text.good_what_were_you_looking_for}}"
+	data-positive-comment-prompt="{{text.good_what_were_you_looking_for}}"
 	data-comment-prompt="{{text.additional_comments}}"
 	data-thanks-feedback="{{text.thank_you_for_your_feedback}}"
 	data-thanks-comments="{{text.thank_you_for_your_comments}}"

--- a/pages/guidancefeed/cdph/c528f9ce6020eece25a2fca791ad64b1.html
+++ b/pages/guidancefeed/cdph/c528f9ce6020eece25a2fca791ad64b1.html
@@ -1,0 +1,12 @@
+---
+layout: "page.njk"
+title: "State Officials Announce Latest COVID-19 Facts"
+meta: "Today, the California Department of Public Health (CDPH) released the most recent statistics on COVID-19, including data on intensive care unit (ICU) capacity across the state."
+tags: "guidancefeed"
+url: "https://www.cdph.ca.gov/Programs/OPA/Pages/NR21-026.aspx"
+author: "California Department of Public Health"
+publishdate: "2021-01-21T00:00:00.000Z"
+permalink: false
+---
+
+<p><a href="https://www.cdph.ca.gov/Programs/OPA/Pages/NR21-026.aspx">State Officials Announce Latest COVID-19 Facts</a></p><p>Today, the California Department of Public Health (CDPH) released the most recent statistics on COVID-19, including data on intensive care unit (ICU) capacity across the state.</p>

--- a/pages/guidancefeed/gov/45461.html
+++ b/pages/guidancefeed/gov/45461.html
@@ -1,0 +1,12 @@
+---
+layout: "page.njk"
+title: "Governor Newsom Signs Executive Order in Response to COVID-19 Pandemic 1.21.21"
+meta: "SACRAMENTO – Governor Gavin Newsom today signed an executive order in response to the COVID-19 pandemic, extending the validity of medical cannabis identification cards that would otherwise have expired. The text of the Governor’s executive order can be found here and a copy can be found here. ###"
+tags: "guidancefeed"
+url: "https://www.gov.ca.gov/2021/01/21/governor-newsom-signs-executive-order-in-response-to-covid-19-pandemic-1-21-21/"
+author: "State of California"
+publishdate: "2021-01-21T20:43:09Z"
+permalink: false
+---
+
+<p><a href="https://www.gov.ca.gov/2021/01/21/governor-newsom-signs-executive-order-in-response-to-covid-19-pandemic-1-21-21/">Governor Newsom Signs Executive Order in Response to COVID-19 Pandemic 1.21.21</a></p><p>SACRAMENTO – Governor Gavin Newsom today signed an executive order in response to the COVID-19 pandemic, extending the validity of medical cannabis identification cards that would otherwise have expired. The text of the Governor’s executive order can be found here and a copy can be found here. ###</p>

--- a/pages/wordpress-posts/healthcare.html
+++ b/pages/wordpress-posts/healthcare.html
@@ -3,7 +3,7 @@ layout: "page.njk"
 title: "Healthcare and coverage"
 meta: "Answers about coronavirus / COVID-19 healthcare and health insurance in California, including testing and treatment costs, waived fees, masks, and the latest global research."
 author: "State of California"
-publishdate: "2021-01-08T18:40:01Z"
+publishdate: "2021-01-22T01:06:32Z"
 tags: ["translate"]
 addtositemap: true
 ---
@@ -152,11 +152,11 @@ addtositemap: true
 
 
 
-<h4 class="wp-accordion">Do Medicare or Medicare Advantage Plans cover coronavirus tests or coronavirus antibody tests?</h4>
+<h4 class="wp-accordion">Do Medicare or Medicare Advantage Plans cover coronavirus tests and COVID-19 vaccines?</h4>
 
 
 
-<p class="wp-accordion-content">Yes. Both plans cover <a href="https://www.medicare.gov/coverage/coronavirus-disease-2019-covid-19-tests">diagnostic</a> and <a href="https://www.medicare.gov/coverage/coronavirus-disease-2019-covid-19-antibody-test">antibody tests</a> at no cost.</p>
+<p class="wp-accordion-content">Yes. Both Medicare and Medicare Advantage plans cover coronavirus tests<strong> </strong>and COVID-19 vaccines at no cost.</p>
 
 
 


### PR DESCRIPTION
The prompt after a negative response was chosen was inappropriate because the same data attribute name was used 

Fixed the attribute name fixing the bug

ticket #CCG-1362