### PR TITLE
Fixed GA error tracker.

### DIFF
--- a/src/js/tracking-you/index.js
+++ b/src/js/tracking-you/index.js
@@ -170,23 +170,29 @@ export default function setupAnalytics() {
   };
 
   // Report a single error to GA.
-  const trackError = (error, fieldsObj = {}) => {
-    window.ga('tracker3.send', 'event', Object.assign({
-      eventCategory: 'javascript',
-      eventAction: 'error',
-      eventLabel: (error && error.stack) || '(not set)',
-      nonInteraction: true
-    }, fieldsObj));
+  const trackError = (error, errorMsg = {}) => {
+    // console.log("Tracking error");
+    const fieldsObj = { eventAction: 'uncaught error: ' + errorMsg };
+    window.ga('send', 'event', 'javascript', 'error', (error && error.stack) || '(not set)', fieldsObj);
+    // this syntax does not work
+    // window.ga('send', 'event', Object.assign({
+    //   eventCategory: 'javascript',
+    //   eventAction: 'error',
+    //   eventLabel: (error && error.stack) || '(not set)',
+    //   nonInteraction: true
+    // }, fieldsObj));
   };
 
   // Tracks and reports errors to GA.
   const trackErrors = () => {
     // Fetch and report errors that we catch before GA is ready.
-    const loadErrorEvents = (window.__e && window.__e.q) || [];
-    const fieldsObj = { eventAction: 'uncaught error' };
-    loadErrorEvents.forEach((event) => trackError(event.error, fieldsObj));
+    // console.log("Tracking Errors Setup")
+    // // this is not currently being set up at loadtime
+    // const loadErrorEvents = (window.__e && window.__e.q) || [];
+    // const fieldsObj = { eventAction: 'uncaught error' };
+    // loadErrorEvents.forEach((event) => trackError(event.error, fieldsObj));
     // Add a new listener to track events in real-time, after we get through the backlog.
-    window.addEventListener('error', (event) => trackError(event.error, fieldsObj));
+    window.addEventListener('error', (event) => trackError(event.error, event.message));
   };
 
   // Check to see if we're on any of the available homepages.


### PR DESCRIPTION
1. Switched to send to our main GA account so we can monitor it.
2. Turned off code which depends on preloading of error events, which we are currently not doing.
3. Fixed syntax of ga() so it works properly.
4. Added error.message to the label.