### PR TITLE
CCG-2441/ie11-hero-image

### DIFF
--- a/pages/_includes/main.njk
+++ b/pages/_includes/main.njk
@@ -98,7 +98,7 @@ formatNumber(tags,1)-%}
 			</div>
 			<div class="hero-photo" role="complementary" aria-labelledby="hero-background">
 				<div class="hero-photo-fade"></div>
-				<img class="hero-photo-pic" alt="Photo Description">
+				<img class="hero-photo-pic" src="/img/hero_v2.jpg" alt="Photo Description">
 				<div id="hero-background" class="hero-photo-description">Photo Description</div>
 			</div>
 		</section>

--- a/src/css/_hero-stats.scss
+++ b/src/css/_hero-stats.scss
@@ -578,14 +578,14 @@ section.featured-content {
 } 
 */
 
-img.hero-photo-pic {
+img.hero-photo-pic, img.hero-photo-pic:before {
 	content:url("/img/hero_v2_mobile.webp");
 	@media (min-width: 767.98px) {
 		content:url("/img/hero_v2_1600.webp");
 	}
 }
 
-.no-webp img.hero-photo-pic {
+.no-webp img.hero-photo-pic, .no-webp img.hero-photo-pic:before {
 	content:url("/img/hero_v2_mobile.jpg");
 	@media (min-width: 767.98px) {
 		content:url("/img/hero_v2.jpg");

--- a/src/css/_hero-stats.scss
+++ b/src/css/_hero-stats.scss
@@ -591,13 +591,3 @@ img.hero-photo-pic {
 		content:url("/img/hero_v2.jpg");
 	}
 }
-
-// explicitly filtering for IE11
-@media all and (-ms-high-contrast:none) {
-	img.hero-photo-pic:after {
-		content:url("/img/hero_v2_mobile.jpg");
-		@media (min-width: 767.98px) {
-			content:url("/img/hero_v2.jpg");
-		}
-	}
-}

--- a/src/css/_hero-stats.scss
+++ b/src/css/_hero-stats.scss
@@ -579,8 +579,6 @@ section.featured-content {
 */
 
 img.hero-photo-pic {
-	width:auto;
-	height:auto;
 	content:url("/img/hero_v2_mobile.webp");
 	@media (min-width: 767.98px) {
 		content:url("/img/hero_v2_1600.webp");

--- a/src/css/_hero-stats.scss
+++ b/src/css/_hero-stats.scss
@@ -578,16 +578,28 @@ section.featured-content {
 } 
 */
 
-img.hero-photo-pic, img.hero-photo-pic:before {
+img.hero-photo-pic {
 	content:url("/img/hero_v2_mobile.webp");
 	@media (min-width: 767.98px) {
 		content:url("/img/hero_v2_1600.webp");
 	}
 }
 
-.no-webp img.hero-photo-pic, .no-webp img.hero-photo-pic:before {
+.no-webp img.hero-photo-pic {
 	content:url("/img/hero_v2_mobile.jpg");
 	@media (min-width: 767.98px) {
 		content:url("/img/hero_v2.jpg");
+	}
+}
+
+// explicitly filtering for IE11
+@media all and (-ms-high-contrast:none) {
+	img.hero-photo-pic:before {
+		content:url("/img/hero_v2_mobile.jpg");
+		width:auto;
+		height:auto;
+		@media (min-width: 767.98px) {
+			content:url("/img/hero_v2.jpg");
+		}
 	}
 }

--- a/src/css/_hero-stats.scss
+++ b/src/css/_hero-stats.scss
@@ -579,6 +579,8 @@ section.featured-content {
 */
 
 img.hero-photo-pic {
+	width:auto;
+	height:auto;
 	content:url("/img/hero_v2_mobile.webp");
 	@media (min-width: 767.98px) {
 		content:url("/img/hero_v2_1600.webp");
@@ -594,10 +596,8 @@ img.hero-photo-pic {
 
 // explicitly filtering for IE11
 @media all and (-ms-high-contrast:none) {
-	img.hero-photo-pic:before {
+	img.hero-photo-pic:after {
 		content:url("/img/hero_v2_mobile.jpg");
-		width:auto;
-		height:auto;
 		@media (min-width: 767.98px) {
 			content:url("/img/hero_v2.jpg");
 		}

--- a/src/css/_hero-stats.scss
+++ b/src/css/_hero-stats.scss
@@ -579,15 +579,13 @@ section.featured-content {
 */
 
 img.hero-photo-pic {
-	content:url("/img/hero_v2_mobile.webp");
-	@media (min-width: 767.98px) {
-		content:url("/img/hero_v2_1600.webp");
+	@media (max-width: 767.98px) {
+		content:url("/img/hero_v2_mobile.webp");
 	}
 }
 
 .no-webp img.hero-photo-pic {
-	content:url("/img/hero_v2_mobile.jpg");
-	@media (min-width: 767.98px) {
-		content:url("/img/hero_v2.jpg");
+	@media (max-width: 767.98px) {
+		content:url("/img/hero_v2_mobile.jpg");
 	}
 }


### PR DESCRIPTION
This fixes a bug.  When we recently changed to the beach hero image on the home page, it stopped displaying on IE11.  This happened because we introduced a new feature: a differently cropped version of the image for mobile/portrait display.  

The image switch was accomplished by using CSS code to swap in a different image, changing the 'src' attribute of the image tag using the _content:url_ css property. Since CSS was controlling the image, I removed the original 'src' attribute from the markup.  This broke IE11, because IE11 doesn't like that newfangled _content:url_ CSS property.

I worked around this issue by re-introducing the 'src' tag in the markup (defaulting to the .jpg image, which IE11 can read) (after several failed attempts to fix by just changing the CSS). On more modern browses, the src still gets overruled by the CSS, however this does introduce a performance penalty: _both_ the jpg and webp versions of the image are loaded. 
 I can see it will be more efficient to just use the jpg.  So I'm removing the CSS source that loads it for now.

Tested on staging using Browser Stack.