### PR TITLE
Revert "removed container's padding when that container is inside of another …"

### DIFF
--- a/src/css/_general.scss
+++ b/src/css/_general.scss
@@ -1932,11 +1932,6 @@ button#dropdown-menu-button:focus {
   border-radius: 50px !important;
 }
 
-.container .container {
-  padding-left: 0;
-  padding-right: 0;
-}
-
 /* Font size */
 .font-size-2em {
   font-size: 2rem !important;


### PR DESCRIPTION
Reverts cagov/covid19#3516

This change causes problems with mobile layouts on several pages like /vaccines and /equity because the containers are nested in multiple places.

The original bug is relatively minor and the side effects of this change degrade the experience on more pages so we need to revert and find a safer way to fix it.

The conflict here is due to unnecessary classes and container elements in a lot of places. If our HTML was cleaner the original fix would not have had negative side effects. Unfortunately there are too many places to take that route to a fix today.