### PR TITLE
Added support for #location-county anchors on state-dash and equity page.

### DIFF
--- a/src/js/dashboard-v3/charts/cagov-chart-dashboard-confirmed-cases/index.js
+++ b/src/js/dashboard-v3/charts/cagov-chart-dashboard-confirmed-cases/index.js
@@ -196,11 +196,13 @@ class CAGovDashboardConfirmedCases extends window.HTMLElement {
       "county-selected",
       function (e) {
         this.county = e.detail.county;
+        let countyEncoded = this.county.toLowerCase().replace(/ /g, "_");
         let searchURL = config.chartsStateDashTablesLoc + this.chartOptions.dataUrlCounty.replace(
           "<county>",
-          this.county.toLowerCase().replace(/ /g, "_")
+          countyEncoded
         );
         this.retrieveData(searchURL, e.detail.county);
+        document.location.replace( '#location-' + countyEncoded);
       }.bind(this),
       false
     );

--- a/src/js/dashboard-v3/index.js
+++ b/src/js/dashboard-v3/index.js
@@ -65,3 +65,4 @@ groupTogglers.forEach(toggle => {
     this.classList.add('toggle-active');
   })
 })
+

--- a/src/js/equity-dash/charts/relative-percentage-by-pop/index.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-pop/index.js
@@ -374,6 +374,8 @@ class CAGOVEquityREPop extends window.HTMLElement {
         );
         this.resetTitle();
         this.resetDescription();
+        let countyEncoded = e.detail.county.toLowerCase().replace(' ','_');
+        document.location.replace( '#location-' + countyEncoded);
       }.bind(this),
       false
     );

--- a/src/js/equity-dash/search/index.js
+++ b/src/js/equity-dash/search/index.js
@@ -33,6 +33,19 @@ class CAGovCountySearch extends window.HTMLElement {
         }
   }
 
+  handleURLPayload() {
+    // Support URL with #location-countyname
+    let curHREF = document.location.href;
+    if (curHREF.includes('#location-')) {
+      let loc = curHREF.split('#location-')[1].replace('_',' ').replace('-',' ');
+      let countyInput = document.querySelector("#location-query");
+      if (loc != 'california') {
+        console.log("Triggering county search",loc,countyInput);
+        this.processCountySearchInput(loc);
+      }
+    }
+  }
+
   connectedCallback () {
     let countyLabel = 'County';
     if(this.dataset.countyLabel) {
@@ -60,10 +73,12 @@ class CAGovCountySearch extends window.HTMLElement {
         let typedInValue = document.querySelector('#location-query').value.trim();
         this.processCountySearchInput(typedInValue);
       }.bind(this))  
+      this.handleURLPayload();
     }.bind(this));
 
     rtlOverride(this, 'div', 'ltr');
 
+    
   }
 
   setupAutoComp(fieldSelector, fieldName, aList) {


### PR DESCRIPTION
When county or statewide is selected, the URL gets updated with

#location-<county>
or
#location-california

When the state-dashboard page is loaded, if the URL contains #location-<county> (and the county name is valid) it performs a county search. Same with equity page.  This enables specific counties to be bookmarked and shared more easily.  Does not work on Vaccines page.