### PR TITLE
Fixing translation links for masks-and-ppe link

### DIFF
--- a/pages/translated-posts/new-ar.html
+++ b/pages/translated-posts/new-ar.html
@@ -6,7 +6,7 @@
 
 
 
-<div class="hero-alert-action"> <a href="/masks-and-ppe/" class="action-link pt-3 pb-3 px-4">احصل على المستجدات</a> </div>
+<div class="hero-alert-action"> <a href="masks-and-ppe/" class="action-link pt-3 pb-3 px-4">احصل على المستجدات</a> </div>
 
 
 

--- a/pages/translated-posts/new-es.html
+++ b/pages/translated-posts/new-es.html
@@ -6,7 +6,7 @@
 
 
 
-<div class="hero-alert-action"> <a href="/masks-and-ppe/" class="action-link pt-3 pb-3 px-4">Obtenga la información más reciente</a> </div>
+<div class="hero-alert-action"> <a href="masks-and-ppe/" class="action-link pt-3 pb-3 px-4">Obtenga la información más reciente</a> </div>
 
 
 

--- a/pages/translated-posts/new-ko.html
+++ b/pages/translated-posts/new-ko.html
@@ -6,7 +6,7 @@
 
 
 
-<div class="hero-alert-action"> <a href="/masks-and-ppe/" class="action-link pt-3 pb-3 px-4">최신 확인하십시오</a> </div>
+<div class="hero-alert-action"> <a href="masks-and-ppe/" class="action-link pt-3 pb-3 px-4">최신 확인하십시오</a> </div>
 
 
 

--- a/pages/translated-posts/new-tl.html
+++ b/pages/translated-posts/new-tl.html
@@ -6,7 +6,7 @@
 
 
 
-<div class="hero-alert-action"> <a href="/masks-and-ppe/" class="action-link pt-3 pb-3 px-4">Malaman ang pinakabago</a> </div>
+<div class="hero-alert-action"> <a href="masks-and-ppe/" class="action-link pt-3 pb-3 px-4">Malaman ang pinakabago</a> </div>
 
 
 

--- a/pages/translated-posts/new-vi.html
+++ b/pages/translated-posts/new-vi.html
@@ -6,7 +6,7 @@
 
 
 
-<div class="hero-alert-action"> <a href="/masks-and-ppe/" class="action-link pt-3 pb-3 px-4">Nhận thông tin mới nhất</a> </div>
+<div class="hero-alert-action"> <a href="masks-and-ppe/" class="action-link pt-3 pb-3 px-4">Nhận thông tin mới nhất</a> </div>
 
 
 

--- a/pages/translated-posts/new-zh-hans.html
+++ b/pages/translated-posts/new-zh-hans.html
@@ -6,7 +6,7 @@
 
 
 
-<div class="hero-alert-action"><a href="/masks-and-ppe/" class="action-link pt-3 pb-3 px-4">了解最新信息</a> </div>
+<div class="hero-alert-action"><a href="masks-and-ppe/" class="action-link pt-3 pb-3 px-4">了解最新信息</a> </div>
 
 
 

--- a/pages/translated-posts/new-zh-hant.html
+++ b/pages/translated-posts/new-zh-hant.html
@@ -6,7 +6,7 @@
 
 
 
-<div class="hero-alert-action"><a href="/masks-and-ppe/" class="action-link pt-3 pb-3 px-4">了解最新資訊</a> </div>
+<div class="hero-alert-action"><a href="masks-and-ppe/" class="action-link pt-3 pb-3 px-4">了解最新資訊</a> </div>
 
 
 

--- a/pages/wordpress-posts/new.html
+++ b/pages/wordpress-posts/new.html
@@ -8,7 +8,7 @@
 
 
 <div class="hero-alert-action">
-<a href="/masks-and-ppe/" class="action-link pt-3 pb-3 px-4">Get the latest</a>
+<a href="masks-and-ppe/" class="action-link pt-3 pb-3 px-4">Get the latest</a>
 </div>
 
 

--- a/pages/wordpress-posts/safely-reopening.html
+++ b/pages/wordpress-posts/safely-reopening.html
@@ -132,7 +132,7 @@ addtositemap: true
 
 
 
-<p>Read more on our <a href="/masks-and-ppe/">Masks</a> page and CDPH’s <a href="https://www.cdph.ca.gov/Programs/CID/DCDC/Pages/COVID-19/guidance-for-face-coverings.aspx">Guidance for the Use of Face Coverings</a>.</p>
+<p>Read more on our <a href="masks-and-ppe/">Masks</a> page and CDPH’s <a href="https://www.cdph.ca.gov/Programs/CID/DCDC/Pages/COVID-19/guidance-for-face-coverings.aspx">Guidance for the Use of Face Coverings</a>.</p>
 
 
 

--- a/pages/wordpress-posts/safely-reopening.html
+++ b/pages/wordpress-posts/safely-reopening.html
@@ -132,7 +132,7 @@ addtositemap: true
 
 
 
-<p>Read more on our <a href="masks-and-ppe/">Masks</a> page and CDPH’s <a href="https://www.cdph.ca.gov/Programs/CID/DCDC/Pages/COVID-19/guidance-for-face-coverings.aspx">Guidance for the Use of Face Coverings</a>.</p>
+<p>Read more on our <a href="/masks-and-ppe/">Masks</a> page and CDPH’s <a href="https://www.cdph.ca.gov/Programs/CID/DCDC/Pages/COVID-19/guidance-for-face-coverings.aspx">Guidance for the Use of Face Coverings</a>.</p>
 
 
 


### PR DESCRIPTION
Replacing the root link with a relative link to make translations work

fix WP page after deployment...
https://as-go-covid19-d-001.azurewebsites.net/wp-admin/post.php?post=1392&action=edit

Only affects `new` + translations