### PR TITLE
CCG-1809. Equity update date time fix.

### DIFF
--- a/pages/_includes/page.njk
+++ b/pages/_includes/page.njk
@@ -47,7 +47,7 @@
               {%- elseif page | engSlug === "state-dashboard" -%}
                 {{ (dailyStatsV2.data.cases.DATE + "T17:00:00Z") | formatDate2(true,tags,1) }}
               {%- elseif page | engSlug === "equity" -%}
-                {{ (equityTopBoxes[0].lowincome_date + "T22:00:00Z") | formatDate2(true,tags,1) }}
+                {{ (equityTopBoxes[0].lowincome_date + "T17:00:00Z") | formatDate2(true,tags, 1) }}
               {%- else -%}
                 {{ publishdate | formatDate2(true,tags) }}
               {%- endif -%}


### PR DESCRIPTION
Changes update date on equity page to 10am. With next data pull, this should show up as Mar 17 (Wed) 10am.