### PR TITLE
Added code to suppress daily totals on summary boxes in expected weekend/holiday conditions.

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -167,6 +167,33 @@ module.exports = function(eleventyConfig) {
       return null;
     }
   );
+  
+  /*
+  Return TRUE if we need to suppress the daily totals in the summary boxes (displaying hyphens instead of numbers).
+  This is currently extra conservative, we will remove some of these conditions when
+  we understand the likely scenarios better.  We hope we can just use the zero test and the day_delta test.
+   */
+  eleventyConfig.addFilter("suppressDailyTotals", (sumdata) => {
+    // Daily Tests (the highest of the three daily numbers) is zero?  The data wasn't counted
+    if (sumdata.data.tests.NEWLY_REPORTED_TESTS == 0) {
+      return true;
+    }
+    // Saturday or Sunday?
+    let publishWeekDay = new Date(sumdata.meta.PUBLISHED_DATE).getDay();
+    if (publishWeekDay >= 5) {
+      return true;
+    }
+    // State Holiday?
+    if (sumdata.meta.PUBLISHED_DATE == '2021-07-05' || sumdata.meta.PUBLISHED_DATE == '2021-09-06') {
+      return true;
+    }
+    // Difference between publish date and test-data collection date is > 1 day?
+    let day_delta = (new Date(sumdata.meta.PUBLISHED_DATE).getTime() - new Date(sumdata.data.tests.DATE).getTime()) / (1000 * 3600 * 24);
+    if (day_delta > 1) {
+      return true;
+    }
+    return false;
+  });
 
   eleventyConfig.addFilter('find', (array, field, value) => array.find(x=>x[field]===value));
 

--- a/pages/_includes/main.njk
+++ b/pages/_includes/main.njk
@@ -29,6 +29,14 @@ formatNumber(tags,1)-%}
 {%-set _varPositivityTrendClassD_='' if _varPositivityTrend_ < 0 else "d-none" %} 
 {%- set translatedLabels = pubData[language.id].homepageLabels.Table1[0] -%}
 
+{%- set _varInhibitDailyTotals_ = dailyStatsV2|suppressDailyTotals() -%}
+{%- if _varInhibitDailyTotals_  -%}
+{%- set _varStatTotalCasesToday_ = '—' -%}
+{%- set _varStatTotalDeathsToday_ = '—' -%}
+{%- set _varStatTestedDaily_ = '—' -%}
+{%- endif -%}
+
+
 {% extends "layout.njk" %}
 {% import "macros.njk" as macros %}
 


### PR DESCRIPTION
This adds an 11ty filter which is used to check if we need to display a hyphen (em-dash actually) instead of digits for the daily totals.  Currently we want to do this on weekends and holidays.  The conditions I am checking are:

* Is the daily tests number zero? (This is the largest of the three numbers, and should never be zero normally). 

* Is it Saturday or Sunday?

* Is it July 5 or Labor Day?

* Is the difference between the tests.date and meta.published_date greater than one day? (is the data stale?)

Any of these conditions will cause hyphens to display.  

Note I also need to add a block of markup to the state-dashboard page, but can't add it until this is merged into master.

Once we see what actually happens on Saturday, I will pare these conditions down to just the necessary ones. 