### PR TITLE
remove the dashboard code from the IE11 bundle

### DIFF
--- a/src/js/es5.js
+++ b/src/js/es5.js
@@ -10,7 +10,7 @@ import './plasma/index.js';
 import './feature-detect/webp.js';
 import './menu/index.js';
 import './roadmap/index.js';
-import './dashboard/index.js';
+// import './dashboard/index.js';
 import './equity-dash/index.js';
 import './equity-dash/charts/ie11.scss';
 


### PR DESCRIPTION
This page is broken in IE11, this code change fixes it and unfortunately does not break state dashboard anymore than it already is in IE11.

This change has been tested in preproduction