### PR TITLE
IE fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
   },
   "scripts": {
     "devserver": "web-dev-server --root-dir docs/",
-    "preinstall": "npx npm-force-resolutions@0.0.3",
     "dev": "cross-env NODE_ENV=development npm run start",
     "start": "npm run watch",
     "serve": "npx @11ty/eleventy --serve --quiet",

--- a/src/css/_hero-stats.scss
+++ b/src/css/_hero-stats.scss
@@ -119,9 +119,6 @@ hero-stats {
 		@include absolute(left 0 top 0);
 		@include size(100%);
 		z-index: -1;
-		@include ie {
-			height: auto !important;
-		}
 		&-pic {
 			@include size(100%, 70vh);
 			@include absolute(left 0 top 0);

--- a/src/js/dashboard-v1/index.js
+++ b/src/js/dashboard-v1/index.js
@@ -98,6 +98,7 @@ let countyMapChartHeight = 660;
 
 // Map responsivness
 var divElement = document.querySelector('.col-lg-10');
+if ( divElement ) {
 if ( divElement.offsetWidth > 920 ) { chartWidth2 = 910;countyMapChartHeight = 560;} 
   else if ( (divElement.offsetWidth > 910) && (divElement.offsetWidth < 920)) { chartWidth2 = 900; chartWidth3 = 900; countyMapChartHeight = 560;} 
   else if ( (divElement.offsetWidth > 800) && (divElement.offsetWidth < 910) ) { chartWidth2 = 750; chartWidth3 = 750; countyMapChartHeight = 660;} 
@@ -106,26 +107,27 @@ if ( divElement.offsetWidth > 920 ) { chartWidth2 = 910;countyMapChartHeight = 5
   else if ( (divElement.offsetWidth > 500) && (divElement.offsetWidth < 600) ) { chartWidth2 = 450; countyMapChartHeight = 660; chartWidth3 = 450;} 
   else { chartWidth2 = 350; countyMapChartHeight = 660; chartWidth3 = 450;}
 
-/* phone */
-if(window.innerWidth < 700) {
-  topChartHeights1 = 930;
-  //countyMapChartHeight = 560;
-  chartWidth = window.innerWidth - 30;
-  //chartWidth2 = chartWidth;
-}
-/* small tablet */
-else if (window.innerWidth > 700 && window.innerWidth < 918) {
-  topChartHeights1 = 930;
-  //countyMapChartHeight = 560;
-  chartWidth = 700;
- // chartWidth2 = chartW920idth;
-}
-/* big tablet */
-else if (window.innerWidth > 919 && window.innerWidth < 1200) {
-  topChartHeights1 = 600;
-  //countyMapChartHeight = 560;
-  chartWidth = 800;
- // chartWidth2 = 920;
+  /* phone */
+  if(window.innerWidth < 700) {
+    topChartHeights1 = 930;
+    //countyMapChartHeight = 560;
+    chartWidth = window.innerWidth - 30;
+    //chartWidth2 = chartWidth;
+  }
+  /* small tablet */
+  else if (window.innerWidth > 700 && window.innerWidth < 918) {
+    topChartHeights1 = 930;
+    //countyMapChartHeight = 560;
+    chartWidth = 700;
+  // chartWidth2 = chartW920idth;
+  }
+  /* big tablet */
+  else if (window.innerWidth > 919 && window.innerWidth < 1200) {
+    topChartHeights1 = 600;
+    //countyMapChartHeight = 560;
+    chartWidth = 800;
+  // chartWidth2 = 920;
+  }
 }
 
 async function setupCharts() {

--- a/src/js/dashboard-v2/index.js
+++ b/src/js/dashboard-v2/index.js
@@ -116,6 +116,7 @@ const tableauPrefix2 = "https://public.tableau.com/views/COVID-19StateDashboardv
 
 // Map responsivness
 var divElement = document.querySelector('.col-lg-10');
+if ( divElement) {
 if ( divElement.offsetWidth > 920 ) { chartWidth2 = 910;countyMapChartHeight = 560;} 
   else if ( (divElement.offsetWidth > 910) && (divElement.offsetWidth < 920)) { chartWidth2 = 900; countyMapChartHeight = 560;} 
   else if ( (divElement.offsetWidth > 800) && (divElement.offsetWidth < 910) ) { chartWidth2 = 750; countyMapChartHeight = 660;} 
@@ -124,34 +125,35 @@ if ( divElement.offsetWidth > 920 ) { chartWidth2 = 910;countyMapChartHeight = 5
   else if ( (divElement.offsetWidth > 500) && (divElement.offsetWidth < 600) ) { chartWidth2 = 450; countyMapChartHeight = 660; } 
   else { chartWidth2 = 350; countyMapChartHeight = 660; }
 
-// jbum overriding chartWidth3
-// chartWidth3 = Math.min(Math.max(275, divElement.offsetWidth-132), 900);
+  // jbum overriding chartWidth3
+  // chartWidth3 = Math.min(Math.max(275, divElement.offsetWidth-132), 900);
 
-// let chartHeight3 = Math.floor(3*chartWidth3/4);
-// if (chartWidth3 <= 600) { // mobile version has a different aspect ratio
-//   chartHeight3 = Math.floor(Math.max(450,chartWidth3)*3/2);
-// }
+  // let chartHeight3 = Math.floor(3*chartWidth3/4);
+  // if (chartWidth3 <= 600) { // mobile version has a different aspect ratio
+  //   chartHeight3 = Math.floor(Math.max(450,chartWidth3)*3/2);
+  // }
 
-/* phone */
-if(window.innerWidth < 700) {
-  topChartHeights1 = 930;
-  //countyMapChartHeight = 560;
-  chartWidth = window.innerWidth - 30;
-  //chartWidth2 = chartWidth;
-}
-/* small tablet */
-else if (window.innerWidth > 700 && window.innerWidth < 918) {
-  topChartHeights1 = 930;
-  //countyMapChartHeight = 560;
-  chartWidth = 700;
- // chartWidth2 = chartW920idth;
-}
-/* big tablet */
-else if (window.innerWidth > 919 && window.innerWidth < 1200) {
-  topChartHeights1 = 600;
-  //countyMapChartHeight = 560;
-  chartWidth = 800;
- // chartWidth2 = 920;
+  /* phone */
+  if(window.innerWidth < 700) {
+    topChartHeights1 = 930;
+    //countyMapChartHeight = 560;
+    chartWidth = window.innerWidth - 30;
+    //chartWidth2 = chartWidth;
+  }
+  /* small tablet */
+  else if (window.innerWidth > 700 && window.innerWidth < 918) {
+    topChartHeights1 = 930;
+    //countyMapChartHeight = 560;
+    chartWidth = 700;
+  // chartWidth2 = chartW920idth;
+  }
+  /* big tablet */
+  else if (window.innerWidth > 919 && window.innerWidth < 1200) {
+    topChartHeights1 = 600;
+    //countyMapChartHeight = 560;
+    chartWidth = 800;
+  // chartWidth2 = 920;
+  }
 }
 
 async function setupCharts() {

--- a/src/js/es5.js
+++ b/src/js/es5.js
@@ -2,7 +2,7 @@ import './config/staging.js';
 import '@webcomponents/webcomponentsjs';
 import 'whatwg-fetch';
 import './polyfills/endswith.js';
-import '@cagov/accordion';
+// import '@cagov/accordion'; accordion indicator svgs are broken, disable accordions in IE until fixed
 import '@cagov/step-list';
 import './dashboard-v2/async-polyfill.js';
 import './alerts/index.js';
@@ -18,11 +18,11 @@ import './vaccines/charts/ie11.scss';
 import './charts-sandbox/index.js';
 import './dashboard-v2/index.js';
 
-import applyAccordionListeners from './tracking-you/index.js';
-// twitter widget doesn't support IE11 so not including here
-window.onload = (event) => {
-  applyAccordionListeners();
-};
+// import applyAccordionListeners from './tracking-you/index.js';
+// // twitter widget doesn't support IE11 so not including here
+// window.onload = (event) => {
+//   applyAccordionListeners();
+// };
 
 // This is an IE polyfill for CustomEvent.
 // Thank you, MDN. https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent/CustomEvent#Polyfill

--- a/src/js/rollup.config.es5.js
+++ b/src/js/rollup.config.es5.js
@@ -36,7 +36,7 @@ export default {
           {
             modules: false,
             targets: {
-              browsers: '> 1%'
+              browsers: '> 0.5%'
             }
           }
         ]


### PR DESCRIPTION
- fix IE homepage readability by removing css that was blocking the whole background image
- get babel polyfilling working again by reducing market share check
- remove unnecessary npx install
- add defensive check into state dash which messes up IE because all the files are combined and that is outside of a web component