### PR TITLE
specify version of force resolutions package

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "axios": "^0.21.1"
   },
   "scripts": {
-    "preinstall": "npx npm-force-resolutions",
+    "preinstall": "npx npm-force-resolutions@0.0.3",
     "dev": "cross-env NODE_ENV=development npm run start",
     "start": "npm run watch",
     "serve": "npx @11ty/eleventy --serve --quiet",


### PR DESCRIPTION
using npx to do an install and then an execution should be avoided in the future...

this hardcoding of a specific package version should fix all the build failures