### PR TITLE
fixing ko food-resources bold text

### DIFF
--- a/pages/translated-posts/food-resources-ko.html
+++ b/pages/translated-posts/food-resources-ko.html
@@ -44,7 +44,7 @@ addtositemap: true
 
 
 
-<h4></strong><strong>대학생을 대상으로 <strong>임시 확대 </strong><strong> 자격 시행</strong></h4>
+<h4>대학생을 대상으로 임시 확대 자격 시행</h4>
 
 
 


### PR DESCRIPTION
Addresses a bold issue in the Korean food-resource page.
https://digital-ca-gov.atlassian.net/browse/CCG-1886

Fixed the original page to remove redundant `<strong>` tags.
see https://github.com/cagov/covid19/commit/244ab1b50dcf97fdd3ee2001cdf7cb064dc2a90f