### PR TITLE
Fix captions on missingness chart to be left-aligned.

### DIFF
--- a/src/js/equity-dash/charts/data-completeness/draw.js
+++ b/src/js/equity-dash/charts/data-completeness/draw.js
@@ -149,9 +149,9 @@ function drawBars(svg, x, y, yAxis, stackedData, color, data, tooltip, translati
         })
         .attr("x", d => {
           if (d.PERCENT_COMPLETE === null) {
-            return x(0) + 309;
+            return x(0) + 72;
           } else {
-            return x(0) + 256;
+            return x(0) + 19;
           }
         })
         .attr("height", y.bandwidth())
@@ -174,7 +174,7 @@ function drawBars(svg, x, y, yAxis, stackedData, color, data, tooltip, translati
             ).toFixed(1) : "0"}%</tspan> ${translations['percent-change-previous-month']}`;
           }
         })
-        .attr('text-anchor', 'end');
+        .attr('text-anchor', 'start');
     });
 
   svg.append("g").call(yAxis);


### PR DESCRIPTION
For some reason, the captions on the missingness chart were originally implemented as text-anchor: end (right aligned). So the code basically asssumed the text was a certain length, positioned to the END of it, and then wrote the text out. Needless to say, they should be left-aligned. The right-alignment has significant display issues with longer text, and made for unpredicatble spacing on the left side. Ashley stumbled across this when she lengthened a caption. Don't know why there were implemented this way, but this fixes it.

