### PR TITLE
remove the dashboard code from the IE11 bundle

### DIFF
--- a/src/js/es5.js
+++ b/src/js/es5.js
@@ -10,7 +10,7 @@ import './plasma/index.js';
 import './feature-detect/webp.js';
 import './menu/index.js';
 import './roadmap/index.js';
-import './dashboard/index.js';
+// import './dashboard/index.js';
 import './equity-dash/index.js';
 import './equity-dash/charts/ie11.scss';
 


### PR DESCRIPTION
Yep, just commenting out the dashboard code in the IE bundle

There are several errors in this code that breaks that page specifically, those will be addressed in CCG-1411. The CCG-1410 ticket prevents that problematic code from also breaking other pages in this browser