### PR TITLE
bump accordion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1347,9 +1347,9 @@
       "dev": true
     },
     "@cagov/accordion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@cagov/accordion/-/accordion-2.0.1.tgz",
-      "integrity": "sha512-mqes+DuQuLmOzKz2EBrrI5y6SKt2s5KxXAqalyakCxoDEx2kBJ3DDudolFk1VLdhWV4RXFYOBbO+2knOxwO1Eg=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@cagov/accordion/-/accordion-2.0.5.tgz",
+      "integrity": "sha512-AN9tbh15xd3jMgmALwq5fbyhfWXbiyDcCaMS8OEQQlEvgv9dqmJOu/KQH3QbiBdoP0LdohV534wJb3VGyZmqoQ=="
     },
     "@cagov/anchor-events": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
-    "@cagov/accordion": "^2.0.1",
+    "@cagov/accordion": "^2.0.5",
     "@cagov/anchor-events": "^1.0.0",
     "@cagov/lookup": "^1.0.3",
     "@cagov/step-list": "^1.0.11",


### PR DESCRIPTION
One weird part of this procedure is I had to run npm install again after doing the package install

This was to retrigger the subdependency overrides

Ran these commands to create this diff:

rm -r node_modules
npm install
git status
npm install @cagov/accordion
npm install