### PR TITLE
CCG-1860/Consolidated formatters. Added Unknown category to Age graph.

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -198,6 +198,21 @@ module.exports = function(eleventyConfig) {
     return floatFormatter.format(number);
   }
   );
+  eleventyConfig.addFilter('formatNumberSmall', (number,tags) => {
+    if (number < 0.005) {
+      fractionDigits = 3;
+    } else if (number < 0.05) {
+      fractionDigits = 2;
+    } else {
+      fractionDigits = 1;
+    }
+    let floatFormatter = new Intl.NumberFormat('us', // forcing US to avoid mixed styles on translated pages
+                  {style:'decimal', 
+                   minimumFractionDigits:fractionDigits,
+                   maximumFractionDigits:fractionDigits});
+    return floatFormatter.format(number);
+  }
+  );
   function addSeperator(nStr){
     nStr += '';
     x = nStr.split('.');

--- a/pages/_includes/main.njk
+++ b/pages/_includes/main.njk
@@ -10,7 +10,7 @@
 {%-set _varStatTotalDeaths_ = data2.deaths.LATEST_TOTAL_CONFIRMED_DEATHS | formatNumber(tags)-%}
 {%-set _varStatTotalDeathsToday_ = data2.deaths.NEWLY_REPORTED_DEATHS | formatNumber(tags)-%}
 {%-set _varStatNewDeathsPer100k_ = (data2.deaths.LATEST_CONFIDENT_AVG_DEATH_RATE_PER_100K_7_DAYS) |
-formatNumberFixed(tags,2)-%}
+formatNumberSmall(tags)-%}
 {%-set _varDeathsTrend_ = data2.deaths.LATEST_CONFIDENT_INCREASE_DEATH_RATE_PER_100K_7_DAYS %}
 
 {%-set _varStatTested_ = data2.tests.LATEST_TOTAL_TESTS_PERFORMED | formatNumber(tags)-%}

--- a/pages/wordpress-posts/state-dashboard.html
+++ b/pages/wordpress-posts/state-dashboard.html
@@ -16,21 +16,21 @@ addtositemap: true
 {%-set _varStatDateNoYear_ = _varStatDate_ | replace(", 2021", "")-%}
 {%-set _varStatTotalCases_ = data2.cases.LATEST_TOTAL_CONFIRMED_CASES | formatNumber(tags)-%}
 {%-set _varStatTotalCasesToday_ = data2.cases.NEWLY_REPORTED_CASES | formatNumber(tags)-%}
-{%-set _varStatNewCasesPer100k_ = (data2.cases.LATEST_CONFIDENT_AVG_CASE_RATE_PER_100K_7_DAYS) | formatNumberFixed(tags,1)-%}
+{%-set _varStatNewCasesPer100k_ = (data2.cases.LATEST_CONFIDENT_AVG_CASE_RATE_PER_100K_7_DAYS) | formatNumberSmall(tags)-%}
 
 {%-set _varStatTotalDeaths_ = data2.deaths.LATEST_TOTAL_CONFIRMED_DEATHS | formatNumber(tags)-%}
 {%-set _varStatTotalDeathsToday_ = data2.deaths.NEWLY_REPORTED_DEATHS | formatNumber(tags)-%}
 {%-set _varStatNewDeathsPer100k_ = (data2.deaths.LATEST_CONFIDENT_AVG_DEATH_RATE_PER_100K_7_DAYS) |
-formatNumberFixed(tags,2)-%}
+formatNumberSmall(tags)-%}
 
 {%-set _varStatTested_ = data2.tests.LATEST_TOTAL_TESTS_PERFORMED | formatNumber(tags)-%}
 {%-set _varStatTestedDaily_ = data2.tests.NEWLY_REPORTED_TESTS | formatNumber(tags)-%}
 {%-set _varStatLatestPositivityPct_ = (100*data2.tests.LATEST_CONFIDENT_POSITIVITY_RATE_7_DAYS) |
-formatNumberFixed(tags,1)-%}
+formatNumberSmall(tags)-%}
 
 {%-set _varStatVaccines_ = data2.vaccinations.CUMMULATIVE_DAILY_DOSES_ADMINISTERED | formatNumber(tags)-%}
 
-{%-set _varStatPos_7DayAvgPct_ = (100*data2.tests.LATEST_CONFIDENT_POSITIVITY_RATE_7_DAYS) | formatNumberFixed(tags,1) -%}
+{%-set _varStatPos_7DayAvgPct_ = (100*data2.tests.LATEST_CONFIDENT_POSITIVITY_RATE_7_DAYS) | formatNumberSmall(tags) -%}
 {%-set _varStatYesterdayDate_ = data2.cases.DATE | formatDate2(false, tags)-%}
 {%-set _varStatHospitalTotal_ = (data2.hospitalizations.HOSPITALIZED_COVID_CONFIRMED_PATIENTS +
 data2.hospitalizations.HOSPITALIZED_SUSPECTED_COVID_PATIENTS) | formatNumber(tags)-%}

--- a/src/js/charts-sandbox/charts/cagov-chart-vaccines-hpi-by-dose/index.js
+++ b/src/js/charts-sandbox/charts/cagov-chart-vaccines-hpi-by-dose/index.js
@@ -2,6 +2,7 @@ import template from "./template.js";
 import getTranslations from "./../../../common/get-strings-list.js";
 import getScreenResizeCharts from "./../../../common/get-window-size.js";
 import rtlOverride from "./../../../common/rtl-override.js";
+import formatValue from "./../../../common/value-formatters.js";
 
 class CAGovVaccinesHPIDose extends window.HTMLElement {
   connectedCallback() {
@@ -68,15 +69,6 @@ class CAGovVaccinesHPIDose extends window.HTMLElement {
         },
       },
     };
-
-    this.intFormatter = new Intl.NumberFormat(
-      "us", // forcing US to avoid mixed styles on translated pages
-      { style: "decimal", minimumFractionDigits: 0, maximumFractionDigits: 0 }
-    );
-    this.pctFormatter = new Intl.NumberFormat(
-      "us", // forcing US to avoid mixed styles on translated pages
-      { style: "percent", minimumFractionDigits: 0, maximumFractionDigits: 1 }
-    );
 
     getScreenResizeCharts(this);
 
