### PR TITLE
Add ID to pagerating section so that it can be linked to

### DIFF
--- a/pages/_includes/footer.njk
+++ b/pages/_includes/footer.njk
@@ -12,7 +12,7 @@ ga('tracker3.send', 'pageview');
 </script>
 <script async defer src='https://www.google-analytics.com/analytics.js'></script>
 
-<pagerating-section>
+<pagerating-section id="pagerating-section">
 	<cagov-pagefeedback 
 	data-endpoint-url="https://api.alpha.ca.gov/WasHelpful"
 	data-question="{{text.is_this_page_useful}}"


### PR DESCRIPTION
Per @aaronhans's direction, this PR adds an id to the page rating section so that it can be linked to directly (which we want to do on the in-development broadband benefit page)