### PR TITLE
CCG-2361 Removed tags from aria-labels on three chart types.

### DIFF
--- a/src/js/equity-dash/charts/data-completeness/draw.js
+++ b/src/js/equity-dash/charts/data-completeness/draw.js
@@ -95,10 +95,10 @@ function drawBars(svg, x, y, yAxis, stackedData, color, data, tooltip, translati
           complete: false,
         });
       }
+      // remove tags and trim excess whitespace
       caption = caption.replace( /(<([^>]+)>)/ig, ' ');
       caption = caption.replace( /\s+/g, ' ');
-      caption = caption.replace( /^ /g, '');
-      caption = caption.replace( / $/g, '');
+      caption = caption.trim();
       return caption;
     })
 

--- a/src/js/equity-dash/charts/data-completeness/draw.js
+++ b/src/js/equity-dash/charts/data-completeness/draw.js
@@ -80,20 +80,27 @@ function drawBars(svg, x, y, yAxis, stackedData, color, data, tooltip, translati
       let percentMissing = d.data.MISSING
         ? parseFloat(d.data.MISSING * 100).toFixed(1) + "%"
         : 0;
+      let caption = '';
 
       if (d[0] == 0) {
-        return translations.chartTooltip({
+        caption = translations.chartTooltip({
           metric: d.data.METRIC,
           highlightData: percentNotMissing,
           complete: true,
         });
       } else {
-        return translations.chartTooltip({
+        caption = translations.chartTooltip({
           metric: d.data.METRIC,
           highlightData: percentMissing,
           complete: false,
         });
-      }})
+      }
+      caption = caption.replace( /(<([^>]+)>)/ig, ' ');
+      caption = caption.replace( /\s+/g, ' ');
+      caption = caption.replace( /^ /g, '');
+      caption = caption.replace( / $/g, '');
+      return caption;
+    })
 
     .on("mouseover focus", function(event, d) {
       d3.select(this).transition();

--- a/src/js/equity-dash/charts/relative-percentage-by-100k/draw-chart.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-100k/draw-chart.js
@@ -75,10 +75,10 @@ export default function drawBars(stackedData, data, statewideRatePer100k) {
       } else if (d.data.APPLIED_SUPPRESSION === "Population") {
         caption = translationsObj['data-missing-applied-suppression-population'+ "--" + selectedMetric.toLowerCase()] || '';
       }
+      // remove tags and trim excess whitespace
       caption = caption.replace( /(<([^>]+)>)/ig, ' ');
       caption = caption.replace( /\s+/g, ' ');
-      caption = caption.replace( /^ /g, '');
-      caption = caption.replace( / $/g, '');
+      caption = caption.trim();
       // console.log("Set 100k aria-label",caption);
       return caption;
     })

--- a/src/js/equity-dash/charts/relative-percentage-by-100k/draw-chart.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-100k/draw-chart.js
@@ -75,8 +75,12 @@ export default function drawBars(stackedData, data, statewideRatePer100k) {
       } else if (d.data.APPLIED_SUPPRESSION === "Population") {
         caption = translationsObj['data-missing-applied-suppression-population'+ "--" + selectedMetric.toLowerCase()] || '';
       }
-
-      return `<div class="chart-tooltip"><div>${caption}</div></div>`;
+      caption = caption.replace( /(<([^>]+)>)/ig, ' ');
+      caption = caption.replace( /\s+/g, ' ');
+      caption = caption.replace( /^ /g, '');
+      caption = caption.replace( / $/g, '');
+      // console.log("Set 100k aria-label",caption);
+      return caption;
     })
     .on("mouseover focus", function (event, d) {
       d3.select(this).transition();

--- a/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart.js
@@ -44,8 +44,7 @@ export default function drawBars({
     .attr("height", "10px")
 
     .attr("tabindex", "0")
-    .attr("aria-label", (d, i) => `<div class="chart-tooltip">
-    <div >unused_caption1</div>`)
+    .attr("aria-label", (d, i) => 'unused_caption1')
     ;
 
   // Yellow bars rendered second
@@ -79,10 +78,13 @@ export default function drawBars({
     .attr("tabindex", "0")
     .attr("aria-label", (d, i) => {
       let caption = component.getToolTipCaption1(d, selectedMetric);
-      return `<div class="chart-tooltip">
-      <div>${caption}</div>
-      </div>`}
-    )
+      caption = caption.replace( /(<([^>]+)>)/ig, ' ');
+      caption = caption.replace( /\s+/g, ' ');
+      caption = caption.replace( /^ /g, '');
+      caption = caption.replace( / $/g, '');
+      // console.log("Set pop aria label",caption);
+      return caption;
+    })
     .on("mouseover focus", function (event, d) {
       d3.select(this).transition();
       // Rephrase as "X people make up XX% of cases statewide and XX% of California's population"

--- a/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart.js
@@ -78,10 +78,10 @@ export default function drawBars({
     .attr("tabindex", "0")
     .attr("aria-label", (d, i) => {
       let caption = component.getToolTipCaption1(d, selectedMetric);
+      // remove tags and trim excess whitespace
       caption = caption.replace( /(<([^>]+)>)/ig, ' ');
       caption = caption.replace( /\s+/g, ' ');
-      caption = caption.replace( /^ /g, '');
-      caption = caption.replace( / $/g, '');
+      caption = caption.trim();
       // console.log("Set pop aria label",caption);
       return caption;
     })


### PR DESCRIPTION
Screen-reader fixes for three chart styles on the equity page. Formerly, the aria-labels duplicated the tooltip markup, which contains tags. This strips out the tags, condenses spaces and removes leading/trailing space in the aria-labels.