@@ -159,7 +151,7 @@ class CAGovVaccinesHPIDose extends window.HTMLElement {
         .attr("class", "bar-upper-label-1")
         .attr("y", (d, i) => yScale(d.COMBINED_DOSES_RATIO) - 18)
         .attr("x", (d, i) => xScale(i)+xScale.bandwidth()/2)
-        .text(d => this.pctFormatter.format(d.COMBINED_DOSES_RATIO))
+        .text(d => formatValue(d.COMBINED_DOSES_RATIO,{format:'percent'}))
         .attr('text-anchor','middle');
 
     groups
@@ -167,7 +159,7 @@ class CAGovVaccinesHPIDose extends window.HTMLElement {
         .attr("class", "bar-upper-label-2")
         .attr("y", (d, i) => yScale(d.COMBINED_DOSES_RATIO) - 4)
         .attr("x", (d, i) => xScale(i)+xScale.bandwidth()/2)
-        .text((d,i) => this.intFormatter.format(d.COMBINED_DOSES))
+        .text((d,i) => formatValue(d.COMBINED_DOSES,{format:'integer'}))
         .attr('text-anchor','middle');
 
     

--- a/src/js/charts-sandbox/charts/cagov-chart-vaccines-hpi-by-people/index.js
+++ b/src/js/charts-sandbox/charts/cagov-chart-vaccines-hpi-by-people/index.js
@@ -2,6 +2,7 @@ import template from "./template.js";
 import getTranslations from "./../../../common/get-strings-list.js";
 import getScreenResizeCharts from "./../../../common/get-window-size.js";
 import rtlOverride from "./../../../common/rtl-override.js";
+import formatValue from "./../../../common/value-formatters.js";
 
 class CAGovVaccinesHPIPeople extends window.HTMLElement {
   connectedCallback() {
@@ -67,15 +68,6 @@ class CAGovVaccinesHPIPeople extends window.HTMLElement {
         },
       },
     };
-
-    this.intFormatter = new Intl.NumberFormat(
-      "us", // forcing US to avoid mixed styles on translated pages
-      { style: "decimal", minimumFractionDigits: 0, maximumFractionDigits: 0 }
-    );
-    this.pctFormatter = new Intl.NumberFormat(
-      "us", // forcing US to avoid mixed styles on translated pages
-      { style: "percent", minimumFractionDigits: 0, maximumFractionDigits: 1 }
-    );
 
     getScreenResizeCharts(this);
 
@@ -182,7 +174,7 @@ class CAGovVaccinesHPIPeople extends window.HTMLElement {
         .attr("class", "bar-upper-label-1")
         .attr("y", (d, i) => yScale(d.D[d.KEY]) - 18)
         .attr("x", (d, i) => xScaleInner(i)+xScaleInner.bandwidth()/2)
-        .text(d => this.pctFormatter.format(d.D[d.KEY]))
+        .text(d => formatValue(d.D[d.KEY],{format:'percent'}))
         .attr('text-anchor','middle');
     let capFields = ['FIRST_DOSE', 'COMPLETED_DOSE'];
     let barcaps2 = groups
@@ -192,7 +184,7 @@ class CAGovVaccinesHPIPeople extends window.HTMLElement {
         .attr("class", "bar-upper-label-2")
         .attr("y", (d, i) => yScale(d.D[d.KEY]) - 4)
         .attr("x", (d, i) => xScaleInner(i)+xScaleInner.bandwidth()/2)
-        .text((d,i) => this.intFormatter.format(d.D[capFields[i]]))
+        .text((d,i) => formatValue(d.D[capFields[i]],{format:'integer'}))
         .attr('text-anchor','middle');
 
     // barcaps.append("text")
@@ -212,10 +204,6 @@ class CAGovVaccinesHPIPeople extends window.HTMLElement {
       .attr("x", (d, i) => xScaleOuter.bandwidth()/2)
       // .attr("width", x.bandwidth() / 4)
       .text(d =>  this.translationsObj.barLabel.replace('{N}',d.HPIQUARTILE))
-      // .html(d => {
-      //   return `<tspan dx="1.5em">${this.pctFormatter.format(d.METRIC_VALUE)}</tspan>`
-      // })
-      // .attr('dominant-baseline','text-top')
       .attr('text-anchor','middle')
 
 

--- a/src/js/common/charts/simple-barchart.js
+++ b/src/js/common/charts/simple-barchart.js
@@ -5,6 +5,9 @@
  * @param {number} x 
  * @param {number} y 
  */
+import formatValue from "./../value-formatters.js";
+
+
 function writeLegend(svg, data, x, y, baselineData) {
     // Build legend.
     const legendText = this.getLegendText();
@@ -153,10 +156,7 @@ function writeBars(svg, data, x, y, baselineData, tooltip, rootID='barid') {
       .attr("y", (d, i) => y(d.CATEGORY) + (y.bandwidth() / 2))
       .attr("x", d => x(max_x_domain)+12)
       // .attr("width", x.bandwidth() / 4)
-      .text(d => this.pctFormatter.format(d.METRIC_VALUE))
-      // .html(d => {
-      //   return `<tspan dx="1.5em">${this.pctFormatter.format(d.METRIC_VALUE)}</tspan>`
-      // })
+      .text(d => formatValue(d.METRIC_VALUE,{format:'percent'}))
       .attr('dominant-baseline','middle')
       .attr('text-anchor','start')
 

--- a/src/js/common/value-formatters.js
+++ b/src/js/common/value-formatters.js
@@ -1,0 +1,64 @@
+// Generic Formatters
+
+let intFormatter = new Intl.NumberFormat(
+    "us", // forcing US to avoid mixed styles on translated pages
+    { style: "decimal", minimumFractionDigits: 0, maximumFractionDigits: 0 }
+);
+let float1Formatter = new Intl.NumberFormat(
+    "us", // forcing US to avoid mixed styles on translated pages
+    { style: "decimal", minimumFractionDigits: 1, maximumFractionDigits: 1 }
+);
+let float2Formatter = new Intl.NumberFormat(
+    "us", // forcing US to avoid mixed styles on translated pages
+    { style: "decimal", minimumFractionDigits: 2, maximumFractionDigits: 2 }
+);
+let float3Formatter = new Intl.NumberFormat(
+    "us", // forcing US to avoid mixed styles on translated pages
+    { style: "decimal", minimumFractionDigits: 3, maximumFractionDigits: 3 }
+);
+
+let pct0Formatter = new Intl.NumberFormat(
+    "us", // forcing US to avoid mixed styles on translated pages
+    { style: "percent", minimumFractionDigits: 1, maximumFractionDigits: 1 }
+);
+let pct1Formatter = new Intl.NumberFormat(
+    "us", // forcing US to avoid mixed styles on translated pages
+    { style: "percent", minimumFractionDigits: 1, maximumFractionDigits: 1 }
+);
+let pct2Formatter = new Intl.NumberFormat(
+    "us", // forcing US to avoid mixed styles on translated pages
+    { style: "percent", minimumFractionDigits: 2, maximumFractionDigits: 2 }
+);
+let pct3Formatter = new Intl.NumberFormat(
+    "us", // forcing US to avoid mixed styles on translated pages
+    { style: "percent", minimumFractionDigits: 3, maximumFractionDigits: 3 }
+);
+
+
+export default function formatValue(v, {format='number',min_decimals=1})
+{
+    // console.log("formatValue",v,format);
+    if (format == 'integer') {
+        return intFormatter.format(v);
+    } else if (format == 'percent') {
+        if (v < .00005) {
+            return pct3Formatter.format(v)
+        } else if (v < .0005) {
+            return pct2Formatter.format(v)
+        } else if (min_decimals == 0) {
+            return pct0Formatter.format(v)
+        } else {
+            return pct1Formatter.format(v)
+        }
+    } else { // number or float
+        if (v < .005) {
+            return float3Formatter.format(v)
+        } else if (v < .05) {
+            return float2Formatter.format(v)
+        } else if (min_decimals == 0) {
+            return intFormatter.format(v)
+        } else {
+            return float1Formatter.format(v)
+        }
+    }
+}

--- a/src/js/dashboard-v2/charts/cagov-chart-dashboard-groups-age-cases/index.js
+++ b/src/js/dashboard-v2/charts/cagov-chart-dashboard-groups-age-cases/index.js
@@ -5,6 +5,7 @@ import rtlOverride from "../../../common/rtl-override.js";
 import renderChart from "../../../common/charts/simple-barchart.js";
 import { parseSnowflakeDate, reformatJSDate } from "../../../common/readable-date.js";
 import applySubstitutions from "./../../../common/apply-substitutions.js";
+import formatValue from "./../../../common/value-formatters.js";
 
 // cagov-chart-dashboard-groups-age-cases
 
@@ -67,15 +68,6 @@ class CAGovDashboardGroupsAgeCases extends window.HTMLElement {
       },
     };
 
-    this.intFormatter = new Intl.NumberFormat(
-      "us", // forcing US to avoid mixed styles on translated pages
-      { style: "decimal", minimumFractionDigits: 0, maximumFractionDigits: 0 }
-    );
-    this.pctFormatter = new Intl.NumberFormat(
-      "us", // forcing US to avoid mixed styles on translated pages
-      { style: "percent", minimumFractionDigits: 1, maximumFractionDigits: 1 }
-    );
-
     getScreenResizeCharts(this);
 
     this.screenDisplayType = window.charts
@@ -130,8 +122,8 @@ class CAGovDashboardGroupsAgeCases extends window.HTMLElement {
     let bd = baselineData.filter(bd => bd.CATEGORY == d.CATEGORY);
     // !! replacements here for category, metric-value, metric-baseline-value
     tooltipText = tooltipText.replace('{category}', `<span class='highlight-data'>${d.CATEGORY}</span>`);
-    tooltipText = tooltipText.replace('{metric-value}', `<span class='highlight-data'>${this.pctFormatter.format(d.METRIC_VALUE)}</span>`);
-    tooltipText = tooltipText.replace('{metric-baseline-value}', `<span class='highlight-data'>${this.pctFormatter.format(bd[0].METRIC_VALUE)}</span>`);
+    tooltipText = tooltipText.replace('{metric-value}', `<span class='highlight-data'>${formatValue(d.METRIC_VALUE,{format:'percent'})}</span>`);
+    tooltipText = tooltipText.replace('{metric-baseline-value}', `<span class='highlight-data'>${formatValue(bd[0].METRIC_VALUE,{format:'percent'})}</span>`);
     return `<div class="chart-tooltip"><div>${tooltipText}</div></div>`;
   }
 
@@ -139,8 +131,8 @@ class CAGovDashboardGroupsAgeCases extends window.HTMLElement {
     let caption = this.translationsObj.chartBarCaption;
     let bd = baselineData.filter(bd => bd.CATEGORY == d.CATEGORY);
     caption = caption.replace('{category}', d.CATEGORY);
-    caption = caption.replace('{metric-value}', this.pctFormatter.format(d.METRIC_VALUE));
-    caption = caption.replace('{metric-baseline-value}', this.pctFormatter.format(bd[0].METRIC_VALUE));
+    caption = caption.replace('{metric-value}', formatValue(d.METRIC_VALUE,{format:'percent'}));
+    caption = caption.replace('{metric-baseline-value}', formatValue(bd[0].METRIC_VALUE,{format:'percent'}));
     // console.log("Aria Label",caption);
     return caption;
   }

--- a/src/js/dashboard-v2/charts/cagov-chart-dashboard-groups-age-deaths/index.js
+++ b/src/js/dashboard-v2/charts/cagov-chart-dashboard-groups-age-deaths/index.js
@@ -3,6 +3,7 @@ import getTranslations from "../../../common/get-strings-list.js";
 import getScreenResizeCharts from "../../../common/get-window-size.js";
 import rtlOverride from "../../../common/rtl-override.js";
 import renderChart from "../../../common/charts/simple-barchart.js";
+import formatValue from "../../../common/value-formatters.js";
 
 // cagov-chart-dashboard-groups-age-deaths
 
@@ -64,15 +65,6 @@ class CAGovDashboardGroupsAgeDeaths extends window.HTMLElement {
       },
     };
 
-    this.intFormatter = new Intl.NumberFormat(
-      "us", // forcing US to avoid mixed styles on translated pages
-      { style: "decimal", minimumFractionDigits: 0, maximumFractionDigits: 0 }
-    );
-    this.pctFormatter = new Intl.NumberFormat(
-      "us", // forcing US to avoid mixed styles on translated pages
-      { style: "percent", minimumFractionDigits: 1, maximumFractionDigits: 1 }
-    );
-
     getScreenResizeCharts(this);
 
     this.screenDisplayType = window.charts
@@ -128,8 +120,8 @@ class CAGovDashboardGroupsAgeDeaths extends window.HTMLElement {
     let bd = baselineData.filter(bd => bd.CATEGORY == d.CATEGORY);
     // !! replacements here for category, metric-value, metric-baseline-value
     tooltipText = tooltipText.replace('{category}', `<span class='highlight-data'>${d.CATEGORY}</span>`);
-    tooltipText = tooltipText.replace('{metric-value}', `<span class='highlight-data'>${this.pctFormatter.format(d.METRIC_VALUE)}</span>`);
-    tooltipText = tooltipText.replace('{metric-baseline-value}', `<span class='highlight-data'>${this.pctFormatter.format(bd[0].METRIC_VALUE)}</span>`);
+    tooltipText = tooltipText.replace('{metric-value}', `<span class='highlight-data'>${formatValue(d.METRIC_VALUE,{format:'percent'})}</span>`);
+    tooltipText = tooltipText.replace('{metric-baseline-value}', `<span class='highlight-data'>${formatValue(bd[0].METRIC_VALUE,{format:'percent'})}</span>`);
     return `<div class="chart-tooltip"><div>${tooltipText}</div></div>`;
   }
 
@@ -137,8 +129,8 @@ class CAGovDashboardGroupsAgeDeaths extends window.HTMLElement {
     let caption = this.translationsObj.chartBarCaption;
     let bd = baselineData.filter(bd => bd.CATEGORY == d.CATEGORY);
     caption = caption.replace('{category}', d.CATEGORY);
-    caption = caption.replace('{metric-value}', this.pctFormatter.format(d.METRIC_VALUE));
-    caption = caption.replace('{metric-baseline-value}', this.pctFormatter.format(bd[0].METRIC_VALUE));
+    caption = caption.replace('{metric-value}', formatValue(d.METRIC_VALUE,{format:'percent'}));
+    caption = caption.replace('{metric-baseline-value}', formatValue(bd[0].METRIC_VALUE,{format:'percent'}));
     // console.log("Aria Label",caption);
     return caption;
   }

--- a/src/js/dashboard-v2/charts/cagov-chart-dashboard-groups-gender-cases/index.js
+++ b/src/js/dashboard-v2/charts/cagov-chart-dashboard-groups-gender-cases/index.js
@@ -5,6 +5,7 @@ import rtlOverride from "../../../common/rtl-override.js";
 import renderChart from "../../../common/charts/simple-barchart.js";
 import { parseSnowflakeDate, reformatJSDate } from "../../../common/readable-date.js";
 import applySubstitutions from "./../../../common/apply-substitutions.js";
+import formatValue from "./../../../common/value-formatters.js";
 
 // cagov-chart-dashboard-groups-gender-cases
 
@@ -71,15 +72,6 @@ class CAGovDashboardGroupsGenderCases extends window.HTMLElement {
       // 'Unknown':'Unknown/undifferentiated',
     };
 
-    this.intFormatter = new Intl.NumberFormat(
-      "us", // forcing US to avoid mixed styles on translated pages
-      { style: "decimal", minimumFractionDigits: 0, maximumFractionDigits: 0 }
-    );
-    this.pctFormatter = new Intl.NumberFormat(
-      "us", // forcing US to avoid mixed styles on translated pages
-      { style: "percent", minimumFractionDigits: 1, maximumFractionDigits: 1 }
-    );
-
     getScreenResizeCharts(this);
 
     this.screenDisplayType = window.charts
@@ -134,8 +126,8 @@ class CAGovDashboardGroupsGenderCases extends window.HTMLElement {
     let bd = baselineData.filter(bd => bd.CATEGORY == d.CATEGORY);
     // !! replacements here for category, metric-value, metric-baseline-value
     tooltipText = tooltipText.replace('{category}', `<span class='highlight-data'>${d.CATEGORY}s</span>`);
-    tooltipText = tooltipText.replace('{metric-value}', `<span class='highlight-data'>${this.pctFormatter.format(d.METRIC_VALUE)}</span>`);
-    tooltipText = tooltipText.replace('{metric-baseline-value}', `<span class='highlight-data'>${this.pctFormatter.format(bd[0].METRIC_VALUE)}</span>`);
+    tooltipText = tooltipText.replace('{metric-value}', `<span class='highlight-data'>${formatValue(d.METRIC_VALUE,{format:'percent'})}</span>`);
+    tooltipText = tooltipText.replace('{metric-baseline-value}', `<span class='highlight-data'>${formatValue(bd[0].METRIC_VALUE,{format:'percent'})}</span>`);
     return `<div class="chart-tooltip"><div>${tooltipText}</div></div>`;
   }
 
@@ -143,8 +135,8 @@ class CAGovDashboardGroupsGenderCases extends window.HTMLElement {
     let caption = this.translationsObj.chartBarCaption;
     let bd = baselineData.filter(bd => bd.CATEGORY == d.CATEGORY);
     caption = caption.replace('{category}', d.CATEGORY+'s');
-    caption = caption.replace('{metric-value}', this.pctFormatter.format(d.METRIC_VALUE));
-    caption = caption.replace('{metric-baseline-value}', this.pctFormatter.format(bd[0].METRIC_VALUE));
+    caption = caption.replace('{metric-value}', formatValue(d.METRIC_VALUE,{format:'percent'}));
+    caption = caption.replace('{metric-baseline-value}', formatValue(bd[0].METRIC_VALUE,{format:'percent'}));
     // console.log("Aria Label",caption);
     return caption;
   }

--- a/src/js/dashboard-v2/charts/cagov-chart-dashboard-groups-gender-deaths/index.js
+++ b/src/js/dashboard-v2/charts/cagov-chart-dashboard-groups-gender-deaths/index.js
@@ -3,6 +3,7 @@ import getTranslations from "../../../common/get-strings-list.js";
 import getScreenResizeCharts from "../../../common/get-window-size.js";
 import rtlOverride from "../../../common/rtl-override.js";
 import renderChart from "../../../common/charts/simple-barchart.js";
+import formatValue from "./../../../common/value-formatters.js";
 
 // cagov-chart-dashboard-groups-gender-deaths
 
@@ -68,15 +69,6 @@ class CAGovDashboardGroupsGenderDeaths extends window.HTMLElement {
       // 'Unknown':'Unknown/undifferentiated',
     };
 
-    this.intFormatter = new Intl.NumberFormat(
-      "us", // forcing US to avoid mixed styles on translated pages
-      { style: "decimal", minimumFractionDigits: 0, maximumFractionDigits: 0 }
-    );
-    this.pctFormatter = new Intl.NumberFormat(
-      "us", // forcing US to avoid mixed styles on translated pages
-      { style: "percent", minimumFractionDigits: 1, maximumFractionDigits: 1 }
-    );
-
     getScreenResizeCharts(this);
 
     this.screenDisplayType = window.charts
@@ -131,8 +123,8 @@ class CAGovDashboardGroupsGenderDeaths extends window.HTMLElement {
     let bd = baselineData.filter(bd => bd.CATEGORY == d.CATEGORY);
     // !! replacements here for category, metric-value, metric-baseline-value
     tooltipText = tooltipText.replace('{category}', `<span class='highlight-data'>${d.CATEGORY}s</span>`);
-    tooltipText = tooltipText.replace('{metric-value}', `<span class='highlight-data'>${this.pctFormatter.format(d.METRIC_VALUE)}</span>`);
-    tooltipText = tooltipText.replace('{metric-baseline-value}', `<span class='highlight-data'>${this.pctFormatter.format(bd[0].METRIC_VALUE)}</span>`);
+    tooltipText = tooltipText.replace('{metric-value}', `<span class='highlight-data'>${formatValue(d.METRIC_VALUE,{format:'percent'})}</span>`);
+    tooltipText = tooltipText.replace('{metric-baseline-value}', `<span class='highlight-data'>${formatValue(bd[0].METRIC_VALUE,{format:'percent'})}</span>`);
     return `<div class="chart-tooltip"><div>${tooltipText}</div></div>`;
   }
 
@@ -140,8 +132,8 @@ class CAGovDashboardGroupsGenderDeaths extends window.HTMLElement {
     let caption = this.translationsObj.chartBarCaption;
     let bd = baselineData.filter(bd => bd.CATEGORY == d.CATEGORY);
     caption = caption.replace('{category}', d.CATEGORY+'s');
-    caption = caption.replace('{metric-value}', this.pctFormatter.format(d.METRIC_VALUE));
-    caption = caption.replace('{metric-baseline-value}', this.pctFormatter.format(bd[0].METRIC_VALUE));
+    caption = caption.replace('{metric-value}', formatValue(d.METRIC_VALUE,{format:'percent'}));
+    caption = caption.replace('{metric-baseline-value}', formatValue(bd[0].METRIC_VALUE,{format:'percent'}));
     // console.log("Aria Label",caption);
     return caption;
   }

--- a/src/js/dashboard-v2/charts/cagov-chart-dashboard-groups-race-ethnicity-cases/index.js
+++ b/src/js/dashboard-v2/charts/cagov-chart-dashboard-groups-race-ethnicity-cases/index.js
@@ -5,6 +5,7 @@ import rtlOverride from "../../../common/rtl-override.js";
 import renderChart from "../../../common/charts/simple-barchart.js";
 import { parseSnowflakeDate, reformatJSDate } from "../../../common/readable-date.js";
 import applySubstitutions from "./../../../common/apply-substitutions.js";
+import formatValue from "./../../../common/value-formatters.js";
 
 // cagov-chart-dashboard-groups-race-ethnicity-cases
 
@@ -73,15 +74,6 @@ class CAGovDashboardGroupsRaceEthnicityCases extends window.HTMLElement {
       'Native Hawaiian and other Pacific Islander':'NHPI',
     };
 
-    this.intFormatter = new Intl.NumberFormat(
-      "us", // forcing US to avoid mixed styles on translated pages
-      { style: "decimal", minimumFractionDigits: 0, maximumFractionDigits: 0 }
-    );
-    this.pctFormatter = new Intl.NumberFormat(
-      "us", // forcing US to avoid mixed styles on translated pages
-      { style: "percent", minimumFractionDigits: 1, maximumFractionDigits: 1 }
-    );
-
     getScreenResizeCharts(this);
 
     this.screenDisplayType = window.charts
@@ -137,8 +129,8 @@ class CAGovDashboardGroupsRaceEthnicityCases extends window.HTMLElement {
     let bd = baselineData.filter(bd => bd.CATEGORY == d.CATEGORY);
     // !! replacements here for category, metric-value, metric-baseline-value
     tooltipText = tooltipText.replace('{category}', `<span class='highlight-data'>${d.CATEGORY}</span>`);
-    tooltipText = tooltipText.replace('{metric-value}', `<span class='highlight-data'>${this.pctFormatter.format(d.METRIC_VALUE)}</span>`);
-    tooltipText = tooltipText.replace('{metric-baseline-value}', `<span class='highlight-data'>${this.pctFormatter.format(bd[0].METRIC_VALUE)}</span>`);
+    tooltipText = tooltipText.replace('{metric-value}', `<span class='highlight-data'>${formatValue(d.METRIC_VALUE,{format:'percent'})}</span>`);
+    tooltipText = tooltipText.replace('{metric-baseline-value}', `<span class='highlight-data'>${formatValue(bd[0].METRIC_VALUE,{format:'percent'})}</span>`);
     return `<div class="chart-tooltip"><div>${tooltipText}</div></div>`;
   }
 
@@ -146,8 +138,8 @@ class CAGovDashboardGroupsRaceEthnicityCases extends window.HTMLElement {
     let caption = this.translationsObj.chartBarCaption;
     let bd = baselineData.filter(bd => bd.CATEGORY == d.CATEGORY);
     caption = caption.replace('{category}', d.CATEGORY);
-    caption = caption.replace('{metric-value}', this.pctFormatter.format(d.METRIC_VALUE));
-    caption = caption.replace('{metric-baseline-value}', this.pctFormatter.format(bd[0].METRIC_VALUE));
+    caption = caption.replace('{metric-value}', formatValue(d.METRIC_VALUE,{format:'percent'}));
+    caption = caption.replace('{metric-baseline-value}', formatValue(bd[0].METRIC_VALUE,{format:'percent'}));
     // console.log("Aria Label",caption);
     return caption;
   }

--- a/src/js/dashboard-v2/charts/cagov-chart-dashboard-groups-race-ethnicity-deaths/index.js
+++ b/src/js/dashboard-v2/charts/cagov-chart-dashboard-groups-race-ethnicity-deaths/index.js
@@ -3,6 +3,7 @@ import getTranslations from "../../../common/get-strings-list.js";
 import getScreenResizeCharts from "../../../common/get-window-size.js";
 import rtlOverride from "../../../common/rtl-override.js";
 import renderChart from "../../../common/charts/simple-barchart.js";
+import formatValue from "./../../../common/value-formatters.js";
 
 // cagov-chart-dashboard-groups-race-ethnicity-deaths
 
@@ -70,15 +71,6 @@ class CAGovDashboardGroupsRaceEthnicityDeaths extends window.HTMLElement {
       'Native Hawaiian and other Pacific Islander':'NHPI',
     };
 
-    this.intFormatter = new Intl.NumberFormat(
-      "us", // forcing US to avoid mixed styles on translated pages
-      { style: "decimal", minimumFractionDigits: 0, maximumFractionDigits: 0 }
-    );
-    this.pctFormatter = new Intl.NumberFormat(
-      "us", // forcing US to avoid mixed styles on translated pages
-      { style: "percent", minimumFractionDigits: 1, maximumFractionDigits: 1 }
-    );
-
     getScreenResizeCharts(this);
 
     this.screenDisplayType = window.charts
@@ -133,8 +125,8 @@ class CAGovDashboardGroupsRaceEthnicityDeaths extends window.HTMLElement {
     let bd = baselineData.filter(bd => bd.CATEGORY == d.CATEGORY);
     // !! replacements here for category, metric-value, metric-baseline-value
     tooltipText = tooltipText.replace('{category}', `<span class='highlight-data'>${d.CATEGORY}</span>`);
-    tooltipText = tooltipText.replace('{metric-value}', `<span class='highlight-data'>${this.pctFormatter.format(d.METRIC_VALUE)}</span>`);
-    tooltipText = tooltipText.replace('{metric-baseline-value}', `<span class='highlight-data'>${this.pctFormatter.format(bd[0].METRIC_VALUE)}</span>`);
+    tooltipText = tooltipText.replace('{metric-value}', `<span class='highlight-data'>${formatValue(d.METRIC_VALUE,{format:'percent'})}</span>`);
+    tooltipText = tooltipText.replace('{metric-baseline-value}', `<span class='highlight-data'>${formatValue(bd[0].METRIC_VALUE,{format:'percent'})}</span>`);
     return `<div class="chart-tooltip"><div>${tooltipText}</div></div>`;
   }
 
@@ -142,8 +134,8 @@ class CAGovDashboardGroupsRaceEthnicityDeaths extends window.HTMLElement {
     let caption = this.translationsObj.chartBarCaption;
     let bd = baselineData.filter(bd => bd.CATEGORY == d.CATEGORY);
     caption = caption.replace('{category}', d.CATEGORY);
-    caption = caption.replace('{metric-value}', this.pctFormatter.format(d.METRIC_VALUE));
-    caption = caption.replace('{metric-baseline-value}', this.pctFormatter.format(bd[0].METRIC_VALUE));
+    caption = caption.replace('{metric-value}', formatValue(d.METRIC_VALUE,{format:'percent'}));
+    caption = caption.replace('{metric-baseline-value}', formatValue(bd[0].METRIC_VALUE,{format:'percent'}));
     // console.log("Aria Label",caption);
     return caption;
   }

--- a/src/js/equity-dash/charts/relative-percentage-by-100k/draw-chart.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-100k/draw-chart.js
@@ -1,4 +1,5 @@
 import { chartOverlayBox, chartOverlayBoxClear } from "../../chart-overlay-box.js";
+import formatValue from "./../../../common/value-formatters.js";
 
 export default function drawBars(stackedData, data, statewideRatePer100k) {
   // console.log("Draw bars this.dimensions",this.dimensions);
@@ -173,7 +174,7 @@ export default function drawBars(stackedData, data, statewideRatePer100k) {
             d.METRIC_VALUE_PER_100K !== null
           ) {
             return d.METRIC_VALUE_PER_100K
-              ? this.intFormatter.format(d.METRIC_VALUE_PER_100K)
+              ? formatValue(d.METRIC_VALUE_PER_100K,{format:'integer'})
               : 0;
           } else {
             if (d.APPLIED_SUPPRESSION === "Total") {

--- a/src/js/equity-dash/charts/relative-percentage-by-100k/index.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-100k/index.js
@@ -5,6 +5,7 @@ import getTranslations from "../../../common/get-strings-list.js";
 import getScreenResizeCharts from "./../../../common/get-window-size.js";
 import { chartOverlayBox, chartOverlayBoxClear } from "../../chart-overlay-box.js";
 import rtlOverride from "./../../../common/rtl-override.js";
+import formatValue from "./../../../common/value-formatters.js";
 
 class CAGOVEquityRE100K extends window.HTMLElement {
   connectedCallback() {
@@ -64,11 +65,6 @@ class CAGOVEquityRE100K extends window.HTMLElement {
         },
       },
     };
-    this.intFormatter = new Intl.NumberFormat('us', // forcing US to avoid mixed styles on translated pages
-                  {style:'decimal', 
-                   minimumFractionDigits:0,
-                   maximumFractionDigits:0});
-
     // Resizing
     getScreenResizeCharts(this);
     this.screenDisplayType = window.charts
@@ -121,7 +117,7 @@ class CAGOVEquityRE100K extends window.HTMLElement {
         "--" +
         this.selectedMetric;
       let filterTxt =
-        this.translationsObj[key] + this.intFormatter.format(statewideRatePer100k);
+        this.translationsObj[key] + formatValue(statewideRatePer100k,{format:'integer'});
       // console.log("Filter key",key);
       // console.log("Filter text",filterTxt);
       filterTxt = filterTxt.replace(
@@ -141,7 +137,7 @@ class CAGOVEquityRE100K extends window.HTMLElement {
       let templateStr = this.translationsObj["chartToolTip-caption"];
       let caption = templateStr
         .replace("placeholderDEMO_CAT", a)
-        .replace("placeholderMETRIC_100K", this.intFormatter.format(b))
+        .replace("placeholderMETRIC_100K", formatValue(b,{format:'integer'}))
         .replace("placeholderFilterScope", c);
       return caption;
     };

--- a/src/js/equity-dash/charts/social-determinants/draw.js
+++ b/src/js/equity-dash/charts/social-determinants/draw.js
@@ -1,3 +1,5 @@
+import formatValue from "./../../../common/value-formatters.js";
+
 let labelMap = new Map();
 labelMap.set("below $40K","0 - $40K");
 labelMap.set("above $120K","$120K+");
@@ -170,7 +172,7 @@ function rewriteBarLabels(component, svg, data, x, y, sparkline) {
     .attr("y", d => y(d.CASE_RATE_PER_100K) - 5)
     .attr("width", x.bandwidth() / 4)
     .html(d => {
-      return `<tspan class="bold" dx="-1.25em" dy="-1.2em">${component.floatFormatter.format(d.CASE_RATE_PER_100K)}</tspan>
+      return `<tspan class="bold" dx="-1.25em" dy="-1.2em">${formatValue(d.CASE_RATE_PER_100K)}</tspan>
       <tspan dx="-1.5em" dy="1.2em">${parseFloat(d.RATE_DIFF_30_DAYS).toFixed(1)}%</tspan>`
     })
     .attr('text-anchor','middle')
@@ -210,7 +212,7 @@ function redrawYLine(component, y, dataset) {
     .attr('class','label bar-chart-yline');
   
   component.svg.append("text")
-    .text(`${component.translationsObj.statewideCaseRate} ${component.floatFormatter.format(component.yDValue)}`)
+    .text(`${component.translationsObj.statewideCaseRate} ${formatValue(component.yDValue,{format:'number',min_decimals:1})}`)
     .attr("y", yDottedLinePos - 6)
     // .attr("x", 38)
     // .attr('text-anchor','start')

--- a/src/js/equity-dash/charts/social-determinants/index.js
+++ b/src/js/equity-dash/charts/social-determinants/index.js
@@ -3,6 +3,7 @@ import {writeXAxis, writeXAxisLabel, rewriteLegend, writeLegend, writeBars, rewr
 import getTranslations from '../../../common/get-strings-list.js';
 import getScreenResizeCharts from './../../../common/get-window-size.js';
 import rtlOverride from "./../../../common/rtl-override.js";
+import formatValue from "./../../../common/value-formatters.js";
 import { reformatReadableDate } from "../../../common/readable-date.js";
 
 class CAGOVChartD3Bar extends window.HTMLElement {
@@ -82,17 +83,7 @@ class CAGOVChartD3Bar extends window.HTMLElement {
       },
     };
 
-    this.intFormatter = new Intl.NumberFormat('us', // forcing US to avoid mixed styles on translated pages
-                  {style:'decimal', 
-                   minimumFractionDigits:0,
-                   maximumFractionDigits:0});
-
-    this.floatFormatter = new Intl.NumberFormat('us', // forcing US to avoid mixed styles on translated pages
-                  {style:'decimal', 
-                   minimumFractionDigits:1,
-                   maximumFractionDigits:1});
-
-         getScreenResizeCharts(this);
+    getScreenResizeCharts(this);
     this.screenDisplayType = window.charts ? window.charts.displayType : 'desktop';
     this.chartBreakpointValues = this.chartOptions[this.screenDisplayType ? this.screenDisplayType : 'desktop'];
 
@@ -190,7 +181,7 @@ class CAGOVChartD3Bar extends window.HTMLElement {
       // ${parseFloat(d.CASE_RATE_PER_100K).toFixed(1)} cases per 100K people. ${parseFloat(d.RATE_DIFF_30_DAYS).toFixed(1)}% change since previous week
       let templateStr = this.translationsObj['ariaBarLabel']
       let label = templateStr
-                    .replace('placeholderCaseRate', this.floatFormatter.format(d.CASE_RATE_PER_100K))
+                    .replace('placeholderCaseRate', formatValue(d.CASE_RATE_PER_100K,{format:'number',min_decimals:1}))
                     .replace('placeholderRateDiff30', parseFloat(d.RATE_DIFF_30_DAYS).toFixed(1) + '%');
       return label;
   }
@@ -199,7 +190,7 @@ class CAGOVChartD3Bar extends window.HTMLElement {
       // <span class="highlight-data">${parseFloat(d.CASE_RATE_PER_100K).toFixed(1)}</span> cases per 100K people. ${parseFloat(d.RATE_DIFF_30_DAYS).toFixed(1)}% change since previous week
       let templateStr = this.translationsObj['tooltipCaption']
       let caption = templateStr
-                    .replace('placeholderCaseRate', this.floatFormatter.format(d.CASE_RATE_PER_100K))
+                    .replace('placeholderCaseRate', formatValue(d.CASE_RATE_PER_100K,{format:'number',min_decimals:1}))
                     .replace('placeholderRateDiff30', parseFloat(d.RATE_DIFF_30_DAYS).toFixed(1) + '%');
       return caption;
   }

--- a/src/js/vaccines/charts/cagov-chart-vaccination-groups-age/index.js
+++ b/src/js/vaccines/charts/cagov-chart-vaccination-groups-age/index.js
@@ -67,15 +67,6 @@ class CAGovVaccinationGroupsAge extends window.HTMLElement {
       },
     };
 
-    this.intFormatter = new Intl.NumberFormat(
-      "us", // forcing US to avoid mixed styles on translated pages
-      { style: "decimal", minimumFractionDigits: 0, maximumFractionDigits: 0 }
-    );
-    this.pctFormatter = new Intl.NumberFormat(
-      "us", // forcing US to avoid mixed styles on translated pages
-      { style: "percent", minimumFractionDigits: 1, maximumFractionDigits: 1 }
-    );
-
     getScreenResizeCharts(this);
 
     this.screenDisplayType = window.charts
@@ -201,8 +192,8 @@ class CAGovVaccinationGroupsAge extends window.HTMLElement {
           let footerDisplayText = applySubstitutions(this.translationsObj.chartDataLabel, footerReplacementDict);
           d3.select(this.querySelector(".chart-data-label")).text(footerDisplayText);
 
-          let croppedData = alldata.data.filter(function(a){return a.CATEGORY !== 'Unknown'});
-          this.alldata = croppedData;
+          // let croppedData = alldata.data.filter(function(a){return a.CATEGORY !== 'Unknown'});
+          // this.alldata = croppedData;
 
 
           renderChart.call(this,null,null,null,'ve-age');

--- a/src/js/vaccines/charts/cagov-chart-vaccination-groups-gender/index.js
+++ b/src/js/vaccines/charts/cagov-chart-vaccination-groups-gender/index.js
@@ -69,15 +69,6 @@ class CAGovVaccinationGroupsGender extends window.HTMLElement {
       },
     };
 
-    this.intFormatter = new Intl.NumberFormat(
-      "us", // forcing US to avoid mixed styles on translated pages
-      { style: "decimal", minimumFractionDigits: 0, maximumFractionDigits: 0 }
-    );
-    this.pctFormatter = new Intl.NumberFormat(
-      "us", // forcing US to avoid mixed styles on translated pages
-      { style: "percent", minimumFractionDigits: 1, maximumFractionDigits: 1 }
-    );
-
     getScreenResizeCharts(this);
 
     this.screenDisplayType = window.charts

--- a/src/js/vaccines/charts/cagov-chart-vaccination-groups-race-ethnicity-age/index.js
+++ b/src/js/vaccines/charts/cagov-chart-vaccination-groups-race-ethnicity-age/index.js
@@ -2,6 +2,7 @@ import template from "./template.js";
 import getTranslations from "./../../../common/get-strings-list.js";
 import getScreenResizeCharts from "./../../../common/get-window-size.js";
 import rtlOverride from "./../../../common/rtl-override.js";
+import formatValue from "./../../../common/value-formatters.js";
 
 class CAGovVaccinationGroupsRaceEthnicityAge extends window.HTMLElement {
   connectedCallback() {
@@ -70,15 +71,6 @@ class CAGovVaccinationGroupsRaceEthnicityAge extends window.HTMLElement {
         },
       },
     };
-
-    this.intFormatter = new Intl.NumberFormat(
-      "us", // forcing US to avoid mixed styles on translated pages
-      { style: "decimal", minimumFractionDigits: 0, maximumFractionDigits: 0 }
-    );
-    this.pctFormatter = new Intl.NumberFormat(
-      "us", // forcing US to avoid mixed styles on translated pages
-      { style: "percent", minimumFractionDigits: 1, maximumFractionDigits: 1 }
-    );
 
     getScreenResizeCharts(this);
 
@@ -221,9 +213,7 @@ class CAGovVaccinationGroupsRaceEthnicityAge extends window.HTMLElement {
       .attr("x", (d) => x(max_x_domain))
       // .attr("width", x.bandwidth() / 4)
       .html((d) => {
-        return `<tspan dx="1.0em">${this.intFormatter.format(
-          d.METRIC_VALUE
-        )}</tspan>`;
+        return `<tspan dx="1.0em">${formatValue(d.METRIC_VALUE,{format:'integer'})}</tspan>`;
       })
       .attr("dominant-baseline", "middle")
       .attr("text-anchor", "start");

--- a/src/js/vaccines/charts/cagov-chart-vaccination-groups-race-ethnicity/index.js
+++ b/src/js/vaccines/charts/cagov-chart-vaccination-groups-race-ethnicity/index.js
@@ -71,15 +71,6 @@ class CAGovVaccinationGroupsRaceEthnicity extends window.HTMLElement {
       },
     };
 
-    this.intFormatter = new Intl.NumberFormat(
-      "us", // forcing US to avoid mixed styles on translated pages
-      { style: "decimal", minimumFractionDigits: 0, maximumFractionDigits: 0 }
-    );
-    this.pctFormatter = new Intl.NumberFormat(
-      "us", // forcing US to avoid mixed styles on translated pages
-      { style: "percent", minimumFractionDigits: 1, maximumFractionDigits: 1 }
-    );
-
     getScreenResizeCharts(this);
 
     this.screenDisplayType = window.charts

--- a/src/js/vaccines/charts/cagov-chart-vaccines-hpi-by-dose/index.js
+++ b/src/js/vaccines/charts/cagov-chart-vaccines-hpi-by-dose/index.js
@@ -5,6 +5,7 @@ import getScreenResizeCharts from "./../../../common/get-window-size.js";
 import rtlOverride from "./../../../common/rtl-override.js";
 import applySubstitutions from "./../../../common/apply-substitutions.js";
 import { parseSnowflakeDate, reformatJSDate } from "./../../../common/readable-date.js";
+import formatValue from "./../../../common/value-formatters.js";
 
 class CAGovVaccinesHPIDose extends window.HTMLElement {
   connectedCallback() {
@@ -70,15 +71,6 @@ class CAGovVaccinesHPIDose extends window.HTMLElement {
       },
     };
 
-    this.intFormatter = new Intl.NumberFormat(
-      "us", // forcing US to avoid mixed styles on translated pages
-      { style: "decimal", minimumFractionDigits: 0, maximumFractionDigits: 0 }
-    );
-    this.pctFormatter = new Intl.NumberFormat(
-      "us", // forcing US to avoid mixed styles on translated pages
-      { style: "percent", minimumFractionDigits: 1, maximumFractionDigits: 1 }
-    );
-
     getScreenResizeCharts(this);
 
     this.screenDisplayType = window.charts
@@ -137,7 +129,7 @@ class CAGovVaccinesHPIDose extends window.HTMLElement {
 
   ariaLabel(d, totalDosesAllQuartiles) {
     const barLabel = applySubstitutions(this.translationsObj.barLabel, {'N':d.HPIQUARTILE});
-    let label = `${this.pctFormatter.format(d.COMBINED_DOSES/totalDosesAllQuartiles)} ${this.translationsObj.legendLabel1} in ${barLabel}`;
+    let label = `${formatValue(d.COMBINED_DOSES/totalDosesAllQuartiles,{format:'percent'})} ${this.translationsObj.legendLabel1} in ${barLabel}`;
     return label;
   }
 
@@ -163,7 +155,7 @@ class CAGovVaccinesHPIDose extends window.HTMLElement {
         .attr("class", "bar-upper-label-1")
         .attr("y", (d, i) => yScale(d.COMBINED_DOSES/totalDosesAllQuartiles) - 18)
         .attr("x", (d, i) => xScale(i)+xScale.bandwidth()/2)
-        .text(d => this.pctFormatter.format(d.COMBINED_DOSES/totalDosesAllQuartiles))
+        .text(d => formatValue(d.COMBINED_DOSES/totalDosesAllQuartiles,{format:'percent'}))
         .attr('text-anchor','middle');
 
     groups
@@ -171,7 +163,7 @@ class CAGovVaccinesHPIDose extends window.HTMLElement {
         .attr("class", "bar-upper-label-2")
         .attr("y", (d, i) => yScale(d.COMBINED_DOSES/totalDosesAllQuartiles) - 4)
         .attr("x", (d, i) => xScale(i)+xScale.bandwidth()/2)
-        .text((d,i) => this.intFormatter.format(d.COMBINED_DOSES))
+        .text((d,i) => formatValue(d.COMBINED_DOSES,{format:'integer'}))
         .attr('text-anchor','middle');
 
     

--- a/src/js/vaccines/charts/cagov-chart-vaccines-hpi-by-people/index.js
+++ b/src/js/vaccines/charts/cagov-chart-vaccines-hpi-by-people/index.js
@@ -5,6 +5,7 @@ import getScreenResizeCharts from "./../../../common/get-window-size.js";
 import rtlOverride from "./../../../common/rtl-override.js";
 import applySubstitutions from "./../../../common/apply-substitutions.js";
 import { parseSnowflakeDate, reformatJSDate } from "./../../../common/readable-date.js";
+import formatValue from "./../../../common/value-formatters.js";
 
 class CAGovVaccinesHPIPeople extends window.HTMLElement {
   connectedCallback() {
@@ -68,15 +69,6 @@ class CAGovVaccinesHPIPeople extends window.HTMLElement {
         },
       },
     };
-
-    this.intFormatter = new Intl.NumberFormat(
-      "us", // forcing US to avoid mixed styles on translated pages
-      { style: "decimal", minimumFractionDigits: 0, maximumFractionDigits: 0 }
-    );
-    this.pctFormatter = new Intl.NumberFormat(
-      "us", // forcing US to avoid mixed styles on translated pages
-      { style: "percent", minimumFractionDigits: 1, maximumFractionDigits: 1 }
-    );
 
     getScreenResizeCharts(this);
 
@@ -155,9 +147,9 @@ class CAGovVaccinesHPIPeople extends window.HTMLElement {
     let label = applySubstitutions(this.translationsObj.barLabel, {'N':d.D.HPIQUARTILE});
     // let label = `${this.translationsObj.barLabel.replace('{N}',d.D.HPIQUARTILE)} `;
     if(d.KEY == "PARTIALLY_VACCINATED_RATIO") {
-      label += `${this.pctFormatter.format(d.D.PARTIALLY_VACCINATED_RATIO)} ${this.translationsObj.legendLabel1}`;
+      label += `${formatValue(d.D.PARTIALLY_VACCINATED_RATIO,{format:'percent'})} ${this.translationsObj.legendLabel1}`;
     } else {
-      label += `${this.pctFormatter.format(d.D.FULLY_VACCINATED_RATIO)} ${this.translationsObj.legendLabel2}`;
+      label += `${formatValue(d.D.FULLY_VACCINATED_RATIO,{format:'percent'})} ${this.translationsObj.legendLabel2}`;
     }
     
     return label;
@@ -191,7 +183,7 @@ class CAGovVaccinesHPIPeople extends window.HTMLElement {
         .attr("class", "bar-upper-label-1")
         .attr("y", (d, i) => yScale(d.D[d.KEY]) - 18)
         .attr("x", (d, i) => xScaleInner(i)+xScaleInner.bandwidth()/2)
-        .text(d => this.pctFormatter.format(d.D[d.KEY]))
+        .text(d => formatValue(d.D[d.KEY],{format:'percent'}))
         .attr('text-anchor','middle');
     let capFields = ['PARTIALLY_VACCINATED', 'FULLY_VACCINATED'];
     let barcaps2 = groups
@@ -201,7 +193,7 @@ class CAGovVaccinesHPIPeople extends window.HTMLElement {
         .attr("class", "bar-upper-label-2")
         .attr("y", (d, i) => yScale(d.D[d.KEY]) - 4)
         .attr("x", (d, i) => xScaleInner(i)+xScaleInner.bandwidth()/2)
-        .text((d,i) => this.intFormatter.format(d.D[capFields[i]]))
+        .text((d,i) => formatValue(d.D[capFields[i]],{format:'integer'}))
         .attr('text-anchor','middle');
 
     // bottom caption


### PR DESCRIPTION
Added generic formatter for percents, small-numbers and integers. Replaced use of locally initialized formatters with this function. 

Fixed format of small floats and percents to add up to 3 decimal places as needed.

Added Unknown category to Vaccines by Age graph (which shows up with adequate decimal places now).

Added FloatSmall formatter for summary boxes with the above behavior.