### PR TITLE
Correcting day-adjustment for equity missingness chart.

### DIFF
--- a/src/js/equity-dash/charts/data-completeness/index.js
+++ b/src/js/equity-dash/charts/data-completeness/index.js
@@ -3,7 +3,7 @@ import drawBars from "./draw.js";
 import getTranslations from './../../../common/get-strings-list.js';
 import getScreenResizeCharts from './../../../common/get-window-size.js';
 import rtlOverride from "./../../../common/rtl-override.js";
-import { reformatReadableDate } from "../../../common/readable-date.js";
+import { reformatReadableDate, parseSnowflakeDate } from "../../../common/readable-date.js";
 
 class CAGOVEquityMissingness extends window.HTMLElement {
   connectedCallback() {
@@ -425,8 +425,12 @@ class CAGOVEquityMissingness extends window.HTMLElement {
     // fetch date for footnote
     // console.log("rendering",this.selectedMetric,this.alldata);
     if (this.selectedMetric in this.alldata && 'cases' in this.alldata[this.selectedMetric]) {
-      const ONE_DAY_LATER = 1;
-      this.updateDate = reformatReadableDate( this.alldata[this.selectedMetric].cases.REPORT_DATE , { month: "long", day: 'numeric', year:'numeric' }, ONE_DAY_LATER);
+      const theDate = parseSnowflakeDate(this.alldata[this.selectedMetric].cases.REPORT_DATE);
+      let TUESDAY_ADJUSTMENT = 0;
+      if (theDate.getDay() < 2) {
+        TUESDAY_ADJUSTMENT = 2 - theDate.getDay();
+      }
+      this.updateDate = reformatReadableDate( this.alldata[this.selectedMetric].cases.REPORT_DATE , { month: "long", day: 'numeric', year:'numeric' }, TUESDAY_ADJUSTMENT);
     } else {
       this.updateDate = 'Unknown';
     }


### PR DESCRIPTION
The date provided with this data is sometimes Monday, and sometimes Tuesday. Previously used a fixed 1 day offset to make it align with the Tuesday dates on the rest of the page. Currently this is forcing it to Wednesday, which is undesirable.  

Now looking at the actual weekday provided and computing a dynamic adjustment to Tuesday for any of Sunday,Monday,Tuesday.  If Wed-Sat, we leave it as it.

