### PR TITLE
CCG-2379/tooltips added to vaccines group charts

### DIFF
--- a/pages/wordpress-posts/vaccination-progress-data.html
+++ b/pages/wordpress-posts/vaccination-progress-data.html
@@ -265,6 +265,9 @@ addtositemap: true
             <li data-label="legendLabelVaccines">% of vaccines administered</li>
             <li data-label="legendLabelPopulation">% of vaccine eligible population</li>
             <li data-label="chartDataLabel">Updated {PUBLISHED_DATE} with data from {LATEST_ADMINISTERED_DATE}. </li>
+            <li data-label="chartBarCaption">People who identified as {category} have received {metric-value} of the vaccines administered and make up {metric-baseline-value} of the vaccine-eligible population.</li>
+            <li data-label="chartBarCaptionOther">People whose race/ethinicity was reported as {category} have received {metric-value} of the vaccines administered. Since “Other” is not an official classification from Census nor OMB, the size of the corresponding vaccine-eligible population is undetermined.</li>
+            <li data-label="chartBarCaptionUnknown">People whose race or ethnicity is {category} have received {metric-value} of the vaccines administered. California does not assign this group a percentage of the vaccine-eligible population.</li>
           </ul>
         </cagov-chart-vaccination-groups-race-ethnicity>
 
@@ -273,8 +276,10 @@ addtositemap: true
             <li data-label="chartTitle">People with at least one dose of vaccine administered by age in California</li>
             <li data-label="chartTitleCounty">People with at least one dose of vaccine administered by age in [REGION]</li>
             <li data-label="legendLabelVaccines">% of vaccines administered</li>
-            <li data-label="legendLabelPopulation">% of vaccine eligible population</li>
+            <li data-label="legendLabelPopulation">% of vaccine-eligible population</li>
             <li data-label="chartDataLabel">Updated {PUBLISHED_DATE} with data from {LATEST_ADMINISTERED_DATE}.</li>
+            <li data-label="chartBarCaption">The {category} age group has received {metric-value} of the vaccines administered and make up {metric-baseline-value} of the vaccine-eligible population.</li>
+            <li data-label="chartBarCaptionOther">People whose age do not fall into any group have received have received {metric-value} of the vaccines administered. California does not assign this group a percentage of the vaccine-eligible population.</li>
           </ul>
         </cagov-chart-vaccination-groups-age>
         
@@ -283,8 +288,10 @@ addtositemap: true
             <li data-label="chartTitle">People with at least one dose of vaccine administered by gender in California</li>
             <li data-label="chartTitleCounty">People with at least one dose of vaccine administered by gender in [REGION]</li>
             <li data-label="legendLabelVaccines">% of vaccines administered</li>
-            <li data-label="legendLabelPopulation">% of vaccine eligible population</li>
+            <li data-label="legendLabelPopulation">% of vaccine-eligible population</li>
             <li data-label="chartDataLabel">Updated {PUBLISHED_DATE} with data from {LATEST_ADMINISTERED_DATE}. “Unknown/undifferentiated” includes those who declined to state, whose gender information is missing, or who identify as transgender, gender non-binary, gender queer or intersex.</li>
+            <li data-label="chartBarCaption">{category} have received {metric-value} of the vaccines administered and make up {metric-baseline-value} of the vaccine-eligible population.</li>
+            <li data-label="chartBarCaptionUnknown">People whose gender is unknown or undifferentiated (see who this includes in the chart information) have received {metric-value} of the vaccines administered. Since “Unknown/Undifferentiated” is not an official classification from Census nor the Office of Management and Budget, the size of the corresponding vaccine-eligible population is undetermined.</li>
           </ul>
         </cagov-chart-vaccination-groups-gender>
     </div>

--- a/pages/wordpress-posts/vaccination-progress-data.html
+++ b/pages/wordpress-posts/vaccination-progress-data.html
@@ -3,7 +3,7 @@ layout: "page.njk"
 title: "Vaccination progress data"
 meta: "This page makes vaccination data transparent and accessible to all Californians."
 author: "State of California"
