### PR TITLE
Updating March 5 notes

### DIFF
--- a/pages/_includes/dashboard.njk
+++ b/pages/_includes/dashboard.njk
@@ -47,8 +47,8 @@
     <div class="container py-2">
     <div class="row pb-4">
             <div class="highlight">
-                <h3 class="color-primary mt-0">Note for March 5, 2021</h3>
-                <p>We are working on fixing an issue with the charts on this page. You can find find information on <a href="https://data.ca.gov/dataset/covid-19-cases">cases, deaths, and demographics</a>; <a href="https://data.ca.gov/dataset/covid-19-testing">tests</a>; and <a href="https://data.ca.gov/dataset/covid-19-hospital-data">hospitals and ICUs</a> in the California Open Data Portal. Additionally, the vaccines administered data for March 5, 2021, includes 135,736 doses that were not previously processed. These doses were reported between March 2, 2021, and March 3, 2021.</p>
+                <h3 class="color-primary mt-0">Note on charts</h3>
+                <p>We are working on fixing an issue with the charts on this page. You can find find information on <a href="https://data.ca.gov/dataset/covid-19-cases">cases, deaths, and demographics</a>; <a href="https://data.ca.gov/dataset/covid-19-testing">tests</a>; and <a href="https://data.ca.gov/dataset/covid-19-hospital-data">hospitals and ICUs</a> in the California Open Data Portal.</p>
             </div>
         </div>
         <div class="row pb-4">

--- a/pages/_includes/main.njk
+++ b/pages/_includes/main.njk
@@ -163,8 +163,7 @@
 						</div>
 					</div>
 					<div class="text-sm text-center text-300 ptop-12px">
-						Details about this data are available in the <a class="hero-stats-footer-slink" href="/state-dashboard/">state dashboard</a>.</br>
-						The vaccines administered data for March 5, 2021, includes 135,736 doses that were not previously processed. These doses were reported between March 2, 2021, and March 3, 2021.
+						Details about this data are available in the <a class="hero-stats-footer-slink" href="/state-dashboard/">state dashboard</a>.
 					</div><!--
 <<p class="text-center text-sm text-300 mt-4">Rates of cases and tests are based on a 7 day average with a 7 day lag.</p>
 <p class="text-center text-sm text-300 mt-3">Rates of deaths are based on a 7 day average with a 21 day lag due to delays in reporting. 


### PR DESCRIPTION
Removing notes about March 5 vaccines administered data from homepage and state dashboard 1.0.

I confirmed data has ticked over on the homepage and state dashboard 1.0.

Thanks for being available on a Saturday Jim!