### PR TITLE
fixing timeout for puppeteer

### DIFF
--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -37,6 +37,7 @@ beforeAll(async () => {
     args: [`--window-size=${width},${height}`]
   });
   page = await browser.newPage();
+  page.setDefaultNavigationTimeout(timeout);   // change timeout
   await page.setViewport({ width, height });
 });
 


### PR DESCRIPTION
This should fix a lot of the automated testing errors.  Some processes are taking 32+ seconds to run, this will set the timeout to 60s along with the other timeouts.