### PR TITLE
CCG-1823 Added colors and hatch-fills to HPI charts on vaccines page.

### DIFF
--- a/src/js/vaccines/charts/cagov-chart-vaccines-hpi-by-dose/index.js
+++ b/src/js/vaccines/charts/cagov-chart-vaccines-hpi-by-dose/index.js
@@ -12,7 +12,6 @@ class CAGovVaccinesHPIDose extends window.HTMLElement {
     this.translationsObj = getTranslations(this);
     this.innerHTML = template(this.translationsObj);
     // Settings and initial values
-    this.barColor = '#1F2574';
 
     this.nbr_bars = 4;
     this.chartOptions = {
@@ -151,7 +150,7 @@ class CAGovVaccinesHPIDose extends window.HTMLElement {
     groups
         .append("rect")
             .attr("class","main-bar")
-            .attr("fill", d=>this.barColor)
+            .attr("class",(d,i) => "main-bar-"+(i+1))
             .attr("x", (d,i) => xScale(i))
             .attr("y", d => yScale(d.COMBINED_DOSES/totalDosesAllQuartiles))
             .attr("width", d => xScale.bandwidth())
@@ -197,7 +196,6 @@ class CAGovVaccinesHPIDose extends window.HTMLElement {
 
     group
       .append("rect")
-        .attr("fill", this.barColor)
         .attr("class", "legend-block")
         .attr("y", legendY)
         .attr("x", 0)

--- a/src/js/vaccines/charts/cagov-chart-vaccines-hpi-by-dose/index.scss
+++ b/src/js/vaccines/charts/cagov-chart-vaccines-hpi-by-dose/index.scss
@@ -26,7 +26,13 @@ cagov-chart-vaccines-hpi-by-dose {
       font-weight: 300;
       font-size: 0.75rem;
     }
-  }
+    .main-bar-1  { fill:#2772B3; }
+    .main-bar-2 { fill:#9FCAE0; }
+    .main-bar-3 { fill:#A7DAA2; }
+    .main-bar-4 { fill:#11873B; }
+    .legend-block  { fill:#000000; }
+
+}
 .d-hide {
   display: none;
 }

--- a/src/js/vaccines/charts/cagov-chart-vaccines-hpi-by-people/index.js
+++ b/src/js/vaccines/charts/cagov-chart-vaccines-hpi-by-people/index.js
@@ -12,7 +12,6 @@ class CAGovVaccinesHPIPeople extends window.HTMLElement {
     this.translationsObj = getTranslations(this);
     this.innerHTML = template(this.translationsObj);
     // Settings and initial values
-    this.colors = {'PARTIALLY_VACCINATED_RATIO':'#92c6df','FULLY_VACCINATED_RATIO':'#013d9c'}
     this.nbr_bars = 4;
     this.chartOptions = {
       // Data
@@ -110,8 +109,24 @@ class CAGovVaccinesHPIPeople extends window.HTMLElement {
         0,
         this.chartBreakpointValues.width,
         this.chartBreakpointValues.height,
-      ])
-      .append("g")
+      ]);
+
+    const patternSuffixes = ['1','2','3','4','L'];
+
+     this.svg.append("defs")
+       .selectAll("pattern")
+       .data(patternSuffixes)
+       .join("pattern")
+        .attr("id",d => 'hatch'+d)
+        .attr("x",0)
+        .attr("x",0)
+        .attr("width",4)
+        .attr("height",4)
+        .attr("patternUnits","userSpaceOnUse")
+        .append('path')
+          .attr('d', 'M-1,1 l2,-2 M0,4 l4,-4 M3,5 l2,-2');
+      
+     this.svg.append("g")
       .attr("transform", "translate(0,0)");
 
     // Set default values for data and labels
@@ -153,18 +168,15 @@ class CAGovVaccinesHPIPeople extends window.HTMLElement {
       .selectAll("g")
       .data(data)
       .join("g")
+      .attr("id",(d,i) => 'hpi-bar-group'+(i+1))
       .attr("transform", (d,i) => `translate(${xScaleOuter(i+1)},0)`);
-
-
-
-    let colors = {'PARTIALLY_VACCINATED_RATIO':'#92c6df','FULLY_VACCINATED_RATIO':'#013d9c'}
 
     let bars = groups
         .selectAll("rect")
         .data(d => ['PARTIALLY_VACCINATED_RATIO','FULLY_VACCINATED_RATIO'].map( key => ({'KEY':key,'D':d})))
         .join("rect")
             .attr("class","bg-bar")
-            .attr("fill", d=>this.colors[d.KEY])
+            .attr("class",(d,i) => 'hpi-bar-'+(i+1))
             .attr("x", (d,i) => xScaleInner(i))
             .attr("y", d => yScale(d.D[d.KEY]))
             .attr("width", d => xScaleInner.bandwidth())
@@ -213,7 +225,7 @@ class CAGovVaccinesHPIPeople extends window.HTMLElement {
 
     group
       .append("rect")
-        .attr("fill", this.colors.PARTIALLY_VACCINATED_RATIO)
+        .attr('id','legend-box-1')
         .attr("class", "legend-block")
         .attr("y", legendY)
         .attr("x", 0)
@@ -231,7 +243,7 @@ class CAGovVaccinesHPIPeople extends window.HTMLElement {
 
     group
       .append("rect")
-        .attr("fill", this.colors.FULLY_VACCINATED_RATIO)
+        .attr('id','legend-box-2')
         .attr("class", "legend-block")
         .attr("y", legendY)
         .attr("x", legend2X)

--- a/src/js/vaccines/charts/cagov-chart-vaccines-hpi-by-people/index.scss
+++ b/src/js/vaccines/charts/cagov-chart-vaccines-hpi-by-people/index.scss
@@ -26,7 +26,22 @@ cagov-chart-vaccines-hpi-by-people {
       font-weight: 300;
       font-size: 0.75rem;
     }
-  }
+    #hatch1 {stroke:#2772B3; stroke-width:1.5;}
+    #hatch2 {stroke:#9FCAE0; stroke-width:1.5;}
+    #hatch3 {stroke:#A7DAA2; stroke-width:1.5;}
+    #hatch4 {stroke:#11873B; stroke-width:1.5;}
+    #hatchL {stroke:#000000; stroke-width:1.5;}
+    #hpi-bar-group1 .hpi-bar-1 { fill:url(#hatch1); }
+    #hpi-bar-group1 .hpi-bar-2  { fill:#2772B3 }
+    #hpi-bar-group2 .hpi-bar-1  { fill:url(#hatch2); }
+    #hpi-bar-group2 .hpi-bar-2 { fill:#9FCAE0 }
+    #hpi-bar-group3 .hpi-bar-1  { fill:url(#hatch3); }
+    #hpi-bar-group3 .hpi-bar-2 { fill:#A7DAA2 }
+    #hpi-bar-group4 .hpi-bar-1  { fill:url(#hatch4); }
+    #hpi-bar-group4 .hpi-bar-2{ fill:#11873B }
+    #legend-box-1 { fill:url(#hatchL); }
+    #legend-box-2 { fill:#000000; }
+}
 .d-hide {
   display: none;
 }


### PR DESCRIPTION
@aaronhans note: I'm noticing these are breaking on IE11.  The prior charts are breaking as well. 

We'll need to repair (and possibly have an alt-solution if IE11 doesn't support SVG patterns). 