### PR TITLE
CCG-1788 Corrected admin date display adjustment to work for old data.

### DIFF
--- a/src/js/vaccines/charts/cagov-chart-vaccination-groups-age/index.js
+++ b/src/js/vaccines/charts/cagov-chart-vaccination-groups-age/index.js
@@ -4,7 +4,7 @@ import getScreenResizeCharts from "./../../../common/get-window-size.js";
 import rtlOverride from "./../../../common/rtl-override.js";
 import renderChart from "../../../common/charts/simple-barchart.js";
 import applySubstitutions from "./../../../common/apply-substitutions.js";
-import { reformatReadableDate,getSnowflakeStyleDate } from "./../../../common/readable-date.js";
+import { parseSnowflakeDate, reformatJSDate } from "./../../../common/readable-date.js";
 
 class CAGovVaccinationGroupsAge extends window.HTMLElement {
   connectedCallback() {
@@ -188,18 +188,16 @@ class CAGovVaccinationGroupsAge extends window.HTMLElement {
           this.metadata = alldata.meta;
           this.alldata = alldata.data;
 
-          const todayStr = getSnowflakeStyleDate(0);
-          let adminDateStr = this.metadata['LATEST_ADMIN_DATE'];
-    
-          if (adminDateStr == todayStr) {
-            const yesterdayStr = getSnowflakeStyleDate(-1);
-            adminDateStr = yesterdayStr;
+          let publishedDate = parseSnowflakeDate(this.metadata['PUBLISHED_DATE']);
+          let collectedDate = parseSnowflakeDate(this.metadata['LATEST_ADMIN_DATE']);
+          if (publishedDate.getTime() == collectedDate.getTime()) {
+            collectedDate.setDate(collectedDate.getDate() - 1);            
           }
-    
           let footerReplacementDict = {
-            'PUBLISHED_DATE' : reformatReadableDate( this.metadata['PUBLISHED_DATE'] ),
-            'LATEST_ADMINISTERED_DATE' : reformatReadableDate( adminDateStr ),
+            'PUBLISHED_DATE' : reformatJSDate( publishedDate ),
+            'LATEST_ADMINISTERED_DATE' : reformatJSDate( collectedDate ),
           };
+
           let footerDisplayText = applySubstitutions(this.translationsObj.chartDataLabel, footerReplacementDict);
           d3.select(this.querySelector(".chart-data-label")).text(footerDisplayText);
 

--- a/src/js/vaccines/charts/cagov-chart-vaccination-groups-gender/index.js
+++ b/src/js/vaccines/charts/cagov-chart-vaccination-groups-gender/index.js
@@ -4,7 +4,7 @@ import getScreenResizeCharts from "./../../../common/get-window-size.js";
 import rtlOverride from "./../../../common/rtl-override.js";
 import renderChart from "../../../common/charts/simple-barchart.js";
 import applySubstitutions from "./../../../common/apply-substitutions.js";
-import { reformatReadableDate,getSnowflakeStyleDate } from "./../../../common/readable-date.js";
+import { parseSnowflakeDate, reformatJSDate } from "./../../../common/readable-date.js";
 
 class CAGovVaccinationGroupsGender extends window.HTMLElement {
   connectedCallback() {
@@ -191,18 +191,16 @@ class CAGovVaccinationGroupsGender extends window.HTMLElement {
           this.metadata = alldata.meta;
           this.alldata = alldata.data;
 
-          const todayStr = getSnowflakeStyleDate(0);
-          let adminDateStr = this.metadata['LATEST_ADMIN_DATE'];
-    
-          if (adminDateStr == todayStr) {
-            const yesterdayStr = getSnowflakeStyleDate(-1);
-            adminDateStr = yesterdayStr;
+          let publishedDate = parseSnowflakeDate(this.metadata['PUBLISHED_DATE']);
+          let collectedDate = parseSnowflakeDate(this.metadata['LATEST_ADMIN_DATE']);
+          if (publishedDate.getTime() == collectedDate.getTime()) {
+            collectedDate.setDate(collectedDate.getDate() - 1);            
           }
-    
           let footerReplacementDict = {
-            'PUBLISHED_DATE' : reformatReadableDate( this.metadata['PUBLISHED_DATE'] ),
-            'LATEST_ADMINISTERED_DATE' : reformatReadableDate( adminDateStr ),
+            'PUBLISHED_DATE' : reformatJSDate( publishedDate ),
+            'LATEST_ADMINISTERED_DATE' : reformatJSDate( collectedDate ),
           };
+
           let footerDisplayText = applySubstitutions(this.translationsObj.chartDataLabel, footerReplacementDict);
     
           // update the display date

--- a/src/js/vaccines/charts/cagov-chart-vaccination-groups-race-ethnicity/index.js
+++ b/src/js/vaccines/charts/cagov-chart-vaccination-groups-race-ethnicity/index.js
@@ -4,7 +4,7 @@ import getScreenResizeCharts from "./../../../common/get-window-size.js";
 import rtlOverride from "./../../../common/rtl-override.js";
 import renderChart from "../../../common/charts/simple-barchart.js";
 import applySubstitutions from "./../../../common/apply-substitutions.js";
-import { reformatReadableDate,getSnowflakeStyleDate } from "./../../../common/readable-date.js";
+import { parseSnowflakeDate, reformatJSDate } from "./../../../common/readable-date.js";
 
 class CAGovVaccinationGroupsRaceEthnicity extends window.HTMLElement {
   connectedCallback() {
@@ -210,18 +210,16 @@ class CAGovVaccinationGroupsRaceEthnicity extends window.HTMLElement {
           this.metadata = alldata.meta;
           this.alldata = alldata.data;
 
-          const todayStr = getSnowflakeStyleDate(0);
-          let adminDateStr = this.metadata['LATEST_ADMIN_DATE'];
-    
-          if (adminDateStr == todayStr) {
-            const yesterdayStr = getSnowflakeStyleDate(-1);
-            adminDateStr = yesterdayStr;
+          let publishedDate = parseSnowflakeDate(this.metadata['PUBLISHED_DATE']);
+          let collectedDate = parseSnowflakeDate(this.metadata['LATEST_ADMIN_DATE']);
+          if (publishedDate.getTime() == collectedDate.getTime()) {
+            collectedDate.setDate(collectedDate.getDate() - 1);            
           }
-    
           let footerReplacementDict = {
-            'PUBLISHED_DATE' : reformatReadableDate( this.metadata['PUBLISHED_DATE'] ),
-            'LATEST_ADMINISTERED_DATE' : reformatReadableDate( adminDateStr ),
+            'PUBLISHED_DATE' : reformatJSDate( publishedDate ),
+            'LATEST_ADMINISTERED_DATE' : reformatJSDate( collectedDate ),
           };
+
           let footerDisplayText = applySubstitutions(this.translationsObj.chartDataLabel, footerReplacementDict);
           d3.select(this.querySelector(".chart-data-label")).text(footerDisplayText);
 

--- a/src/js/vaccines/charts/cagov-chart-vaccines-hpi-by-dose/index.js
+++ b/src/js/vaccines/charts/cagov-chart-vaccines-hpi-by-dose/index.js
@@ -4,7 +4,7 @@ import getTranslations from "./../../../common/get-strings-list.js";
 import getScreenResizeCharts from "./../../../common/get-window-size.js";
 import rtlOverride from "./../../../common/rtl-override.js";
 import applySubstitutions from "./../../../common/apply-substitutions.js";
-import { reformatReadableDate,getSnowflakeStyleDate } from "./../../../common/readable-date.js";
+import { parseSnowflakeDate, reformatJSDate } from "./../../../common/readable-date.js";
 
 class CAGovVaccinesHPIDose extends window.HTMLElement {
   connectedCallback() {
@@ -282,18 +282,16 @@ class CAGovVaccinesHPIDose extends window.HTMLElement {
       let categories = data.map(rec => (rec.HPIQUARTILE-1));
       this.dimensions.width = this.dimensions.margin.left+this.dimensions.bar_hspace*categories.length + this.dimensions.margin.right;
 
-      const todayStr = getSnowflakeStyleDate(0);
-      let adminDateStr = this.metadata['LATEST_ADMINISTERED_DATE'];
-
-      if (adminDateStr == todayStr) {
-        const yesterdayStr = getSnowflakeStyleDate(-1);
-        adminDateStr = yesterdayStr;
+      let publishedDate = parseSnowflakeDate(this.metadata['PUBLISHED_DATE']);
+      let collectedDate = parseSnowflakeDate(this.metadata['LATEST_ADMINISTERED_DATE']);
+      if (publishedDate.getTime() == collectedDate.getTime()) {
+        collectedDate.setDate(collectedDate.getDate() - 1);            
       }
-
       let footerReplacementDict = {
-        'PUBLISHED_DATE' : reformatReadableDate( this.metadata['PUBLISHED_DATE'] ),
-        'LATEST_ADMINISTERED_DATE' : reformatReadableDate( adminDateStr ),
+        'PUBLISHED_DATE' : reformatJSDate( publishedDate ),
+        'LATEST_ADMINISTERED_DATE' : reformatJSDate( collectedDate ),
       };
+
       let footerDisplayText = applySubstitutions(this.translationsObj.footerText, footerReplacementDict);
 
       // update the display date

--- a/src/js/vaccines/charts/cagov-chart-vaccines-hpi-by-people/index.js
+++ b/src/js/vaccines/charts/cagov-chart-vaccines-hpi-by-people/index.js
@@ -4,7 +4,7 @@ import getTranslations from "./../../../common/get-strings-list.js";
 import getScreenResizeCharts from "./../../../common/get-window-size.js";
 import rtlOverride from "./../../../common/rtl-override.js";
 import applySubstitutions from "./../../../common/apply-substitutions.js";
-import { reformatReadableDate, getSnowflakeStyleDate } from "./../../../common/readable-date.js";
+import { parseSnowflakeDate, reformatJSDate } from "./../../../common/readable-date.js";
 
 class CAGovVaccinesHPIPeople extends window.HTMLElement {
   connectedCallback() {
@@ -313,18 +313,16 @@ class CAGovVaccinesHPIPeople extends window.HTMLElement {
       let subcategories = ['FIRST_DOSE_RATIO','COMPLETED_DOSE_RATIO'];
       this.dimensions.width = this.dimensions.margin.left+this.dimensions.bar_hspace*categories.length + this.dimensions.margin.right;
 
-      const todayStr = getSnowflakeStyleDate(0);
-      let adminDateStr = this.metadata['LATEST_ADMINISTERED_DATE'];
-
-      if (adminDateStr == todayStr) {
-        const yesterdayStr = getSnowflakeStyleDate(-1);
-        adminDateStr = yesterdayStr;
+      let publishedDate = parseSnowflakeDate(this.metadata['PUBLISHED_DATE']);
+      let collectedDate = parseSnowflakeDate(this.metadata['LATEST_ADMINISTERED_DATE']);
+      if (publishedDate.getTime() == collectedDate.getTime()) {
+        collectedDate.setDate(collectedDate.getDate() - 1);            
       }
-
       let footerReplacementDict = {
-        'PUBLISHED_DATE' : reformatReadableDate( this.metadata['PUBLISHED_DATE'] ),
-        'LATEST_ADMINISTERED_DATE' : reformatReadableDate( adminDateStr ),
+        'PUBLISHED_DATE' : reformatJSDate( publishedDate ),
+        'LATEST_ADMINISTERED_DATE' : reformatJSDate( collectedDate ),
       };
+
       let footerDisplayText = applySubstitutions(this.translationsObj.footerText, footerReplacementDict);
 
       // update the display date


### PR DESCRIPTION
Insures that the 'data from (administered)' date is always at least one-day behind the published date.

Does not use 'today' 'yesterday' logic anymore.
