### PR TITLE
fix label

### DIFF
--- a/pages/_includes/news-feed-home.html
+++ b/pages/_includes/news-feed-home.html
@@ -13,7 +13,7 @@
         {%- endfor %}
       </div>
       <a href="latest-news/" class="link-arrow-blue">
-        <div class="link-arrow-label">{{varViewMoreNews}}</div>
+        <div class="link-arrow-label">{{translatedLabels.varViewMoreNews}}</div>
         <cagov-arrow></cagov-arrow>
       </a>
     </div>


### PR DESCRIPTION
Text for link missing is causing accessibility audit fail