### PR TITLE
revert pipeline changes

### DIFF
--- a/pages/rootcopy/azure-pipelines.yml
+++ b/pages/rootcopy/azure-pipelines.yml
@@ -10,15 +10,10 @@ trigger:
 pr: none
 
 pool:
- name: Default
- Agent.Name: 'VM-CDT-PUB-JMP1-AGENT2'
+ ReleaseAgent: AzureProdAse
+ Agent.Name: prod-ase01-jump
 
 steps:
-
-- checkout: self
-  
-  fetchDepth: 2
-
 - task: DeleteFiles@1
   name: Delete_Git_Folder
   inputs:


### PR DESCRIPTION
The updates made today were done to cope with Azure outage. We pointed the pipeline at a dedicated build server. This doesn't yet have autoscaling so now that the azure outage is over we want to revert to the shared pool