### PR TITLE
Rolled back canned GMT time displays by one hour to account for PST going forward.

### DIFF
--- a/pages/_data/statsData.js
+++ b/pages/_data/statsData.js
@@ -7,7 +7,7 @@ const data = {
     totalDeaths: caseStats[0]['NUMBERDIED'],
     totalDeathsIncrease: caseStats[0]['NUMBERDIED_DAILYPCTCHG'] * 100,
     testsReported: caseStats[0]['TESTED'],
-    lastStatsDate: caseStats[0]['DATE'] + 'T18:00:00Z'
+    lastStatsDate: caseStats[0]['DATE'] + 'T17:00:00Z'
   }
 };
 

--- a/pages/_includes/main.njk
+++ b/pages/_includes/main.njk
@@ -72,7 +72,7 @@ formatNumber(tags,1)-%}
 				<div class="hero-stats" role="region" aria-labelledby="tracking-covid">
 					<h2 class="color-orange text-center m-0 pb-2 pt-3" id="tracking-covid">{{varStatsHeader}}</h2>
 					<div class="text-sm text-center text-300">
-						{{- varUpdateText | replace("[UpdatedDate]", (dailyStatsV2.data.cases.DATE + "T18:00:00Z") | formatDate2(true,tags,+1)) | replace("[DataDate]",dailyStatsV2.data.cases.DATE | formatDate2(false,tags)) -}}
+						{{- varUpdateText | replace("[UpdatedDate]", (dailyStatsV2.data.cases.DATE + "T17:00:00Z") | formatDate2(true,tags,+1)) | replace("[DataDate]",dailyStatsV2.data.cases.DATE | formatDate2(false,tags)) -}}
 					</div>
 
 

--- a/pages/_includes/page.njk
+++ b/pages/_includes/page.njk
@@ -43,12 +43,11 @@
               {%- if page | engSlug === "safer-economy" or page | engSlug === "data-and-tools" -%}
                 {{ "today" | formatDate2(true,tags) }}
               {%- elseif page | engSlug === "v1-state-dashboard" -%}
-                {{ (tableauCovidMetrics[0].DATE + "T18:00:00Z") | formatDate2(true,tags,1) }}
+                {{ (tableauCovidMetrics[0].DATE + "T17:00:00Z") | formatDate2(true,tags,1) }}
               {%- elseif page | engSlug === "state-dashboard" -%}
-                {# {{ (tableauCovidMetrics[0].DATE + "T19:00:00Z") | formatDate2(true,tags,1) }} #}
-                {{ (dailyStatsV2.data.cases.DATE + "T18:00:00Z") | formatDate2(true,tags,1) }}
+                {{ (dailyStatsV2.data.cases.DATE + "T17:00:00Z") | formatDate2(true,tags,1) }}
               {%- elseif page | engSlug === "equity" -%}
-                {{ (equityTopBoxes[0].lowincome_date + "T23:00:00Z") | formatDate2(true,tags,1) }}
+                {{ (equityTopBoxes[0].lowincome_date + "T22:00:00Z") | formatDate2(true,tags,1) }}
                 {# {{ "today" | formatDate2(true,tags,-1) }} #}
               {%- else -%}
                 {{ publishdate | formatDate2(true,tags) }}


### PR DESCRIPTION
Note: This will cause times to appear too early (until DST kicks in). 

Should be merged between 2am and 9am on Sunday Mar 14th.

Although our clocks jump forward, we adjust GMT _backward_.  Why?  Right now when it is 6pm GMT, it is 10am here.  After DST kicks in, we roll forward, but GMT does not. Then, when it is 6pm GMT it will be 11am here. So we roll back GMT from 6pm to 5pm to compensate.