### PR TITLE
use different urls for spanish feedback

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -639,6 +639,10 @@ module.exports = function(eleventyConfig) {
     const langRecord = getLangRecord(tags);
     return langRecord['pulse-survey'];
   });
+  eleventyConfig.addFilter('feedbackSurveyUrl', (tags, field) => {
+    const langRecord = getLangRecord(tags);
+    return langRecord[field];
+  });
 
   eleventyConfig.addFilter('publishdateorfiledate', page => {
     let out = (page.data

--- a/pages/_data/langData.json
+++ b/pages/_data/langData.json
@@ -12,6 +12,8 @@
       "rtl": false,
       "npi-survey": "https://www.surveymonkey.com/r/GFDXW5B?source=covid",
       "pulse-survey": "",
+      "feedback-survey-positive": "https://ethn.io/85017",
+      "feedback-survey-negative": "https://ethn.io/77745",
       "enabled": true
     },
     {
@@ -26,6 +28,8 @@
       "rtl": false,
       "npi-survey": "https://www.surveymonkey.com/r/GFDXW5B?source=covid",
       "pulse-survey": "",
+      "feedback-survey-positive": "https://ethn.io/52351",
+      "feedback-survey-negative": "https://ethn.io/73497",
       "enabled": true
     },
     {
@@ -40,6 +44,8 @@
       "rtl": false,
       "npi-survey": "https://www.surveymonkey.com/r/GFDXW5B?source=covid",
       "pulse-survey": "",
+      "feedback-survey-positive": "https://ethn.io/85017",
+      "feedback-survey-negative": "https://ethn.io/77745",
       "enabled": true
     },
     {
@@ -54,6 +60,8 @@
       "rtl": true,
       "npi-survey": "https://www.surveymonkey.com/r/GFDXW5B?source=covid",
       "pulse-survey": "",
+      "feedback-survey-positive": "https://ethn.io/85017",
+      "feedback-survey-negative": "https://ethn.io/77745",
       "enabled": true
     },
     {
@@ -68,6 +76,8 @@
       "rtl": false,
       "npi-survey": "https://www.surveymonkey.com/r/GFDXW5B?source=covid",
       "pulse-survey": "",
+      "feedback-survey-positive": "https://ethn.io/85017",
+      "feedback-survey-negative": "https://ethn.io/77745",
       "enabled": true
     },
     {
@@ -82,6 +92,8 @@
       "rtl": false,
       "npi-survey": "https://www.surveymonkey.com/r/GFDXW5B?source=covid",
       "pulse-survey": "",
+      "feedback-survey-positive": "https://ethn.io/85017",
+      "feedback-survey-negative": "https://ethn.io/77745",
       "enabled": true
     },
     {
@@ -96,6 +108,8 @@
       "rtl": false,
       "npi-survey": "https://www.surveymonkey.com/r/GFDXW5B?source=covid",
       "pulse-survey": "",
+      "feedback-survey-positive": "https://ethn.io/85017",
+      "feedback-survey-negative": "https://ethn.io/77745",
       "enabled": true
     },
     {
@@ -110,6 +124,8 @@
       "rtl": false,
       "npi-survey": "https://www.surveymonkey.com/r/GFDXW5B?source=covid",
       "pulse-survey": "",
+      "feedback-survey-positive": "https://ethn.io/85017",
+      "feedback-survey-negative": "https://ethn.io/77745",
       "enabled": true
     }
   ]

--- a/pages/_includes/footer.njk
+++ b/pages/_includes/footer.njk
@@ -26,10 +26,10 @@ ga('tracker3.send', 'pageview');
 	data-required-field="{{text.this_field_required}}"
 	data-character-limit="{{text.character_limit}}"
 	data-anything-to-add="{{text.anything_to_add}}"
-	data-positive-survey-url="{{text.positive_survey_url}}"
+	data-positive-survey-url="{{ tags | feedbackSurveyUrl('feedback-survey-positive') | safe }}"
 	data-take-the-survey="{{text.take_the_survey}}"
 	data-any-other-feedback="{{text.any_other_feedback}}"
-	data-negative-survey-url="{{text.negative_survey_url}}"
+	data-negative-survey-url="{{ tags | feedbackSurveyUrl('feedback-survey-negative') | safe }}"
 	data-take-our-survey="{{text.take_our_survey}}"
 	></cagov-pagefeedback>	
 </pagerating-section>


### PR DESCRIPTION
We want different urls on the Spanish pages for the links presented to users after they submit the single field feedback form at the bottom of every page.

- Added new data to the langData file for all languages
- Added a new 11ty filter to get the language specific value
- Called this new filter passing in the field name so we can reuse it for positive and negative survey urls

