### PR TITLE
2021 03 09/ccg 1736

### DIFF
--- a/pages/_includes/reopening-matrix.njk
+++ b/pages/_includes/reopening-matrix.njk
@@ -1,78 +1,112 @@
 {%- set JSON = pubData[language.id].reopeningMatrixData -%}
 {%- set DataTables = ["Table1", "Table3", "Table4"] -%}
-
-{%- set MatrixLabels = JSON.Table5 -%}
-{# {% set currentRiskLevel = MatrixLabels | where("Status", "Current") %} #}
-{% set currentRiskLevel = MatrixLabels[1] %}
-{% set currentTable = "Table1" %}
-
 {%- set Headers = JSON.Table2[0] -%}
 
+{%- set MatrixLabels = JSON.Table5 -%}
+
+{%- set currentTable = "Table1" -%}
+{%- set currentRiskLevel = MatrixLabels[0] -%}
+
+{% for riskLevel in MatrixLabels -%}
+  {% if riskLevel.Status !== "" %}
+    {# {% set currentTable = riskLevel.Table %} #}
+    {# {% set currentRiskLevel = riskLevel %} #}
+  {% endif %}
+{% endfor %}
 
 {#- dynamic classnames are really cool but the purger cannot understand, hence this -#}
 <div class="d-none bg-purple-alert bg-red-alert bg-orange-alert bg-yellow-alert bg-purple-btn bg-red-btn bg-orange-btn bg-yellow-btn text-700 bg-lightblue"></div>
 
 <div class="the-matrix d-none">
+  {% set accordionExpanded = "false" %}
   {% for DataTable in DataTables -%}
     {%- set Rows = JSON[DataTable] -%}
-    <h4 class="wp-accordion">Title 11</h4>
-    <div class="wp-accordion-content" aria-expanded="true">
-      <div class="row mr-0 ml-0">
-        {% for item in Rows | reverse -%}
-          {%- set CssColor = item['_Color label'] | lower -%}
-          <div class="col-md-3 pl-0 pr-0 bg-{{CssColor}}-alert">
-            <div class="card border-0 bg-transparent pl-2">
-              <div class="pt-3 card-body text-black text-center">
-                <div class="btn-matrix bg-{{CssColor}}-btn">{{item['County tier'] | safe}}</div>
+    {% set tableRiskLevel = MatrixLabels[loop.index - 1] %}
+    
+    {% if tableRiskLevel.Status !== "" %}
+      {% set accordionExpanded = "true" %}
+    {% endif %}
 
-                {% if item['New cases'] !== "" %}
-                  <p class="card-text text-small mt-3 text-left">
-                    <span aria-hidden="true">&#8226; </span>
-                    {{item['New cases']}}
-                  </p>
-                {% endif %}
-
-                {% if item['Positive tests'] !== "" %}
-                  <p class="card-text text-small mt-3 text-left">
-                    <span aria-hidden="true">&#8226; </span>
-                    {{item['Positive tests']}}
-                  </p>
-                {% endif %}
-
-                {% if item['Positive-heq'] !== ""  %}
-                  <p class="card-text text-small mt-3 text-left">
-                    <span aria-hidden="true">&#8226; </span>
-                    {{ item['Positive-heq']| safe}}
-                  </p>
-                {% endif %}
-              </div>
-            </div>
+    <cagov-accordion class="prog-enhanced">
+      <div class="card">
+        <button
+          class="card-header accordion-alpha"
+          type="button"
+          aria-expanded="{{accordionExpanded}}"
+        >
+          <div class="accordion-title">
+            <h4>
+              {% if tableRiskLevel.Status !== "" %}
+                {{ tableRiskLevel.Status + ":" | safe }}
+              {% endif %}
+              {{ tableRiskLevel.Title | safe }}
+            </h4>
           </div>
-        {% endfor %}
+          <div class="plus-munus"><cagov-plus></cagov-plus><cagov-minus></cagov-minus></div>
+        </button>
+        <div class="card-container" aria-hidden="true" style="height: 0px;">
+          <div class="card-body">
+            <p>{{  tableRiskLevel.Description | safe }}</p>
+            <div class="row mr-0 ml-0">
+              {% for item in Rows | reverse -%}
+                {%- set CssColor = item['_Color label'] | lower -%}
+                <div class="col-md-3 pl-0 pr-0 bg-{{CssColor}}-alert">
+                  <div class="card border-0 bg-transparent pl-2">
+                    <div class="pt-3 card-body text-black text-center">
+                      <div class="btn-matrix bg-{{CssColor}}-btn">{{item['County tier'] | safe}}</div>
+
+                      {% if item['New cases'] !== "" %}
+                        <p class="card-text text-small mt-3 text-left">
+                          <span aria-hidden="true">&#8226; </span>
+                          {{item['New cases'] | safe }}
+                        </p>
+                      {% endif %}
+
+                      {% if item['Positive tests'] !== "" %}
+                        <p class="card-text text-small mt-3 text-left">
+                          <span aria-hidden="true">&#8226; </span>
+                          {{item['Positive tests'] | safe }}
+                        </p>
+                      {% endif %}
+
+                      {% if item['Positive-heq'] !== ""  %}
+                        <p class="card-text text-small mt-3 text-left">
+                          <span aria-hidden="true">&#8226; </span>
+                          {{ item['Positive-heq']| safe}}
+                        </p>
+                      {% endif %}
+                    </div>
+                  </div>
+                </div>
+              {% endfor %}
+            </div>
+            <br/>
+            <p class="small-text">{{  tableRiskLevel.Footnote | safe }}</p>
+          </div>
+        </div>
       </div>
-    </div>
+    </cagov-accordion>
   {% endfor %}
 </div>
 
-
 <div class="the-matrix-descriptions d-none">
   {%- set Rows = JSON[currentTable] -%}
-    <div class="row mr-0 ml-0">
-      {% for item in Rows | reverse -%}
-        {%- set CssColor = item['_Color label'] | lower -%}
-        <div class="col-md-3 pl-0 pr-0">
-          <div class="card border-0 bg-transparent pl-2">
-            <div class="pt-3 card-body text-black text-center">
-              <div class="btn-matrix bg-{{CssColor}}-btn">{{item['County tier'] | safe}}</div>
+  <div class="row mr-0 ml-0">
+    {% for item in Rows | reverse -%}
+      {%- set CssColor = item['_Color label'] | lower -%}
+      <div class="col-md-3 pl-0 pr-0">
+        <div class="card border-0 bg-transparent pl-2">
+          <div class="pt-3 card-body text-black text-center">
+            <div class="btn-matrix bg-{{CssColor}}-btn">{{item['County tier'] | safe}}</div>
 
-              {% if item['description'] !== "" %}
-                <p class="card-text text-small mt-3 text-center">
-                  {{item['description']}}
-                </p>
-              {% endif %}
-            </div>
+            {% if item['description'] !== "" %}
+              <p class="card-text text-small mt-3 text-center">
+                {{item['description']}}
+              </p>
+            {% endif %}
           </div>
         </div>
-      {% endfor %}
-    </div>
+      </div>
+    {% endfor %}
+  </div>
 </div>

--- a/pages/_includes/reopening-matrix.njk
+++ b/pages/_includes/reopening-matrix.njk
@@ -1,96 +1,110 @@
 {%- set JSON = pubData[language.id].reopeningMatrixData -%}
+{%- set DataTables = ["Table1", "Table3", "Table4"] -%}
+{%- set MatrixLabels = JSON.Table5 -%}
+
 {%- set Headers = JSON.Table2[0] -%}
-{%- set Rows = JSON.Table1 -%}
 
-{#- dynamic classnames are really cool but the purger cannot understand, hence this -#}
-<div class="d-none bg-purple-alert bg-red-alert bg-orange-alert bg-yellow-alert bg-purple-btn bg-red-btn bg-orange-btn bg-yellow-btn text-700 bg-lightblue"></div>
+{% for DataTable in DataTables -%}
 
 
-<div class="the-matrix d-none">
-  <div class="row mr-0 ml-0 matrix-row">
-      <div class="col-md-3 pl-2 d-none d-md-block bd-right-black">
-        <h4 class="h5 card-title mb-0">{{Headers["Header – county risk level"] | safe}}</h4>
-      </div>
-      
-      <div class="col-md-3 pl-2 d-none d-md-block bd-right-black">
-        <h4 class="h5 card-title mb-0">{{Headers["Header – new cases"] | safe}}*</h4><p class="text-small mb-0">7-day average of daily COVID-19 cases per 100K with 7-day lag, adjusted for number of tests performed</p>
-      </div>
+  {%- set Rows = JSON[DataTable] -%}
 
-      <div class="col-md-6 pl-2 d-none d-md-block">
-        <h4 class="h5 card-title mb-0">{{Headers["Header – positive tests"] | safe}}**</h4><p class="text-small mb-0">7-day average of all COVID-19 tests performed that are positive
-      </p>
+  <h4 class="wp-accordion">Title</h4>
+
+  <div class="wp-accordion-content">
+
+  {#- dynamic classnames are really cool but the purger cannot understand, hence this -#}
+  <div class="d-none bg-purple-alert bg-red-alert bg-orange-alert bg-yellow-alert bg-purple-btn bg-red-btn bg-orange-btn bg-yellow-btn text-700 bg-lightblue"></div>
+
+
+  <div class="the-matrix d-none">
+    <div class="row mr-0 ml-0 matrix-row">
+        <div class="col-md-3 pl-2 d-none d-md-block bd-right-black">
+          <h4 class="h5 card-title mb-0">{{Headers["Header – county risk level"] | safe}}</h4>
+        </div>
         
-      </div>
-    </div>
-  <div class="row mr-0 ml-0 matrix-row">
-      <div class="col-md-3 d-none d-md-block bd-right-black"></div>
-      <div class="col-md-3 d-none d-md-block bd-right-black"></div>
-        <div class="col-md-3 d-none d-md-block pl-2 bd-right-white bg-lightblue">
-          <p class="text-700 my-1 text-small">Entire county</p>
+        <div class="col-md-3 pl-2 d-none d-md-block bd-right-black">
+          <h4 class="h5 card-title mb-0">{{Headers["Header – new cases"] | safe}}*</h4><p class="text-small mb-0">7-day average of daily COVID-19 cases per 100K with 7-day lag, adjusted for number of tests performed</p>
         </div>
-        <div class="col-md-3 d-none d-md-block pl-2 bg-lightblue">
-          <p class="text-700 my-1 text-small">Health equity quartile</p>
-        </div>
-    </div>
-  {% for item in Rows | reverse -%}
-  {%- set CssColor = item['_Color label'] | lower -%}
-  <div class="row mr-0 ml-0 matrix-row">
-    <div class="col-md-3 pl-0 pr-0 bd-right-black bd-0-mobile bd-bottom-black-mobile bg-{{CssColor}}-alert">
-      <div class="card border-0 bg-transparent pl-2">
-        <div class="card-body text-black">
-          <div class="btn-matrix bg-{{CssColor}}-btn">{{item['County tier'] | safe}}</div>
-          <p class="card-text text-small mt-3">
-            {{item['description'] | safe}}
-          </p>
-        </div>
-      </div>
-    </div>
 
-    <div class="col-md-3 pl-0 bd-right-black bd-0-mobile  pr-0 bg-{{CssColor}}-alert">
-      <div class="card border-0 bg-transparent">
-        <div class="card-body text-black bd-bottom-black-mobile">
-          <div class="d-md-none pl-2">
-            <h4 class="color-purple mb-0">Adjusted cases*</h4>
-            <p class="card-text text-small mt-0 mb-3">7-day average of daily COVID-19 cases per 100K with 7-day lag, adjusted for number of tests performed</p>
-          </div>
-             <p class="matrix-h5 pl-2">{{item['New cases']}}</h5>
-          <p class="card-text text-small pl-2">
-          {{Headers['Description – new cases'] | safe}}
-          </p>
+        <div class="col-md-6 pl-2 d-none d-md-block">
+          <h4 class="h5 card-title mb-0">{{Headers["Header – positive tests"] | safe}}**</h4><p class="text-small mb-0">7-day average of all COVID-19 tests performed that are positive
+        </p>
+          
         </div>
       </div>
-    </div>
-      <div class="col-md-3 pl-0 pr-0 bd-right-white bd-0-mobile bg-{{CssColor}}-alert">
-        
+    <div class="row mr-0 ml-0 matrix-row">
+        <div class="col-md-3 d-none d-md-block bd-right-black"></div>
+        <div class="col-md-3 d-none d-md-block bd-right-black"></div>
+          <div class="col-md-3 d-none d-md-block pl-2 bd-right-white bg-lightblue">
+            <p class="text-700 my-1 text-small">Entire county</p>
+          </div>
+          <div class="col-md-3 d-none d-md-block pl-2 bg-lightblue">
+            <p class="text-700 my-1 text-small">Health equity quartile</p>
+          </div>
+      </div>
+    {% for item in Rows | reverse -%}
+    {%- set CssColor = item['_Color label'] | lower -%}
+    <div class="row mr-0 ml-0 matrix-row">
+      <div class="col-md-3 pl-0 pr-0 bd-right-black bd-0-mobile bd-bottom-black-mobile bg-{{CssColor}}-alert">
+        <div class="card border-0 bg-transparent pl-2">
+          <div class="card-body text-black">
+            <div class="btn-matrix bg-{{CssColor}}-btn">{{item['County tier'] | safe}}</div>
+            <p class="card-text text-small mt-3">
+              {{item['description'] | safe}}
+            </p>
+          </div>
+        </div>
+      </div>
 
-        <div class="card border-0 bg-transparent pl-2">
-        <div class="d-md-none">
-            <h4 class="color-purple mb-0">Positivity rate**</h4>
-            <p class="card-text text-small my-0">7-day average of all COVID-19 tests performed that are positive</p>
-            <h4 class="my-0 font-size-1-1em">Entire county</h4>
+      <div class="col-md-3 pl-0 bd-right-black bd-0-mobile  pr-0 bg-{{CssColor}}-alert">
+        <div class="card border-0 bg-transparent">
+          <div class="card-body text-black bd-bottom-black-mobile">
+            <div class="d-md-none pl-2">
+              <h4 class="color-purple mb-0">Adjusted cases*</h4>
+              <p class="card-text text-small mt-0 mb-3">7-day average of daily COVID-19 cases per 100K with 7-day lag, adjusted for number of tests performed</p>
+            </div>
+              <p class="matrix-h5 pl-2">{{item['New cases']}}</h5>
+            <p class="card-text text-small pl-2">
+            {{Headers['Description – new cases'] | safe}}
+            </p>
           </div>
-              <div class="card-body text-black">
-                <p class="matrix-h5">{{item['Positive tests'] | safe}}</p>
-                <p class="card-text text-small">
-                {{ Headers['Description – positive cases'] | safe}}
-                </p>
-              </div>
         </div>
       </div>
-      <div class="col-md-3 pl-0 pr-0 bg-{{CssColor}}-alert">
-         
-        <div class="card border-0 bg-transparent pl-2">
-         <div class="d-md-none">
-            <h4 class="my-0 font-size-1-1em">Health equity quartile</h4>
+        <div class="col-md-3 pl-0 pr-0 bd-right-white bd-0-mobile bg-{{CssColor}}-alert">
+          
+
+          <div class="card border-0 bg-transparent pl-2">
+          <div class="d-md-none">
+              <h4 class="color-purple mb-0">Positivity rate**</h4>
+              <p class="card-text text-small my-0">7-day average of all COVID-19 tests performed that are positive</p>
+              <h4 class="my-0 font-size-1-1em">Entire county</h4>
+            </div>
+                <div class="card-body text-black">
+                  <p class="matrix-h5">{{item['Positive tests'] | safe}}</p>
+                  <p class="card-text text-small">
+                  {{ Headers['Description – positive cases'] | safe}}
+                  </p>
+                </div>
           </div>
-              <div class="card-body text-black">
-                <p class="matrix-h5">{{item['Positive-heq'] | safe}}</p>
-                <p class="card-text text-small">
-                {{ Headers['Description – positive cases'] | safe}}
-                </p>
-              </div>
         </div>
-      </div>
+        <div class="col-md-3 pl-0 pr-0 bg-{{CssColor}}-alert">
+          
+          <div class="card border-0 bg-transparent pl-2">
+          <div class="d-md-none">
+              <h4 class="my-0 font-size-1-1em">Health equity quartile</h4>
+            </div>
+                <div class="card-body text-black">
+                  <p class="matrix-h5">{{item['Positive-heq'] | safe}}</p>
+                  <p class="card-text text-small">
+                  {{ Headers['Description – positive cases'] | safe}}
+                  </p>
+                </div>
+          </div>
+        </div>
+    </div>
+    {% endfor %}
   </div>
-  {% endfor %}
+
 </div>
+{% endfor %}

--- a/pages/_includes/reopening-matrix.njk
+++ b/pages/_includes/reopening-matrix.njk
@@ -1,110 +1,78 @@
 {%- set JSON = pubData[language.id].reopeningMatrixData -%}
 {%- set DataTables = ["Table1", "Table3", "Table4"] -%}
+
 {%- set MatrixLabels = JSON.Table5 -%}
+{# {% set currentRiskLevel = MatrixLabels | where("Status", "Current") %} #}
+{% set currentRiskLevel = MatrixLabels[1] %}
+{% set currentTable = "Table1" %}
 
 {%- set Headers = JSON.Table2[0] -%}
 
-{% for DataTable in DataTables -%}
 
+{#- dynamic classnames are really cool but the purger cannot understand, hence this -#}
+<div class="d-none bg-purple-alert bg-red-alert bg-orange-alert bg-yellow-alert bg-purple-btn bg-red-btn bg-orange-btn bg-yellow-btn text-700 bg-lightblue"></div>
 
-  {%- set Rows = JSON[DataTable] -%}
+<div class="the-matrix d-none">
+  {% for DataTable in DataTables -%}
+    {%- set Rows = JSON[DataTable] -%}
+    <h4 class="wp-accordion">Title 11</h4>
+    <div class="wp-accordion-content" aria-expanded="true">
+      <div class="row mr-0 ml-0">
+        {% for item in Rows | reverse -%}
+          {%- set CssColor = item['_Color label'] | lower -%}
+          <div class="col-md-3 pl-0 pr-0 bg-{{CssColor}}-alert">
+            <div class="card border-0 bg-transparent pl-2">
+              <div class="pt-3 card-body text-black text-center">
+                <div class="btn-matrix bg-{{CssColor}}-btn">{{item['County tier'] | safe}}</div>
 
-  <h4 class="wp-accordion">Title</h4>
-
-  <div class="wp-accordion-content">
-
-  {#- dynamic classnames are really cool but the purger cannot understand, hence this -#}
-  <div class="d-none bg-purple-alert bg-red-alert bg-orange-alert bg-yellow-alert bg-purple-btn bg-red-btn bg-orange-btn bg-yellow-btn text-700 bg-lightblue"></div>
-
-
-  <div class="the-matrix d-none">
-    <div class="row mr-0 ml-0 matrix-row">
-        <div class="col-md-3 pl-2 d-none d-md-block bd-right-black">
-          <h4 class="h5 card-title mb-0">{{Headers["Header – county risk level"] | safe}}</h4>
-        </div>
-        
-        <div class="col-md-3 pl-2 d-none d-md-block bd-right-black">
-          <h4 class="h5 card-title mb-0">{{Headers["Header – new cases"] | safe}}*</h4><p class="text-small mb-0">7-day average of daily COVID-19 cases per 100K with 7-day lag, adjusted for number of tests performed</p>
-        </div>
-
-        <div class="col-md-6 pl-2 d-none d-md-block">
-          <h4 class="h5 card-title mb-0">{{Headers["Header – positive tests"] | safe}}**</h4><p class="text-small mb-0">7-day average of all COVID-19 tests performed that are positive
-        </p>
-          
-        </div>
-      </div>
-    <div class="row mr-0 ml-0 matrix-row">
-        <div class="col-md-3 d-none d-md-block bd-right-black"></div>
-        <div class="col-md-3 d-none d-md-block bd-right-black"></div>
-          <div class="col-md-3 d-none d-md-block pl-2 bd-right-white bg-lightblue">
-            <p class="text-700 my-1 text-small">Entire county</p>
-          </div>
-          <div class="col-md-3 d-none d-md-block pl-2 bg-lightblue">
-            <p class="text-700 my-1 text-small">Health equity quartile</p>
-          </div>
-      </div>
-    {% for item in Rows | reverse -%}
-    {%- set CssColor = item['_Color label'] | lower -%}
-    <div class="row mr-0 ml-0 matrix-row">
-      <div class="col-md-3 pl-0 pr-0 bd-right-black bd-0-mobile bd-bottom-black-mobile bg-{{CssColor}}-alert">
-        <div class="card border-0 bg-transparent pl-2">
-          <div class="card-body text-black">
-            <div class="btn-matrix bg-{{CssColor}}-btn">{{item['County tier'] | safe}}</div>
-            <p class="card-text text-small mt-3">
-              {{item['description'] | safe}}
-            </p>
-          </div>
-        </div>
-      </div>
-
-      <div class="col-md-3 pl-0 bd-right-black bd-0-mobile  pr-0 bg-{{CssColor}}-alert">
-        <div class="card border-0 bg-transparent">
-          <div class="card-body text-black bd-bottom-black-mobile">
-            <div class="d-md-none pl-2">
-              <h4 class="color-purple mb-0">Adjusted cases*</h4>
-              <p class="card-text text-small mt-0 mb-3">7-day average of daily COVID-19 cases per 100K with 7-day lag, adjusted for number of tests performed</p>
-            </div>
-              <p class="matrix-h5 pl-2">{{item['New cases']}}</h5>
-            <p class="card-text text-small pl-2">
-            {{Headers['Description – new cases'] | safe}}
-            </p>
-          </div>
-        </div>
-      </div>
-        <div class="col-md-3 pl-0 pr-0 bd-right-white bd-0-mobile bg-{{CssColor}}-alert">
-          
-
-          <div class="card border-0 bg-transparent pl-2">
-          <div class="d-md-none">
-              <h4 class="color-purple mb-0">Positivity rate**</h4>
-              <p class="card-text text-small my-0">7-day average of all COVID-19 tests performed that are positive</p>
-              <h4 class="my-0 font-size-1-1em">Entire county</h4>
-            </div>
-                <div class="card-body text-black">
-                  <p class="matrix-h5">{{item['Positive tests'] | safe}}</p>
-                  <p class="card-text text-small">
-                  {{ Headers['Description – positive cases'] | safe}}
+                {% if item['New cases'] !== "" %}
+                  <p class="card-text text-small mt-3 text-left">
+                    <span aria-hidden="true">&#8226; </span>
+                    {{item['New cases']}}
                   </p>
-                </div>
-          </div>
-        </div>
-        <div class="col-md-3 pl-0 pr-0 bg-{{CssColor}}-alert">
-          
-          <div class="card border-0 bg-transparent pl-2">
-          <div class="d-md-none">
-              <h4 class="my-0 font-size-1-1em">Health equity quartile</h4>
-            </div>
-                <div class="card-body text-black">
-                  <p class="matrix-h5">{{item['Positive-heq'] | safe}}</p>
-                  <p class="card-text text-small">
-                  {{ Headers['Description – positive cases'] | safe}}
+                {% endif %}
+
+                {% if item['Positive tests'] !== "" %}
+                  <p class="card-text text-small mt-3 text-left">
+                    <span aria-hidden="true">&#8226; </span>
+                    {{item['Positive tests']}}
                   </p>
-                </div>
+                {% endif %}
+
+                {% if item['Positive-heq'] !== ""  %}
+                  <p class="card-text text-small mt-3 text-left">
+                    <span aria-hidden="true">&#8226; </span>
+                    {{ item['Positive-heq']| safe}}
+                  </p>
+                {% endif %}
+              </div>
+            </div>
           </div>
-        </div>
+        {% endfor %}
+      </div>
     </div>
-    {% endfor %}
-  </div>
-
+  {% endfor %}
 </div>
-{% endfor %}
+
+
+<div class="the-matrix-descriptions d-none">
+  {%- set Rows = JSON[currentTable] -%}
+    <div class="row mr-0 ml-0">
+      {% for item in Rows | reverse -%}
+        {%- set CssColor = item['_Color label'] | lower -%}
+        <div class="col-md-3 pl-0 pr-0">
+          <div class="card border-0 bg-transparent pl-2">
+            <div class="pt-3 card-body text-black text-center">
+              <div class="btn-matrix bg-{{CssColor}}-btn">{{item['County tier'] | safe}}</div>
+
+              {% if item['description'] !== "" %}
+                <p class="card-text text-small mt-3 text-center">
+                  {{item['description']}}
+                </p>
+              {% endif %}
+            </div>
+          </div>
+        </div>
+      {% endfor %}
+    </div>
+</div>

--- a/src/css/_reopening.scss
+++ b/src/css/_reopening.scss
@@ -31,6 +31,7 @@ cagov-reopening {
     padding: 20px;
     background-color: #f3f5fc;
     margin: 20px 0;
+    
     @include tablet {
 			padding: 50px;
 		}

--- a/src/js/roadmap/index.js
+++ b/src/js/roadmap/index.js
@@ -13,6 +13,12 @@ class CAGovReopening extends window.HTMLElement {
       document.querySelector('.matrix-holder').innerHTML = theMatrix.innerHTML;
     }
 
+    let theMatrixDescriptions = document.querySelector('.the-matrix-descriptions');
+
+    if(theMatrixDescriptions) {
+      document.querySelector('.matrix-county-risk-levels').innerHTML = theMatrixDescriptions.innerHTML;
+    }
+
     window.fetch('/countystatus.json')
     .then(response => response.json())
     .then(function(data) {

--- a/src/js/roadmap/template.js
+++ b/src/js/roadmap/template.js
@@ -1,8 +1,9 @@
 export default function template(json) {
-  return /*html*/`
+  return /*html*/ `
   <div class="reopening-fields">
+
   <h2 class="subtitle-color mt-3">${json.title}</h2>
-    <form action="#" class="reopening-activities">
+    <form action="#" class="reopening-activities ">
       <div class="form-row">
         <div class="form-group col-md-6 reopening-form-group">
           <label for="location-query">${json.countyLabel}</label>
@@ -56,5 +57,5 @@ export default function template(json) {
       <button type="submit" id="reopening-submit" class="btn btn-primary">${json.buttonText}</button>
     </form>
     <div class="card-holder"></div>
-  </div>`
+  </div>`;
 }


### PR DESCRIPTION
Ported konstantin’s markup into reopening-matrix.njk

Added another dynamic display for risk level key to cagov-reopening template

New tables that label the accordions, includes a translatable “Current” status (if anything is in the “Status” field it will add it to the label & expand the accordion

 

**Not done / issues / to do**

full-bleed doesn’t work - it’s stuck in col-10

used cagov-accordion but not seeing other implementations of it… will check with Aaron to make sure it’s ready

we will need to check mobile & mobile layout

table may need better css classes to match figma

check headers with the dates, not sure which is which based on google doc

need to check on accordion expansion… implementation looks right, but need to check it - if it doesn’t work we’ll revert to the original but would be nice to make it happen 

some issues with nunjucks array filtering - we don’t seem to have good similar examples, so I hard coded the ‘current’ table to give time to figure out the funky syntax issue.
