### PR TITLE
Fixed number formatting bug in equity chart.

### DIFF
--- a/src/js/equity-dash/charts/social-determinants/draw.js
+++ b/src/js/equity-dash/charts/social-determinants/draw.js
@@ -172,7 +172,7 @@ function rewriteBarLabels(component, svg, data, x, y, sparkline) {
     .attr("y", d => y(d.CASE_RATE_PER_100K) - 5)
     .attr("width", x.bandwidth() / 4)
     .html(d => {
-      return `<tspan class="bold" dx="-1.25em" dy="-1.2em">${formatValue(d.CASE_RATE_PER_100K)}</tspan>
+      return `<tspan class="bold" dx="-1.25em" dy="-1.2em">${formatValue(d.CASE_RATE_PER_100K,{format:'number'})}</tspan>
       <tspan dx="-1.5em" dy="1.2em">${parseFloat(d.RATE_DIFF_30_DAYS).toFixed(1)}%</tspan>`
     })
     .attr('text-anchor','middle')


### PR DESCRIPTION
Missing parameter to formatting function was causing labels to not appear in tabbed charts on the bottom of the equity page.