### PR TITLE
bump packages to fix security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@cagov/accordion": "^2.0.8",
+        "@cagov/accordion": "^2.0.11",
         "@cagov/anchor-events": "^1.0.0",
         "@cagov/go-to-top": "^1.0.8",
         "@cagov/lookup": "^1.0.3",
@@ -1501,9 +1501,9 @@
       "dev": true
     },
     "node_modules/@cagov/accordion": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@cagov/accordion/-/accordion-2.0.8.tgz",
-      "integrity": "sha512-8XRg4jkLiHjBLx/6kx3pbkmdFAna58IslQCAcvSd/tQgNuK2+3n6/dEiDEto1+rM+xP6WlYaLXDTBJpXoauOjg=="
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@cagov/accordion/-/accordion-2.0.11.tgz",
+      "integrity": "sha512-34M0f/d5mafMLul0zUjwMbneBeRkR8/RSmjr4AtbEW6Vqg1YK1dkxaXGQ166G0u5YGORlobBOvMd6H/8+dqGcQ=="
     },
     "node_modules/@cagov/anchor-events": {
       "version": "1.0.0",
@@ -6220,9 +6220,9 @@
       }
     },
     "node_modules/engine.io-client": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.1.tgz",
-      "integrity": "sha512-oVu9kBkGbcggulyVF0kz6BV3ganqUeqXvD79WOFKa+11oK692w1NyFkuEj4xrkFRpZhn92QOqTk4RQq5LiBXbQ==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.2.tgz",
+      "integrity": "sha512-QEqIp+gJ/kMHeUun7f5Vv3bteRHppHH/FMBQX/esFj/fuYfjyUKWGMo3VCvIP/V8bE9KcjHmRZrhIz2Z9oNsDA==",
       "dev": true,
       "dependencies": {
         "component-emitter": "~1.3.0",
@@ -6234,7 +6234,7 @@
         "parseqs": "0.0.6",
         "parseuri": "0.0.6",
         "ws": "~7.4.2",
-        "xmlhttprequest-ssl": "~1.5.4",
+        "xmlhttprequest-ssl": "~1.6.2",
         "yeast": "0.1.2"
       }
     },
@@ -9017,9 +9017,9 @@
       }
     },
     "node_modules/hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
     },
     "node_modules/hsl-regex": {
       "version": "1.0.0",
@@ -12583,9 +12583,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.1.22",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.22.tgz",
-      "integrity": "sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ==",
+      "version": "3.1.23",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
+      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
       "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -14119,13 +14119,13 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.2.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.9.tgz",
-      "integrity": "sha512-b+TmuIL4jGtCHtoLi+G/PisuIl9avxs8IZMSmlABRwNz5RLUUACrC+ws81dcomz1nRezm5YPdXiMEzBEKgYn+Q==",
+      "version": "8.2.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.15.tgz",
+      "integrity": "sha512-2zO3b26eJD/8rb106Qu2o7Qgg52ND5HPjcyQiK2B98O388h43A448LCslC0dI2P97wCAQRJsFvwTRcXxTKds+Q==",
       "dev": true,
       "dependencies": {
         "colorette": "^1.2.2",
-        "nanoid": "^3.1.22",
+        "nanoid": "^3.1.23",
         "source-map": "^0.6.1"
       },
       "engines": {
@@ -24041,9 +24041,9 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
     },
     "node_modules/xmlhttprequest-ssl": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
-      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.2.tgz",
+      "integrity": "sha512-tYOaldF/0BLfKuoA39QMwD4j2m8lq4DIncqj1yuNELX4vz9+z/ieG/vwmctjJce+boFHXstqhWnHSxc4W8f4qg==",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
@@ -25436,9 +25436,9 @@
       "dev": true
     },
     "@cagov/accordion": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@cagov/accordion/-/accordion-2.0.8.tgz",
-      "integrity": "sha512-8XRg4jkLiHjBLx/6kx3pbkmdFAna58IslQCAcvSd/tQgNuK2+3n6/dEiDEto1+rM+xP6WlYaLXDTBJpXoauOjg=="
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@cagov/accordion/-/accordion-2.0.11.tgz",
+      "integrity": "sha512-34M0f/d5mafMLul0zUjwMbneBeRkR8/RSmjr4AtbEW6Vqg1YK1dkxaXGQ166G0u5YGORlobBOvMd6H/8+dqGcQ=="
     },
     "@cagov/anchor-events": {
       "version": "1.0.0",
@@ -29265,9 +29265,9 @@
       }
     },
     "engine.io-client": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.1.tgz",
-      "integrity": "sha512-oVu9kBkGbcggulyVF0kz6BV3ganqUeqXvD79WOFKa+11oK692w1NyFkuEj4xrkFRpZhn92QOqTk4RQq5LiBXbQ==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.2.tgz",
+      "integrity": "sha512-QEqIp+gJ/kMHeUun7f5Vv3bteRHppHH/FMBQX/esFj/fuYfjyUKWGMo3VCvIP/V8bE9KcjHmRZrhIz2Z9oNsDA==",
       "dev": true,
       "requires": {
         "component-emitter": "~1.3.0",
@@ -29279,7 +29279,7 @@
         "parseqs": "0.0.6",
         "parseuri": "0.0.6",
         "ws": "~7.4.2",
-        "xmlhttprequest-ssl": "~1.5.4",
+        "xmlhttprequest-ssl": "~1.6.2",
         "yeast": "0.1.2"
       },
       "dependencies": {
@@ -31515,9 +31515,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.8.tgz",
-      "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
     },
     "hsl-regex": {
       "version": "1.0.0",
@@ -34316,9 +34316,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.1.22",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.22.tgz",
-      "integrity": "sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ==",
+      "version": "3.1.23",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
+      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
       "dev": true
     },
     "nanomatch": {
@@ -35495,13 +35495,13 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "postcss": {
-      "version": "8.2.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.9.tgz",
-      "integrity": "sha512-b+TmuIL4jGtCHtoLi+G/PisuIl9avxs8IZMSmlABRwNz5RLUUACrC+ws81dcomz1nRezm5YPdXiMEzBEKgYn+Q==",
+      "version": "8.2.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.15.tgz",
+      "integrity": "sha512-2zO3b26eJD/8rb106Qu2o7Qgg52ND5HPjcyQiK2B98O388h43A448LCslC0dI2P97wCAQRJsFvwTRcXxTKds+Q==",
       "dev": true,
       "requires": {
         "colorette": "^1.2.2",
-        "nanoid": "^3.1.22",
+        "nanoid": "^3.1.23",
         "source-map": "^0.6.1"
       },
       "dependencies": {
@@ -43088,9 +43088,9 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
     },
     "xmlhttprequest-ssl": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.5.tgz",
-      "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4=",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.2.tgz",
+      "integrity": "sha512-tYOaldF/0BLfKuoA39QMwD4j2m8lq4DIncqj1yuNELX4vz9+z/ieG/vwmctjJce+boFHXstqhWnHSxc4W8f4qg==",
       "dev": true
     },
     "xtend": {


### PR DESCRIPTION
Security fixes for package subdependencies: xmlhttprequest-ssl -> engine.io

Warning of this issue provided by github monitoring and npm audit

Package updates have been deployed to staging and preproduction