### PR TITLE
fix the strings passed into feedback widget

### DIFF
--- a/pages/_includes/footer.njk
+++ b/pages/_includes/footer.njk
@@ -18,7 +18,7 @@ ga('tracker3.send', 'pageview');
 	data-question="{{text.is_this_page_useful}}"
 	data-yes="{{text.answer_yes}}"
 	data-no="{{text.answer_no}}"
-	data-comment-prompt="{{text.good_what_were_you_looking_for}}"
+	data-positive-comment-prompt="{{text.good_what_were_you_looking_for}}"
 	data-comment-prompt="{{text.additional_comments}}"
 	data-thanks-feedback="{{text.thank_you_for_your_feedback}}"
 	data-thanks-comments="{{text.thank_you_for_your_comments}}"


### PR DESCRIPTION
This has been merged to preproduction and tested there, wrong string was being presented during feedback flow