### PR TITLE
Patch reopening matrix to use en table so that the accordions will at…

### DIFF
--- a/pages/_includes/reopening-matrix.njk
+++ b/pages/_includes/reopening-matrix.njk
@@ -1,4 +1,4 @@
-{%- set JSON = pubData[language.id].reopeningMatrixData -%}
+{%- set JSON = pubData["en"].reopeningMatrixData -%}
 {%- set DataTables = ["Table1", "Table3", "Table4"] -%}
 {%- set Headers = JSON.Table2[0] -%}
 


### PR DESCRIPTION
Patch reopening matrix to use en table so that the accordions will at least be correct & not show an error (the content on that matrix & required with this release) - will revert when translation issues are resolved.

We will revert this once the translations come through but can't tell where we landed on that publish so prepping this PR for now.