### PR TITLE
added missing blue color class to the general.scss

### DIFF
--- a/src/css/_general.scss
+++ b/src/css/_general.scss
@@ -758,6 +758,12 @@ li,
 .color-purple-hover:focus {
   color: $darkblue !important;
 }
+.color-blue {
+  color: $blue !important;
+}
+.color-blue-hover:hover, .color-blue-hover:focus {
+  color: $blue !important;
+}
 .bg-blue {
   color: $blue !important;
 }


### PR DESCRIPTION
so, editors can easily add .color-blue class to the text blocks in wp posts