### PR TITLE
Adjust spacing for safer economy page

### DIFF
--- a/src/css/_reopening.scss
+++ b/src/css/_reopening.scss
@@ -1,6 +1,7 @@
 .safer-economy-page {
   .jumbotron + .container {
-    padding-top: 0;
+    padding-top: 35px;
+    padding-bottom: 10px;
   }
   .jumbotron {
     margin-bottom: 0;
@@ -14,6 +15,10 @@
       }
     }
   }
+}
+
+.highlight {
+  margin-bottom: 50px;
 }
 
 html[dir=rtl] {


### PR DESCRIPTION
Increase padding on Safer Economy page around banner. Will need to be reverted when banner is removed.