### PR TITLE
Removed forced underline. Removed extraneous <span> tag.

### DIFF
--- a/pages/_includes/main.njk
+++ b/pages/_includes/main.njk
@@ -244,7 +244,7 @@ formatNumber(tags,1)-%}
 	 M15.48,4.93V21.9h-4.63V4.93C10.85,4.93,15.48,4.93,15.48,4.93z M9.31,14.36v7.54H4.68v-7.54C4.68,14.36,9.31,14.36,9.31,14.36z"/>
 </svg>
 </span> 
-						<span class="underline"> {{translatedLabels.varStateSummary}}</span></a>
+						<span > {{translatedLabels.varStateSummary}}</span></a>
 
 
 						<a class="hero-stats-footer-link mt-2" href="/vaccination-progress-data">
@@ -257,15 +257,16 @@ formatNumber(tags,1)-%}
 	 M15.48,4.93V21.9h-4.63V4.93C10.85,4.93,15.48,4.93,15.48,4.93z M9.31,14.36v7.54H4.68v-7.54C4.68,14.36,9.31,14.36,9.31,14.36z"/>
 </svg>
 </span> 
-						<span class="underline"> <span class="underline">{{translatedLabels.varVaccination}}</span></a>
+						<span>{{translatedLabels.varVaccination}}</span></a>
 
-						<a class="hero-stats-footer-link mt-2" href="{{ "equity/"  | toTranslatedPath(tags) }}"><span class="no-underline" aria-hidden="true">
+						<a class="hero-stats-footer-link mt-2" href="{{ "equity/"  | toTranslatedPath(tags) }}">
+						<span class="no-underline" aria-hidden="true">
 						<svg class="chart-icon" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 26.33 25.29" style="enable-background:new 0 0 26.33 25.29;" xml:space="preserve">
 <path class="chart-icon-path" d="M3.14,0.31C2.29,0.31,1.6,1,1.6,1.85v21.59c0,0.85,0.69,1.54,1.54,1.54h20.05c0.85,0,1.54-0.69,1.54-1.54V1.85
 	c0-0.85-0.69-1.54-1.54-1.54C23.19,0.31,3.14,0.31,3.14,0.31z M21.65,8.7v13.2h-4.63V8.7C17.02,8.7,21.65,8.7,21.65,8.7z
 	 M15.48,4.93V21.9h-4.63V4.93C10.85,4.93,15.48,4.93,15.48,4.93z M9.31,14.36v7.54H4.68v-7.54C4.68,14.36,9.31,14.36,9.31,14.36z"/>
-						</span> <span class="underline">{{translatedLabels.varHealthEquity}}</span></a>
+						</span> <span>{{translatedLabels.varHealthEquity}}</span></a>
 						
 					</div>
 				</div>


### PR DESCRIPTION
Fixes a cosmetic issue Peggy noticed. Adam's preferred link style is to remove unlinks on hover. On these links, the underline was being forced, and it was causing a weird issue in which the underline on the space in front of the links disappeared on hover.  This fixes it to behave using Adam's preferred style, in which the underlines disappear completely on hover.

Accomplished by removing explicit "underline" classes in the markup.  Also spotted and removed an extraneous <span> tag.