### PR TITLE
Fixed HPE charts for IE11.

### DIFF
--- a/src/js/config/staging.js
+++ b/src/js/config/staging.js
@@ -1,7 +1,8 @@
 window.config = {
   equityChartsDataLoc: 'https://files.covid19.ca.gov/data/to-review/',
   equityChartsVEDataLoc: 'https://files.covid19.ca.gov/data/vaccine-equity/',
-  chartsVHPIDataLoc: 'https://files.covid19.ca.gov/data/vaccine-hpi/',
+  chartsVHPIDataLocDoses: 'https://files.covid19.ca.gov/data/vaccine-hpi/v2/',
+  chartsVHPIDataLocPeople: 'https://files.covid19.ca.gov/data/vaccine-hpi/v2/',
 
 }
 // only used by es5.js

--- a/src/js/vaccines/charts/cagov-chart-vaccines-hpi-by-people/index.js
+++ b/src/js/vaccines/charts/cagov-chart-vaccines-hpi-by-people/index.js
@@ -460,7 +460,7 @@ class CAGovVaccinesHPIPeople extends window.HTMLElement {
         this.writeBars.call(this, this.svg, data, this.yScale, this.xScaleOuter, this.xScaleInner);
         this.writeLegend.call(this, this.svg, data, this.yScale, this.xScaleOuter, this.xScaleInner);
         this.writeExtras.call(this, this.svg, data, this.yScale, this.xScaleOuter, this.xScaleInner);
-    }
+      }
 
   retrieveData(url) {
     let component = this;

--- a/src/js/vaccines/charts/ie11.scss
+++ b/src/js/vaccines/charts/ie11.scss
@@ -36,6 +36,24 @@ cagov-chart-vaccines-hpi-by-dose {
   }
 }
 
+cagov-chart-vaccines-hpi-by-people {
+  #hatch1 {stroke:#2772B3; stroke-width:1.5;}
+  #hatch2 {stroke:#9FCAE0; stroke-width:1.5;}
+  #hatch3 {stroke:#A7DAA2; stroke-width:1.5;}
+  #hatch4 {stroke:#11873B; stroke-width:1.5;}
+  #hatchL {stroke:#000000; stroke-width:1.5;}
+  #hpi-bar-group1 .hpi-bar-1 { fill:url(#hatch1); }
+  #hpi-bar-group1 .hpi-bar-2  { fill:#2772B3 }
+  #hpi-bar-group2 .hpi-bar-1  { fill:url(#hatch2); }
+  #hpi-bar-group2 .hpi-bar-2 { fill:#9FCAE0 }
+  #hpi-bar-group3 .hpi-bar-1  { fill:url(#hatch3); }
+  #hpi-bar-group3 .hpi-bar-2 { fill:#A7DAA2 }
+  #hpi-bar-group4 .hpi-bar-1  { fill:url(#hatch4); }
+  #hpi-bar-group4 .hpi-bar-2{ fill:#11873B }
+  #legend-box-1 { fill:url(#hatchL); }
+  #legend-box-2 { fill:#000000; }
+}
+
 svg .tick text {
   text-anchor: start;
 }


### PR DESCRIPTION
Config needed an update so charts wouldn't break in IE11.  Also added explicit styling. HPE Charts look a bit different, but at least they are showing up now.