### PR TITLE
specify version of force resolutions package

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "axios": "^0.21.1"
   },
   "scripts": {
-    "preinstall": "npx npm-force-resolutions",
+    "preinstall": "npx npm-force-resolutions@0.0.3",
     "dev": "cross-env NODE_ENV=development npm run start",
     "start": "npm run watch",
     "serve": "npx @11ty/eleventy --serve --quiet",


### PR DESCRIPTION
This does fix the build problems

But this is a temporary solution, future fix will remove hardcoded package version and hopefully avoid using npx to do the install as well as the execution