### PR TITLE
Changed default text weight to 300.

### DIFF
--- a/src/css/_general.scss
+++ b/src/css/_general.scss
@@ -569,7 +569,7 @@ textarea {
 body {
   color: $black;
   font-family: "Roboto", sans-serif;
-  font-weight: 500;
+  font-weight: 300;
   font-size: 1.2rem;
 }
 


### PR DESCRIPTION
Something recently caused the default body text to change from weight of 300 (correct) to 500 (incorrect).  This overrides the default body weight which was set to 500 -> 300.

This fixes the problem, however, this file (_general.scss) has not been changed in weeks, and the problem is new, so there was likely a different css font-weight override in place that recently disappeared.  Worth looking into...  However, Adam has confirmed that this fix looks good.