### PR TITLE
Change display update times from 11am to 10am (19 GMT -> 18 GMT)

### DIFF
--- a/pages/_data/statsData.js
+++ b/pages/_data/statsData.js
@@ -7,7 +7,7 @@ const data = {
     totalDeaths: caseStats[0]['NUMBERDIED'],
     totalDeathsIncrease: caseStats[0]['NUMBERDIED_DAILYPCTCHG'] * 100,
     testsReported: caseStats[0]['TESTED'],
-    lastStatsDate: caseStats[0]['DATE'] + 'T19:00:00Z'
+    lastStatsDate: caseStats[0]['DATE'] + 'T18:00:00Z'
   }
 };
 

--- a/pages/_includes/page.njk
+++ b/pages/_includes/page.njk
@@ -43,10 +43,10 @@
               {%- if page | engSlug === "safer-economy" or page | engSlug === "data-and-tools" -%}
                 {{ "today" | formatDate2(true,tags) }}
               {%- elseif page | engSlug === "state-dashboard" -%}
-                {{ (tableauCovidMetrics[0].DATE + "T19:00:00Z") | formatDate2(true,tags,1) }}
+                {{ (tableauCovidMetrics[0].DATE + "T18:00:00Z") | formatDate2(true,tags,1) }}
               {%- elseif page | engSlug === "v2-state-dashboard" -%}
                 {# {{ (tableauCovidMetrics[0].DATE + "T19:00:00Z") | formatDate2(true,tags,1) }} #}
-                {{ (dailyStatsV2.data.cases.DATE + "T19:00:00Z") | formatDate2(true,tags,1) }}
+                {{ (dailyStatsV2.data.cases.DATE + "T18:00:00Z") | formatDate2(true,tags,1) }}
               {%- elseif page | engSlug === "equity" -%}
                 {{ (equityTopBoxes[0].lowincome_date + "T23:00:00Z") | formatDate2(true,tags,1) }}
                 {# {{ "today" | formatDate2(true,tags,-1) }} #}


### PR DESCRIPTION
Affects homepage, state-dashboard and v2-state-dashboard.  

Note: This should not be merged with master til tomorrow just after 10am.