-publishdate: "2021-06-10T16:52:53Z"
+publishdate: "2021-06-10T20:40:29Z"
 tags: ["translate"]
 addtositemap: true
 ---
@@ -266,8 +266,8 @@ addtositemap: true
             <li data-label="legendLabelPopulation">% of vaccine eligible population</li>
             <li data-label="chartDataLabel">Updated {PUBLISHED_DATE} with data from {LATEST_ADMINISTERED_DATE}. </li>
             <li data-label="chartBarCaption">People who identified as {category} have received {metric-value} of the vaccines administered and make up {metric-baseline-value} of the vaccine-eligible population.</li>
-            <li data-label="chartBarCaptionOther">People whose race/ethinicity was reported as {category} have received {metric-value} of the vaccines administered. Since “Other” is not an official classification from Census nor OMB, the size of the corresponding vaccine-eligible population is undetermined.</li>
-            <li data-label="chartBarCaptionUnknown">People whose race or ethnicity is {category} have received {metric-value} of the vaccines administered. California does not assign this group a percentage of the vaccine-eligible population.</li>
+            <li data-label="chartBarCaptionOther">People whose race/ethinicity was reported as Other have received {metric-value} of the vaccines administered. Since “Other” is not an official classification from Census nor OMB, the size of the corresponding vaccine eligible population is undetermined.</li>
+            <li data-label="chartBarCaptionUnknown">People whose race or ethnicity is unknown have received {metric-value} of the vaccines administered. California does not assign this group a percentage of the vaccine-eligible population.</li>
           </ul>
         </cagov-chart-vaccination-groups-race-ethnicity>
 
@@ -276,9 +276,9 @@ addtositemap: true
             <li data-label="chartTitle">People with at least one dose of vaccine administered by age in California</li>
             <li data-label="chartTitleCounty">People with at least one dose of vaccine administered by age in [REGION]</li>
             <li data-label="legendLabelVaccines">% of vaccines administered</li>
-            <li data-label="legendLabelPopulation">% of vaccine-eligible population</li>
+            <li data-label="legendLabelPopulation">% of vaccine eligible population</li>
             <li data-label="chartDataLabel">Updated {PUBLISHED_DATE} with data from {LATEST_ADMINISTERED_DATE}.</li>
-            <li data-label="chartBarCaption">The {category} age group has received {metric-value} of the vaccines administered and make up {metric-baseline-value} of the vaccine-eligible population.</li>
+            <li data-label="chartBarCaption">The {category} age group has received {metric-value} of the vaccines administered and make up {metric-baseline-value} of the vaccine eligible population.</li>
             <li data-label="chartBarCaptionOther">People whose age do not fall into any group have received have received {metric-value} of the vaccines administered. California does not assign this group a percentage of the vaccine-eligible population.</li>
           </ul>
         </cagov-chart-vaccination-groups-age>
@@ -288,10 +288,10 @@ addtositemap: true
             <li data-label="chartTitle">People with at least one dose of vaccine administered by gender in California</li>
             <li data-label="chartTitleCounty">People with at least one dose of vaccine administered by gender in [REGION]</li>
             <li data-label="legendLabelVaccines">% of vaccines administered</li>
-            <li data-label="legendLabelPopulation">% of vaccine-eligible population</li>
+            <li data-label="legendLabelPopulation">% of vaccine eligible population</li>
             <li data-label="chartDataLabel">Updated {PUBLISHED_DATE} with data from {LATEST_ADMINISTERED_DATE}. “Unknown/undifferentiated” includes those who declined to state, whose gender information is missing, or who identify as transgender, gender non-binary, gender queer or intersex.</li>
