### PR TITLE
override the large ul line heights when we want small bullets

### DIFF
--- a/src/css/_general.scss
+++ b/src/css/_general.scss
@@ -2070,6 +2070,9 @@ font {
 .text-small {
   font-size: 0.85rem !important;
 }
+ul.small-text {
+  line-height: 1.5rem;
+}
 .caption {
   font-size: 0.95rem !important;
   line-height: 1.5;


### PR DESCRIPTION
change required for new vaccines charts page which has bullets that are all small text