### PR TITLE
Added date hack for HPI charts. Removed some console logging.

### DIFF
--- a/src/js/charts-sandbox/charts/cagov-chart-vaccines-hpi-by-dose/index.js
+++ b/src/js/charts-sandbox/charts/cagov-chart-vaccines-hpi-by-dose/index.js
@@ -297,7 +297,7 @@ class CAGovVaccinesHPIDose extends window.HTMLElement {
 
         this.svg.selectAll("g").remove();
 
-        console.log("yscale test",this.yScale(0.5))
+        // console.log("yscale test",this.yScale(0.5))
 
         this.writeBars.call(this, this.svg, data, this.yScale, this.xScale);
         this.writeLegend.call(this, this.svg, data, this.yScale, this.xScale);

--- a/src/js/charts-sandbox/charts/cagov-chart-vaccines-hpi-by-people/index.js
+++ b/src/js/charts-sandbox/charts/cagov-chart-vaccines-hpi-by-people/index.js
@@ -369,7 +369,7 @@ class CAGovVaccinesHPIPeople extends window.HTMLElement {
 
         this.svg.selectAll("g").remove();
 
-        console.log("yscale test",this.yScale(0.5))
+        // console.log("yscale test",this.yScale(0.5))
 
         this.writeBars.call(this, this.svg, data, this.yScale, this.xScaleOuter, this.xScaleInner);
         this.writeLegend.call(this, this.svg, data, this.yScale, this.xScaleOuter, this.xScaleInner);

--- a/src/js/common/charts/simple-barchart.js
+++ b/src/js/common/charts/simple-barchart.js
@@ -61,7 +61,7 @@ function writeLegend(svg, data, x, y) {
 function writeBars(svg, data, x, y) {
     let max_x_domain = x.domain()[1];
 
-    console.log("Write bars data=",data);
+    // console.log("Write bars data=",data);
 
     let groups = svg.append("g")
       .selectAll("g")
@@ -192,7 +192,7 @@ export default function renderChart(extrasFunc = null) {
     .paddingInner(5.0/6.0)
     .paddingOuter(0.5);
 
-    console.log("this.y",this.y);
+    // console.log("this.y",this.y);
   
     // Position for labels.
     // this.yAxis = (g) =>

--- a/src/js/common/readable-date.js
+++ b/src/js/common/readable-date.js
@@ -12,6 +12,24 @@ function parseSnowflakeDate(dateStr) {
     return new Date(yyyy,mm-1,dd);
 }
 
+// Return local date string in form YYYY-MM-DD adjusted for dayDelta (0 for today -1 for yesterday)
+//
+function getSnowflakeStyleDate(dayDelta) {
+    let date = new Date();
+    date.setDate(date.getDate() + dayDelta);
+    // return date.toLocaleString( 'us', { year: "numeric", month: '2-digit', year:'2-digit' });
+    let month = '' + (date.getMonth() + 1),
+    day = '' + date.getDate(),
+    year = date.getFullYear();
+
+    if (month.length < 2) 
+        month = '0' + month;
+    if (day.length < 2) 
+        day = '0' + day;
+
+    return [year, month, day].join('-');
+}
+
 // Date converter for use on chart footnotes.
 // Converts a string (typically from Snowflake) 
 // in the form YYYY-MM-DD
@@ -30,4 +48,4 @@ function reformatReadableDate(dateStr, // expects YYYY-MM-DD
 }
 
 
-export {reformatReadableDate, parseSnowflakeDate};
+export {reformatReadableDate, getSnowflakeStyleDate, parseSnowflakeDate};

--- a/src/js/vaccines/charts/cagov-chart-vaccination-groups-age/index.js
+++ b/src/js/vaccines/charts/cagov-chart-vaccination-groups-age/index.js
@@ -183,9 +183,9 @@ class CAGovVaccinationGroupsAge extends window.HTMLElement {
       .then((response) => response.json())
       .then(
         function (alldata) {
-          console.log("Age data meta", alldata.meta);
+          // console.log("Age data meta", alldata.meta);
           this.alldata = alldata.data;
-          console.log("Age data", alldata.data);
+          // console.log("Age data", alldata.data);
           // "Unknown"
           let croppedData = alldata.data.filter(function(a){return a.CATEGORY !== 'Unknown'});
           this.alldata = croppedData;

--- a/src/js/vaccines/charts/cagov-chart-vaccination-groups-gender/index.js
+++ b/src/js/vaccines/charts/cagov-chart-vaccination-groups-gender/index.js
@@ -186,7 +186,7 @@ class CAGovVaccinationGroupsGender extends window.HTMLElement {
       .then((response) => response.json())
       .then(
         function (alldata) {
-          console.log("Gender data meta", alldata.meta);
+          // console.log("Gender data meta", alldata.meta);
           this.alldata = alldata.data;
           renderChart.call(this);
           this.resetTitle({

--- a/src/js/vaccines/charts/cagov-chart-vaccination-groups-race-ethnicity/index.js
+++ b/src/js/vaccines/charts/cagov-chart-vaccination-groups-race-ethnicity/index.js
@@ -203,7 +203,7 @@ class CAGovVaccinationGroupsRaceEthnicity extends window.HTMLElement {
       .then((response) => response.json())
       .then(
         function (alldata) {
-          console.log("Race/Eth data meta", alldata.meta);
+          // console.log("Race/Eth data meta", alldata.meta);
           // console.log("Race/Eth data data", alldata.data);
           this.alldata = alldata.data;
 

--- a/src/js/vaccines/charts/cagov-chart-vaccines-hpi-by-dose/index.js
+++ b/src/js/vaccines/charts/cagov-chart-vaccines-hpi-by-dose/index.js
@@ -4,7 +4,7 @@ import getTranslations from "./../../../common/get-strings-list.js";
 import getScreenResizeCharts from "./../../../common/get-window-size.js";
 import rtlOverride from "./../../../common/rtl-override.js";
 import applySubstitutions from "./../../../common/apply-substitutions.js";
-import { reformatReadableDate } from "./../../../common/readable-date.js";
+import { reformatReadableDate,getSnowflakeStyleDate } from "./../../../common/readable-date.js";
 
 class CAGovVaccinesHPIDose extends window.HTMLElement {
   connectedCallback() {
@@ -276,9 +276,17 @@ class CAGovVaccinesHPIDose extends window.HTMLElement {
       let categories = data.map(rec => (rec.HPIQUARTILE-1));
       this.dimensions.width = this.dimensions.margin.left+this.dimensions.bar_hspace*categories.length + this.dimensions.margin.right;
 
+      const todayStr = getSnowflakeStyleDate(0);
+      let adminDateStr = this.metadata['LATEST_ADMINISTERED_DATE'];
+
+      if (adminDateStr == todayStr) {
+        const yesterdayStr = getSnowflakeStyleDate(-1);
+        adminDateStr = yesterdayStr;
+      }
+
       let footerReplacementDict = {
         'PUBLISHED_DATE' : reformatReadableDate( this.metadata['PUBLISHED_DATE'] ),
-        'LATEST_ADMINISTERED_DATE' : reformatReadableDate( this.metadata['LATEST_ADMINISTERED_DATE'] ),
+        'LATEST_ADMINISTERED_DATE' : reformatReadableDate( adminDateStr ),
       };
       let footerDisplayText = applySubstitutions(this.translationsObj.footerText, footerReplacementDict);
 

--- a/src/js/vaccines/charts/cagov-chart-vaccines-hpi-by-people/index.js
+++ b/src/js/vaccines/charts/cagov-chart-vaccines-hpi-by-people/index.js
@@ -4,7 +4,7 @@ import getTranslations from "./../../../common/get-strings-list.js";
 import getScreenResizeCharts from "./../../../common/get-window-size.js";
 import rtlOverride from "./../../../common/rtl-override.js";
 import applySubstitutions from "./../../../common/apply-substitutions.js";
-import { reformatReadableDate } from "./../../../common/readable-date.js";
+import { reformatReadableDate, getSnowflakeStyleDate } from "./../../../common/readable-date.js";
 
 class CAGovVaccinesHPIPeople extends window.HTMLElement {
   connectedCallback() {
@@ -313,9 +313,17 @@ class CAGovVaccinesHPIPeople extends window.HTMLElement {
       let subcategories = ['FIRST_DOSE_RATIO','COMPLETED_DOSE_RATIO'];
       this.dimensions.width = this.dimensions.margin.left+this.dimensions.bar_hspace*categories.length + this.dimensions.margin.right;
 
+      const todayStr = getSnowflakeStyleDate(0);
+      let adminDateStr = this.metadata['LATEST_ADMINISTERED_DATE'];
+
+      if (adminDateStr == todayStr) {
+        const yesterdayStr = getSnowflakeStyleDate(-1);
+        adminDateStr = yesterdayStr;
+      }
+
       let footerReplacementDict = {
         'PUBLISHED_DATE' : reformatReadableDate( this.metadata['PUBLISHED_DATE'] ),
-        'LATEST_ADMINISTERED_DATE' : reformatReadableDate( this.metadata['LATEST_ADMINISTERED_DATE'] ),
+        'LATEST_ADMINISTERED_DATE' : reformatReadableDate( adminDateStr ),
       };
       let footerDisplayText = applySubstitutions(this.translationsObj.footerText, footerReplacementDict);
 


### PR DESCRIPTION
The hack prevents "today" from showing up as the last_administered_date for the HPI charts (if it's set to today, we display yesterday).