### PR TITLE
DST Fix

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -233,12 +233,11 @@ module.exports = function(eleventyConfig) {
             ? new Date()
             : datestring.indexOf('Z') > -1
               ? new Date(datestring)
-              : new Date(`${datestring} PST`);
+              : new Date(`${datestring} PST`); // WILL ALWAYS BREAK - not valid javascript. your choices are Z (GMT) or '' (unreliable local time)
       if(targetdate) {
         if(addDays) {
           targetdate.setUTCDate(targetdate.getUTCDate() + addDays);
         }
-
 
         const langId = getLangRecord(tags).id;
         const formatRecord = dateFormats[langId.toLowerCase()];

--- a/pages/_includes/main.njk
+++ b/pages/_includes/main.njk
@@ -72,7 +72,7 @@ formatNumber(tags,1)-%}
 				<div class="hero-stats" role="region" aria-labelledby="tracking-covid">
 					<h2 class="color-orange text-center m-0 pb-2 pt-3" id="tracking-covid">{{varStatsHeader}}</h2>
 					<div class="text-sm text-center text-300">
-						{{- varUpdateText | replace("[UpdatedDate]", (dailyStatsV2.data.cases.DATE + "T18:00:00Z") | formatDate2(true,tags,+1)) | replace("[DataDate]",dailyStatsV2.data.cases.DATE | formatDate2(false,tags)) -}}
+						{{- varUpdateText | replace("[UpdatedDate]", (dailyStatsV2.data.cases.DATE + "T17:00:00Z") | formatDate2(true,tags,+1)) | replace("[DataDate]",dailyStatsV2.data.cases.DATE | formatDate2(false,tags)) -}}
 					</div>
 
 

--- a/pages/_includes/page.njk
+++ b/pages/_includes/page.njk
@@ -43,12 +43,11 @@
               {%- if page | engSlug === "safer-economy" or page | engSlug === "data-and-tools" -%}
                 {{ "today" | formatDate2(true,tags) }}
               {%- elseif page | engSlug === "v1-state-dashboard" -%}
-                {{ (tableauCovidMetrics[0].DATE + "T18:00:00Z") | formatDate2(true,tags,1) }}
+                {{ (tableauCovidMetrics[0].DATE + "T17:00:00Z") | formatDate2(true,tags,1) }}
               {%- elseif page | engSlug === "state-dashboard" -%}
-                {{ (dailyStatsV2.data.cases.DATE + "T18:00:00Z") | formatDate2(true,tags,1) }}
+                {{ (dailyStatsV2.data.cases.DATE + "T17:00:00Z") | formatDate2(true,tags,1) }}
               {%- elseif page | engSlug === "equity" -%}
-                {{ (equityTopBoxes[0].lowincome_date + "T23:00:00Z") | formatDate2(true,tags,1) }}
-                {# {{ "today" | formatDate2(true,tags,-1) }} #}
+                {{ (equityTopBoxes[0].lowincome_date + "T22:00:00Z") | formatDate2(true,tags,1) }}
               {%- else -%}
                 {{ publishdate | formatDate2(true,tags) }}
               {%- endif -%}


### PR DESCRIPTION
Rolls times back an hour in spots where dates are currently shown an hour off.

Added comment to some invalid code that we should not trigger (and are not, at the moment).

