### PR TITLE
Added substitution utility that works with both double and single curly brackets. Using this for HPI charts.

### DIFF
--- a/src/js/charts-sandbox/charts/cagov-chart-vaccines-hpi-by-people/index.js
+++ b/src/js/charts-sandbox/charts/cagov-chart-vaccines-hpi-by-people/index.js
@@ -3,7 +3,7 @@ import getTranslations from "./../../../common/get-strings-list.js";
 import getScreenResizeCharts from "./../../../common/get-window-size.js";
 import rtlOverride from "./../../../common/rtl-override.js";
 
-class CAGovVaccinesHPEPeople extends window.HTMLElement {
+class CAGovVaccinesHPIPeople extends window.HTMLElement {
   connectedCallback() {
     console.log("Loading CAGovVaccinationGroupsAge");
     this.translationsObj = getTranslations(this);
@@ -394,5 +394,5 @@ class CAGovVaccinesHPEPeople extends window.HTMLElement {
 
 window.customElements.define(
   "cagov-chart-vaccines-hpi-by-people",
-  CAGovVaccinesHPEPeople
+  CAGovVaccinesHPIPeople
 );

--- a/src/js/common/apply-substitutions.js
+++ b/src/js/common/apply-substitutions.js
@@ -1,8 +1,8 @@
 /* Substitute strings in text using either {{VAR}} or {var}, case-sensitive
 */
 
-export default function applySubstitutions(textString, subdict) {
-    for (const key in subdict) {
+export default function applySubstitutions(textString, substitutions) {
+    for (const key in substitutions) {
         const value = subdict[key];
         textString = textString.replace('{{' + key + '}}', value);
         textString = textString.replace('{' + key + '}', value);

--- a/src/js/common/apply-substitutions.js
+++ b/src/js/common/apply-substitutions.js
@@ -1,0 +1,11 @@
+/* Substitute strings in text using either {{VAR}} or {var}, case-sensitive
+*/
+
+export default function applySubstitutions(textString, subdict) {
+    for (const key in subdict) {
+        const value = subdict[key];
+        textString = textString.replace('{{' + key + '}}', value);
+        textString = textString.replace('{' + key + '}', value);
+    }
+    return textString;
+}

--- a/src/js/vaccines/charts/cagov-chart-vaccines-hpi-by-dose/index.js
+++ b/src/js/vaccines/charts/cagov-chart-vaccines-hpi-by-dose/index.js
@@ -6,7 +6,7 @@ import rtlOverride from "./../../../common/rtl-override.js";
 import applySubstitutions from "./../../../common/apply-substitutions.js";
 import { reformatReadableDate } from "./../../../common/readable-date.js";
 
-class CAGovVaccinesHPEDose extends window.HTMLElement {
+class CAGovVaccinesHPIDose extends window.HTMLElement {
   connectedCallback() {
     console.log("Loading CAGovVaccinationGroupsAge");
     this.translationsObj = getTranslations(this);
@@ -277,8 +277,8 @@ class CAGovVaccinesHPEDose extends window.HTMLElement {
       this.dimensions.width = this.dimensions.margin.left+this.dimensions.bar_hspace*categories.length + this.dimensions.margin.right;
 
       let footerReplacementDict = {
-        'PUBLISHED_DATE':reformatReadableDate( this.metadata['PUBLISHED_DATE'] ),
-        'LATEST_ADMINISTERED_DATE':reformatReadableDate( this.metadata['LATEST_ADMINISTERED_DATE'] ),
+        'PUBLISHED_DATE' : reformatReadableDate( this.metadata['PUBLISHED_DATE'] ),
+        'LATEST_ADMINISTERED_DATE' : reformatReadableDate( this.metadata['LATEST_ADMINISTERED_DATE'] ),
       };
       let footerDisplayText = applySubstitutions(this.translationsObj.footerText, footerReplacementDict);
 
@@ -335,5 +335,5 @@ class CAGovVaccinesHPEDose extends window.HTMLElement {
 
 window.customElements.define(
   "cagov-chart-vaccines-hpi-by-dose",
-  CAGovVaccinesHPEDose
+  CAGovVaccinesHPIDose
 );

--- a/src/js/vaccines/charts/cagov-chart-vaccines-hpi-by-dose/index.js
+++ b/src/js/vaccines/charts/cagov-chart-vaccines-hpi-by-dose/index.js
@@ -3,6 +3,7 @@ import template from "./template.js";
 import getTranslations from "./../../../common/get-strings-list.js";
 import getScreenResizeCharts from "./../../../common/get-window-size.js";
 import rtlOverride from "./../../../common/rtl-override.js";
+import applySubstitutions from "./../../../common/apply-substitutions.js";
 import { reformatReadableDate } from "./../../../common/readable-date.js";
 
 class CAGovVaccinesHPEDose extends window.HTMLElement {
@@ -136,7 +137,8 @@ class CAGovVaccinesHPEDose extends window.HTMLElement {
   }
 
   ariaLabel(d) {
-    let label = `${this.pctFormatter.format(d.COMBINED_DOSES_RATIO)} ${this.translationsObj.legendLabel1} in ${this.translationsObj.barLabel.replace('{N}',d.HPIQUARTILE)}`;
+    const barLabel = applySubstitutions(this.translationsObj.barLabel, {'N':d.HPIQUARTILE});
+    let label = `${this.pctFormatter.format(d.COMBINED_DOSES_RATIO)} ${this.translationsObj.legendLabel1} in ${barLabel}`;
     return label;
   }
 
@@ -181,7 +183,7 @@ class CAGovVaccinesHPEDose extends window.HTMLElement {
       .attr("y", (d, i) => yScale(0) + 20)
       .attr("x", (d, i) => xScale(i)+xScale.bandwidth()/2)
       // .attr("width", x.bandwidth() / 4)
-      .text(d =>  this.translationsObj.barLabel.replace('{N}',d.HPIQUARTILE))
+      .text(d =>  applySubstitutions(this.translationsObj.barLabel, {'N':d.HPIQUARTILE}))
       .attr('text-anchor','middle')
   }
 
@@ -274,13 +276,14 @@ class CAGovVaccinesHPEDose extends window.HTMLElement {
       let categories = data.map(rec => (rec.HPIQUARTILE-1));
       this.dimensions.width = this.dimensions.margin.left+this.dimensions.bar_hspace*categories.length + this.dimensions.margin.right;
 
-      let footerDisplayText = this.translationsObj.footerText;
-      footerDisplayText = footerDisplayText.replace('{PUBLISHED_DATE}', 
-        reformatReadableDate( this.metadata['PUBLISHED_DATE'] ));
-      footerDisplayText = footerDisplayText.replace('{LATEST_ADMINISTERED_DATE}', 
-        reformatReadableDate( this.metadata['LATEST_ADMINISTERED_DATE'] ));
+      let footerReplacementDict = {
+        'PUBLISHED_DATE':reformatReadableDate( this.metadata['PUBLISHED_DATE'] ),
+        'LATEST_ADMINISTERED_DATE':reformatReadableDate( this.metadata['LATEST_ADMINISTERED_DATE'] ),
+      };
+      let footerDisplayText = applySubstitutions(this.translationsObj.footerText, footerReplacementDict);
+
       // update the display date
-      this.translationsObj.footerDisplayDate = footerDisplayText;
+      // this.translationsObj.footerDisplayDate = footerDisplayText;
       d3.select(this.querySelector(".chart-data-label")).text(footerDisplayText);
 
 

--- a/src/js/vaccines/charts/cagov-chart-vaccines-hpi-by-people/index.js
+++ b/src/js/vaccines/charts/cagov-chart-vaccines-hpi-by-people/index.js
@@ -6,7 +6,7 @@ import rtlOverride from "./../../../common/rtl-override.js";
 import applySubstitutions from "./../../../common/apply-substitutions.js";
 import { reformatReadableDate } from "./../../../common/readable-date.js";
 
-class CAGovVaccinesHPEPeople extends window.HTMLElement {
+class CAGovVaccinesHPIPeople extends window.HTMLElement {
   connectedCallback() {
     console.log("Loading CAGovVaccinationGroupsAge");
     this.translationsObj = getTranslations(this);
@@ -314,8 +314,8 @@ class CAGovVaccinesHPEPeople extends window.HTMLElement {
       this.dimensions.width = this.dimensions.margin.left+this.dimensions.bar_hspace*categories.length + this.dimensions.margin.right;
 
       let footerReplacementDict = {
-        'PUBLISHED_DATE':reformatReadableDate( this.metadata['PUBLISHED_DATE'] ),
-        'LATEST_ADMINISTERED_DATE':reformatReadableDate( this.metadata['LATEST_ADMINISTERED_DATE'] ),
+        'PUBLISHED_DATE' : reformatReadableDate( this.metadata['PUBLISHED_DATE'] ),
+        'LATEST_ADMINISTERED_DATE' : reformatReadableDate( this.metadata['LATEST_ADMINISTERED_DATE'] ),
       };
       let footerDisplayText = applySubstitutions(this.translationsObj.footerText, footerReplacementDict);
 
@@ -378,5 +378,5 @@ class CAGovVaccinesHPEPeople extends window.HTMLElement {
 
 window.customElements.define(
   "cagov-chart-vaccines-hpi-by-people",
-  CAGovVaccinesHPEPeople
+  CAGovVaccinesHPIPeople
 );

--- a/src/js/vaccines/charts/cagov-chart-vaccines-hpi-by-people/index.js
+++ b/src/js/vaccines/charts/cagov-chart-vaccines-hpi-by-people/index.js
@@ -3,6 +3,7 @@ import template from "./template.js";
 import getTranslations from "./../../../common/get-strings-list.js";
 import getScreenResizeCharts from "./../../../common/get-window-size.js";
 import rtlOverride from "./../../../common/rtl-override.js";
+import applySubstitutions from "./../../../common/apply-substitutions.js";
 import { reformatReadableDate } from "./../../../common/readable-date.js";
 
 class CAGovVaccinesHPEPeople extends window.HTMLElement {
@@ -136,7 +137,8 @@ class CAGovVaccinesHPEPeople extends window.HTMLElement {
   }
 
   ariaLabel(d) {
-    let label = `${this.translationsObj.barLabel.replace('{N}',d.D.HPIQUARTILE)} `;
+    let label = applySubstitutions(this.translationsObj.barLabel, {'N':d.D.HPIQUARTILE});
+    // let label = `${this.translationsObj.barLabel.replace('{N}',d.D.HPIQUARTILE)} `;
     if(d.KEY == "FIRST_DOSE_RATIO") {
       label += `${this.pctFormatter.format(d.D.FIRST_DOSE_RATIO)} ${this.translationsObj.legendLabel1}`;
     } else {
@@ -196,11 +198,8 @@ class CAGovVaccinesHPEPeople extends window.HTMLElement {
       .attr("class", "bar-lower-label")
       .attr("y", (d, i) => yScale(0) + 20)
       .attr("x", (d, i) => xScaleOuter.bandwidth()/2)
-      .text(d =>  this.translationsObj.barLabel.replace('{N}',d.HPIQUARTILE))
+      .text(d =>  applySubstitutions(this.translationsObj.barLabel, {'N':d.HPIQUARTILE}))
       .attr('text-anchor','middle')
-
-
-
 
   }
 
@@ -313,13 +312,15 @@ class CAGovVaccinesHPEPeople extends window.HTMLElement {
       let categories = data.map(rec => (rec.HPIQUARTILE));
       let subcategories = ['FIRST_DOSE_RATIO','COMPLETED_DOSE_RATIO'];
       this.dimensions.width = this.dimensions.margin.left+this.dimensions.bar_hspace*categories.length + this.dimensions.margin.right;
-      let footerDisplayText = this.translationsObj.footerText;
-      footerDisplayText = footerDisplayText.replace('{PUBLISHED_DATE}', 
-        reformatReadableDate( this.metadata['PUBLISHED_DATE'] ));
-      footerDisplayText = footerDisplayText.replace('{LATEST_ADMINISTERED_DATE}', 
-        reformatReadableDate( this.metadata['LATEST_ADMINISTERED_DATE'] ));
+
+      let footerReplacementDict = {
+        'PUBLISHED_DATE':reformatReadableDate( this.metadata['PUBLISHED_DATE'] ),
+        'LATEST_ADMINISTERED_DATE':reformatReadableDate( this.metadata['LATEST_ADMINISTERED_DATE'] ),
+      };
+      let footerDisplayText = applySubstitutions(this.translationsObj.footerText, footerReplacementDict);
+
       // update the display date
-      this.translationsObj.footerDisplayDate = footerDisplayText;
+      // this.translationsObj.footerDisplayDate = footerDisplayText;
       d3.select(this.querySelector(".chart-data-label")).text(footerDisplayText);
 
       let max_y = d3.max(data, d => d.FIRST_DOSE_RATIO)


### PR DESCRIPTION
The intent is to leave in single-curly support, but favor double-curlies, so that we can incrementally fix the substitution strings on wordpress without breaking anything.