### PR TITLE
Fixed a missing </a> in a translation.

### DIFF
--- a/pages/translated-posts/housing-and-homelessness-zh-hant.html
+++ b/pages/translated-posts/housing-and-homelessness-zh-hant.html
@@ -140,7 +140,7 @@ addtositemap: true
 
 
 
-<p class="wp-accordion-content">可能會為您和您的家人提供一間汽車旅館房間或酒店房間。請聯絡當地無家可歸者</a>持續性護理機構<a href="https://www.bcsh.ca.gov/hcfc/documents/coc_poc.pdf">，以讓您獲得此服務。</p>
+<p class="wp-accordion-content">可能會為您和您的家人提供一間汽車旅館房間或酒店房間。請聯絡當地無家可歸者</a>持續性護理機構<a href="https://www.bcsh.ca.gov/hcfc/documents/coc_poc.pdf">，以讓您獲得此服務。</a></p>
 
 
 


### PR DESCRIPTION
Translation tag missing content.

Specifically, housing-and-homelessness-zh-hant.html .

- [ ] Let Avantpage know