### PR TITLE
Ccg 1575/min height charts state dash

### DIFF
--- a/pages/wordpress-posts/v2-state-dashboard.html
+++ b/pages/wordpress-posts/v2-state-dashboard.html
@@ -363,7 +363,7 @@ data2.icu.ICU_SUSPECTED_COVID_PATIENTS_DAILY) | formatNumber(tags)-%}
 
 
 <div class="row d-flex justify-content-md-center">
-  <div class="toggle-group-container cases-group">
+  <div class="toggle-group-container cases-group hospitals-group">
     <div id="hospital-county-graph" class="toggle-group-element">
       <div class="tableauPlaceholder" id="hospitalChartCounty"></div>
     </div>

--- a/src/css/_dashboard.scss
+++ b/src/css/_dashboard.scss
@@ -10,7 +10,7 @@
 }
 .toggle-group-container:not(.d3-charts) {
   width: 1000px;
-  min-height: 650px;
+  min-height: 520px;
   margin-bottom:50px;
   position: relative;
   .toggle-group-element {
@@ -19,8 +19,8 @@
     left: 0;
     width: 100%;
   }
-  &.cases-group {
-   min-height: 650px;
+  &.hospitals-group {
+   min-height: 550px;
   }
 }
 


### PR DESCRIPTION

I think this is what we want in order to decrease the spacing between the top 3 charts and the captions below

This has been merged to staging

I haven't modified the WordPress file to add that new class yet