-            <li data-label="chartBarCaption">{category} have received {metric-value} of the vaccines administered and make up {metric-baseline-value} of the vaccine-eligible population.</li>
-            <li data-label="chartBarCaptionUnknown">People whose gender is unknown or undifferentiated (see who this includes in the chart information) have received {metric-value} of the vaccines administered. Since “Unknown/Undifferentiated” is not an official classification from Census nor the Office of Management and Budget, the size of the corresponding vaccine-eligible population is undetermined.</li>
+            <li data-label="chartBarCaption">{category} have received {metric-value} of the vaccines administered and make up {metric-baseline-value} of the vaccine eligible population.</li>
+            <li data-label="chartBarCaptionUnknown">People whose gender is unknown or undifferentiated (see who this includes in the chart information) have received {metric-value} of the vaccines administered. Since “Unknown/Undifferentiated” is not an official classification from Census nor OMB, the size of the corresponding vaccine eligible population is undetermined.</li>
           </ul>
         </cagov-chart-vaccination-groups-gender>
     </div>

--- a/pages/wordpress-posts/vaccination-progress-data.html
+++ b/pages/wordpress-posts/vaccination-progress-data.html
@@ -3,7 +3,7 @@ layout: "page.njk"
 title: "Vaccination progress data"
 meta: "This page makes vaccination data transparent and accessible to all Californians."
 author: "State of California"
-publishdate: "2021-06-10T20:40:29Z"
+publishdate: "2021-06-10T22:04:24Z"
 tags: ["translate"]
 addtositemap: true
 ---
@@ -266,8 +266,8 @@ addtositemap: true
             <li data-label="legendLabelPopulation">% of vaccine eligible population</li>
             <li data-label="chartDataLabel">Updated {PUBLISHED_DATE} with data from {LATEST_ADMINISTERED_DATE}. </li>
             <li data-label="chartBarCaption">People who identified as {category} have received {metric-value} of the vaccines administered and make up {metric-baseline-value} of the vaccine-eligible population.</li>
-            <li data-label="chartBarCaptionOther">People whose race/ethinicity was reported as Other have received {metric-value} of the vaccines administered. Since “Other” is not an official classification from Census nor OMB, the size of the corresponding vaccine eligible population is undetermined.</li>
-            <li data-label="chartBarCaptionUnknown">People whose race or ethnicity is unknown have received {metric-value} of the vaccines administered. California does not assign this group a percentage of the vaccine-eligible population.</li>
+            <li data-label="chartBarCaptionOther">People whose race/ethinicity was reported as {category} have received {metric-value} of the vaccines administered. Since Other is not an official classification from Census nor the Office of Management and Budget, the size of the corresponding vaccine-eligible population is undetermined.</li>
+            <li data-label="chartBarCaptionUnknown">People whose race or ethnicity is {category} have received {metric-value} of the vaccines administered. California does not assign this group a percentage of the vaccine-eligible population.</li>
           </ul>
         </cagov-chart-vaccination-groups-race-ethnicity>
 
@@ -278,7 +278,7 @@ addtositemap: true
             <li data-label="legendLabelVaccines">% of vaccines administered</li>
             <li data-label="legendLabelPopulation">% of vaccine eligible population</li>
             <li data-label="chartDataLabel">Updated {PUBLISHED_DATE} with data from {LATEST_ADMINISTERED_DATE}.</li>
-            <li data-label="chartBarCaption">The {category} age group has received {metric-value} of the vaccines administered and make up {metric-baseline-value} of the vaccine eligible population.</li>
+            <li data-label="chartBarCaption">The {category} age group has received {metric-value} of the vaccines administered and make up {metric-baseline-value} of the vaccine-eligible population.</li>
             <li data-label="chartBarCaptionOther">People whose age do not fall into any group have received have received {metric-value} of the vaccines administered. California does not assign this group a percentage of the vaccine-eligible population.</li>
           </ul>
         </cagov-chart-vaccination-groups-age>
@@ -290,8 +290,8 @@ addtositemap: true
             <li data-label="legendLabelVaccines">% of vaccines administered</li>
             <li data-label="legendLabelPopulation">% of vaccine eligible population</li>
             <li data-label="chartDataLabel">Updated {PUBLISHED_DATE} with data from {LATEST_ADMINISTERED_DATE}. “Unknown/undifferentiated” includes those who declined to state, whose gender information is missing, or who identify as transgender, gender non-binary, gender queer or intersex.</li>
