### PR TITLE
CCG-2371 Added support for statewide pop numbers.

### DIFF
--- a/src/js/vaccines/charts/cagov-chart-vaccination-groups-age/index.js
+++ b/src/js/vaccines/charts/cagov-chart-vaccination-groups-age/index.js
@@ -14,6 +14,7 @@ class CAGovVaccinationGroupsAge extends window.HTMLElement {
     // Settings and initial values
     this.nbr_bars = 4;
     let bar_vspace = 60;
+
     this.chartOptions = {
       // Data
       dataUrl:
@@ -194,9 +195,14 @@ class CAGovVaccinationGroupsAge extends window.HTMLElement {
 
           let croppedData = alldata.data.filter(function(a){return a.CATEGORY !== 'Unknown'});
           this.alldata = croppedData;
-
-
-          renderChart.call(this,null,null,null,'ve-age');
+          this.popdata = null;
+          if ('POP_METRIC_VALUE' in this.alldata[0]) {
+            console.log("Pop data found for age chart");
+            this.popdata = this.alldata.map(row => {
+              return {CATEGORY: row.CATEGORY, METRIC_VALUE: row.POP_METRIC_VALUE};
+            });
+          }
+          renderChart.call(this,null,this.popdata,null,'ve-age');
           this.resetTitle({
             region: regionName, 
             chartTitle: this.translationsObj.chartTitle,

--- a/src/js/vaccines/charts/cagov-chart-vaccination-groups-gender/index.js
+++ b/src/js/vaccines/charts/cagov-chart-vaccination-groups-gender/index.js
@@ -181,6 +181,13 @@ class CAGovVaccinationGroupsGender extends window.HTMLElement {
         function (alldata) {
           this.metadata = alldata.meta;
           this.alldata = alldata.data;
+          this.popdata = null;
+          if ('POP_METRIC_VALUE' in this.alldata[0]) {
+            console.log("Pop data found for gen chart");
+            this.popdata = this.alldata.map(row => {
+              return {CATEGORY: row.CATEGORY, METRIC_VALUE: row.POP_METRIC_VALUE};
+            });
+          }
 
           let publishedDate = parseSnowflakeDate(this.metadata['PUBLISHED_DATE']);
           let collectedDate = parseSnowflakeDate(this.metadata['LATEST_ADMIN_DATE']);
@@ -199,7 +206,7 @@ class CAGovVaccinationGroupsGender extends window.HTMLElement {
           d3.select(this.querySelector(".chart-data-label")).text(footerDisplayText);
 
 
-          renderChart.call(this);
+          renderChart.call(this,null,this.popdata);
           this.resetTitle({
             region: regionName, 
             chartTitle: this.translationsObj.chartTitle,

--- a/src/js/vaccines/charts/cagov-chart-vaccination-groups-race-ethnicity/index.js
+++ b/src/js/vaccines/charts/cagov-chart-vaccination-groups-race-ethnicity/index.js
@@ -200,6 +200,13 @@ class CAGovVaccinationGroupsRaceEthnicity extends window.HTMLElement {
           // console.log("Race/Eth data data", alldata.data);
           this.metadata = alldata.meta;
           this.alldata = alldata.data;
+          this.popdata = null;
+          if ('POP_METRIC_VALUE' in this.alldata[0]) {
+            console.log("Pop data found for eth chart");
+            this.popdata = this.alldata.map(row => {
+              return {CATEGORY: row.CATEGORY, METRIC_VALUE: row.POP_METRIC_VALUE};
+            });
+          }
 
           let publishedDate = parseSnowflakeDate(this.metadata['PUBLISHED_DATE']);
           let collectedDate = parseSnowflakeDate(this.metadata['LATEST_ADMIN_DATE']);
@@ -214,7 +221,7 @@ class CAGovVaccinationGroupsRaceEthnicity extends window.HTMLElement {
           let footerDisplayText = applySubstitutions(this.translationsObj.chartDataLabel, footerReplacementDict);
           d3.select(this.querySelector(".chart-data-label")).text(footerDisplayText);
 
-          renderChart.call(this, this.renderExtras, null, null, 've-race-eth');
+          renderChart.call(this, this.renderExtras, this.popdata, null, 've-race-eth');
           this.resetTitle({
             region: regionName, 
             chartTitle: this.translationsObj.chartTitle,

--- a/src/js/vaccines/rollup.config.js
+++ b/src/js/vaccines/rollup.config.js
@@ -11,7 +11,7 @@ const defaultConfig = {
 }
 const stagingConfig =  {
   equityChartsSampleDataLoc: 'https://raw.githubusercontent.com/cagov/covid-static/staging/data/chart-sandbox/',
-  equityChartsVEDataLoc: 'https://raw.githubusercontent.com/cagov/covid-static/staging/data/vaccine-equity/',
+  equityChartsVEDataLoc: 'https://raw.githubusercontent.com/cagov/covid-static-data/7cf5fc39e0bfc91658c7f9bd5ac985178fee43f8/data/vaccine-equity/',
   chartsVHPIDataLocDoses: 'https://raw.githubusercontent.com/cagov/covid-static/staging/data/vaccine-hpi//v2/',
   chartsVHPIDataLocPeople: 'https://raw.githubusercontent.com/cagov/covid-static/staging/data/vaccine-hpi/v2/',
 }


### PR DESCRIPTION
This backward compatible update shows state-wide population numbers and legends if the data is present in the supplied JSON data.  If the data are not supplied, the charts are the same as before.  The vaccines-by-groups charts currently on staging show these additions.