### PR TITLE
use new field for first dose column

### DIFF
--- a/src/js/vaccines/charts/cagov-chart-vaccines-hpi-by-people/index.js
+++ b/src/js/vaccines/charts/cagov-chart-vaccines-hpi-by-people/index.js
@@ -181,7 +181,7 @@ class CAGovVaccinesHPIPeople extends window.HTMLElement {
         .attr("x", (d, i) => xScaleInner(i)+xScaleInner.bandwidth()/2)
         .text(d => this.pctFormatter.format(d.D[d.KEY]))
         .attr('text-anchor','middle');
-    let capFields = ['FIRST_DOSE', 'COMPLETED_DOSE'];
+    let capFields = ['FIRST_DOSE_ONLY', 'COMPLETED_DOSE'];
     let barcaps2 = groups
         .selectAll("g")
         .data(d => ['FIRST_DOSE_RATIO','COMPLETED_DOSE_RATIO'].map( key => ({'KEY':key,'D':d})))


### PR DESCRIPTION
Per Hannah:

Back of envelope math shows we have too many data points in the top chart, vaccinations should represent the 7M people vaccinated not the 10M shots given

which generate: cagov/covid-static#265

So the SQL has been updated to remove the dose 2 people from first dose counts here https://github.com/cagov/Cron/pull/106 and this PR updates the frontend to use the new FIRST_DOSE_ONLY field