### PR TITLE
Ccg 1814/equity linechart hover glitch

### DIFF
--- a/src/js/equity-dash/charts/healthy-places-index/index.js
+++ b/src/js/equity-dash/charts/healthy-places-index/index.js
@@ -365,8 +365,8 @@ class CAGOVChartD3Lines extends window.HTMLElement {
     svg.on("mouseleave touchend", null);
 
     if (!using_data_overlay) {
-      const tooltip = new Tooltip(true);
-      const tooltip2 = new Tooltip(false);
+      const tooltip = new Tooltip(true, y);
+      const tooltip2 = new Tooltip(false, y);
 
       
       svg

--- a/src/js/equity-dash/charts/healthy-places-index/tooltip.js
+++ b/src/js/equity-dash/charts/healthy-places-index/tooltip.js
@@ -1,7 +1,9 @@
 import { parseSnowflakeDate } from "../../../common/readable-date.js";
 
 export default class Tooltip {
-  constructor(needs_anno) {
+  constructor(needs_anno, yScale) {
+    let yRange = yScale.range();
+    console.log("Range",yRange);
     this.needs_anno = needs_anno;
     // this.legend = legend; // no longer using this param
     this.node = document.createElementNS("http://www.w3.org/2000/svg","g")
@@ -10,7 +12,7 @@ export default class Tooltip {
     this.node.setAttribute("display", "none");
     this.node.innerHTML = 
     (needs_anno? 
-       `<rect x="0" width=0.25 y=10 height=52 fill="#003D9D" stroke=none opacity=0.5></rect>
+       `<rect x="0" width=0.25 y=${yRange[1]} height=${(yRange[0] - yRange[1])} fill="#003D9D" stroke=none opacity=0.5></rect>
         <rect x="-5.5" width="10" y="89.5" height="3.5" fill="white" opacity=0.5></rect>
         <text class="date" y="62", x="0"></text>`
       : '') + 


### PR DESCRIPTION
Fixes a bug in which a partial line appeared on line chart when hovering mouse (the line is intended to span the vertical length of the chart).