-            <li data-label="chartBarCaption">{category} have received {metric-value} of the vaccines administered and make up {metric-baseline-value} of the vaccine eligible population.</li>
-            <li data-label="chartBarCaptionUnknown">People whose gender is unknown or undifferentiated (see who this includes in the chart information) have received {metric-value} of the vaccines administered. Since “Unknown/Undifferentiated” is not an official classification from Census nor OMB, the size of the corresponding vaccine eligible population is undetermined.</li>
+            <li data-label="chartBarCaption">{category} have received {metric-value} of the vaccines administered and make up {metric-baseline-value} of the vaccine-eligible population.</li>
+            <li data-label="chartBarCaptionUnknown">People whose gender is <b>unknown</b> or <b>undifferentiated</b> (see who this includes in the chart information) have received {metric-value} of the vaccines administered. Since Unknown/Undifferentiated is not an official classification from Census nor the Office of Management and Budget, the size of the corresponding vaccine-eligible population is undetermined.</li>
           </ul>
         </cagov-chart-vaccination-groups-gender>
     </div>

--- a/src/js/common/charts/simple-barchart.js
+++ b/src/js/common/charts/simple-barchart.js
@@ -143,6 +143,7 @@ function writeBars(svg, data, x, y, baselineData, tooltip, rootID='barid') {
     groups
         .append("rect")
         .attr("fill", "#1f2574")
+        .attr("fill-opacity",(d,i) => baselineData[i].METRIC_VALUE == -1? 0 : 1)
         .attr("y", (d, i) => y(d.CATEGORY)-y.bandwidth()/2)
         .attr("x", (d,i) => x(baselineData[i].METRIC_VALUE)-2)
         .attr("width", d => 4)

--- a/src/js/vaccines/charts/cagov-chart-vaccination-groups-age/index.js
+++ b/src/js/vaccines/charts/cagov-chart-vaccination-groups-age/index.js
@@ -5,6 +5,7 @@ import rtlOverride from "./../../../common/rtl-override.js";
 import renderChart from "../../../common/charts/simple-barchart.js";
 import applySubstitutions from "./../../../common/apply-substitutions.js";
 import { parseSnowflakeDate, reformatJSDate } from "./../../../common/readable-date.js";
+import formatValue from "./../../../common/value-formatters.js";
 
 class CAGovVaccinationGroupsAge extends window.HTMLElement {
   connectedCallback() {
@@ -103,6 +104,12 @@ class CAGovVaccinationGroupsAge extends window.HTMLElement {
       .append("g")
       .attr("transform", "translate(0,0)");
 
+    this.tooltip = d3
+      .select("cagov-chart-vaccination-groups-age")
+      .append("div")
+      .attr("class", "tooltip-container")
+      .text("Empty Tooltip");
+
     // Set default values for data and labels
     this.dataUrl = this.chartOptions.dataUrl;
 
@@ -154,6 +161,19 @@ class CAGovVaccinationGroupsAge extends window.HTMLElement {
     return label;
   }
 
+  getTooltip(d,baselineData) {
+    let tooltipText = this.translationsObj.chartBarCaption;
+    if (d.CATEGORY == "Other") {
+      tooltipText = this.translationsObj.chartBarCaptionOther;
+    }
+    let bd = baselineData.filter(bd => bd.CATEGORY == d.CATEGORY);
+    // !! replacements here for category, metric-value, metric-baseline-value
+    tooltipText = tooltipText.replace('{category}', `<span class='highlight-data'>${d.CATEGORY}</span>`);
+    tooltipText = tooltipText.replace('{metric-value}', `<span class='highlight-data'>${formatValue(d.METRIC_VALUE,{format:'percent'})}</span>`);
+    tooltipText = tooltipText.replace('{metric-baseline-value}', `<span class='highlight-data'>${formatValue(bd[0].METRIC_VALUE,{format:'percent'})}</span>`);
+    return tooltipText;
+  }
+
   listenForLocations() {
     let searchElement = document.querySelector("cagov-county-search");
     searchElement.addEventListener(
@@ -199,10 +219,10 @@ class CAGovVaccinationGroupsAge extends window.HTMLElement {
           if ('POP_METRIC_VALUE' in this.alldata[0]) {
             console.log("Pop data found for age chart");
             this.popdata = this.alldata.map(row => {
-              return {CATEGORY: row.CATEGORY, METRIC_VALUE: row.POP_METRIC_VALUE};
+              return {CATEGORY: row.CATEGORY, METRIC_VALUE: (row.CATEGORY == "Other" || row.CATEGORY == "Unknown"? -1 : row.POP_METRIC_VALUE)};
             });
           }
-          renderChart.call(this,null,this.popdata,null,'ve-age');
+          renderChart.call(this,null,this.popdata,this.tooltip,'ve-age');
           this.resetTitle({
             region: regionName, 
             chartTitle: this.translationsObj.chartTitle,

--- a/src/js/vaccines/charts/cagov-chart-vaccination-groups-age/index.scss
+++ b/src/js/vaccines/charts/cagov-chart-vaccination-groups-age/index.scss
@@ -14,6 +14,28 @@ cagov-chart-vaccination-groups-age {
     font-weight: 300;
     font-size: 0.75rem;
   }
+  div.tooltip-container {
+    font-weight: 300;
+    font-size: 0.75rem;
+    line-height: 2;
+    color: black;
+    text-align: center;
+  }
+  .tooltip-container {
+    position: absolute;
+    z-index: 10;
+    visibility: hidden;
+    background: #fff;
+    width: 280px;
+  }
+  .tooltip-container {
+    pointer-events: none;
+    /* padding: 10px; */
+    padding: 1rem 2rem;
+    box-shadow: 0px 0px 5px 2px rgba(0, 0, 0, 0.14);
+    /* box-shadow: -12px 11px 5px -4px rgba(0, 0, 0, 0.4); */
+    border: none;
+  }
 }
 .d-hide {
   display: none;

--- a/src/js/vaccines/charts/cagov-chart-vaccination-groups-gender/index.scss
+++ b/src/js/vaccines/charts/cagov-chart-vaccination-groups-gender/index.scss
@@ -14,6 +14,28 @@ cagov-chart-vaccination-groups-gender {
       font-weight: 300;
       font-size: 0.75rem;
     }
+    div.tooltip-container {
+      font-weight: 300;
+      font-size: 0.75rem;
+      line-height: 2;
+      color: black;
+      text-align: center;
+    }
+    .tooltip-container {
+      position: absolute;
+      z-index: 10;
+      visibility: hidden;
+      background: #fff;
+      width: 280px;
+    }
+    .tooltip-container {
+      pointer-events: none;
+      /* padding: 10px; */
+      padding: 1rem 2rem;
+      box-shadow: 0px 0px 5px 2px rgba(0, 0, 0, 0.14);
+      /* box-shadow: -12px 11px 5px -4px rgba(0, 0, 0, 0.4); */
+      border: none;
+    }
 }
 .d-hide {
   display:none;

--- a/src/js/vaccines/charts/cagov-chart-vaccination-groups-race-ethnicity/index.scss
+++ b/src/js/vaccines/charts/cagov-chart-vaccination-groups-race-ethnicity/index.scss
@@ -14,6 +14,28 @@ cagov-chart-vaccination-groups-race-ethnicity {
       font-weight: 300;
       font-size: 0.75rem;
     }
+    div.tooltip-container {
+      font-weight: 300;
+      font-size: 0.75rem;
+      line-height: 2;
+      color: black;
+      text-align: center;
+    }
+    .tooltip-container {
+      position: absolute;
+      z-index: 10;
+      visibility: hidden;
+      background: #fff;
+      width: 280px;
+    }
+    .tooltip-container {
+      pointer-events: none;
+      /* padding: 10px; */
+      padding: 1rem 2rem;
+      box-shadow: 0px 0px 5px 2px rgba(0, 0, 0, 0.14);
+      /* box-shadow: -12px 11px 5px -4px rgba(0, 0, 0, 0.4); */
+      border: none;
+    }
 }
 .d-hide {
   display:none;


### PR DESCRIPTION
Tooltip display added to vaccines group charts.
Inhibiting display of baseline indicators on exceptional categories (other, unknown, unknown/undifferentiated)
