### PR TITLE
fix bottom padding

### DIFF
--- a/pages/_includes/page.njk
+++ b/pages/_includes/page.njk
@@ -66,7 +66,7 @@
   {% include "dashboard-v2.njk" %}
   {% endpagesection -%}
 
-  <div class="container">
+  <div class="container{%- pagesection page, 'state-dashboard' %} pb-0{%- endpagesection %}">
     <div class="row">
       <div class="col-lg-10 mx-auto">
         {{ content | safe  }}


### PR DESCRIPTION
This fixes the bug in the bottom margin of the state dashboard where the full bleed color element has undesirable white line above feedback.

This cannot be tested in staging because there is a fix in progress started 5 days ago to remove the sitewide padding to that box seen here https://github.com/cagov/covid19/blob/staging/src/css/_covid.scss#L709 that work requires reviewing changes to all pages

This fix can be removed if the above fix is deployed but can also coexist without problems when that change goes live