### PR TITLE
remove max width on charts because width is controlled by parent

### DIFF
--- a/src/css/_charts.scss
+++ b/src/css/_charts.scss
@@ -16,10 +16,6 @@
     display: none;
   }
 
-  .svg-holder {
-    max-width: 613px;
-  }
-
   .svg-holder svg {
     width: 100%;
   }


### PR DESCRIPTION
The problem reported by Adam is that charts on desktop layouts aren't centered and their footnotes are not the same width.

This CSS change affects all D3 charts but it makes them look slightly better at big screen sizes on /vaccine and /equity and doesn't break the layout on mobile