### PR TITLE
CCG-1936 Using translation table string for hero image alt.

### DIFF
--- a/pages/_includes/main.njk
+++ b/pages/_includes/main.njk
@@ -103,9 +103,9 @@ formatNumber(tags,1)-%}
 					<source media="(max-width: 767px)" type="image/jpeg" srcset="/img/hero_v2_mobile.jpg">
 					<source media="(min-width: 768px)" type="image/webp" srcset="/img/hero_v2_1600.webp">
 					<source media="(min-width: 768px)" type="image/jpeg" srcset="/img/hero_v2_1600.jpg">
-					<img class="hero-photo-pic" src="/img/hero_v2_1600.jpg" alt="Beachgoers enjoy themselves">
+					<img class="hero-photo-pic" src="/img/hero_v2_1600.jpg" alt="{{translatedLabels.varHeroImageAlt}}">
 				</picture>
-				<div id="hero-background" class="hero-photo-description">Photo Description</div>
+				<div id="hero-background" class="hero-photo-description">{{translatedLabels.varHeroImageAlt}}</div>
 			</div>
 		</section>
 	</hero-stats>


### PR DESCRIPTION
Alt Text for hero-image now comes Home Page Labels on wordpress.

Text suggested by Peggy: Three young women enjoy a sunny walk on a California beach.

Alt was previously "Photo Description" (untranslated).  Until this is translated, the alt tag will be empty for translated pages.