### PR TITLE
add anchor link tracking

### DIFF
--- a/src/js/tracking-you/index.js
+++ b/src/js/tracking-you/index.js
@@ -20,6 +20,11 @@ export default function setupAnalytics() {
           reportGA('pdf', this.href.split(window.location.hostname)[1])
         });    
       }
+      if(a.href.indexOf('#') > -1) {
+        a.addEventListener('click',function() {
+          reportGA('anchor', this.href.split(window.location.hostname)[1])
+        });    
+      }
     } else {
       // console.log("Adding offsite link handler:",window.location.hostname,a.href);
       a.addEventListener('click',function() {


### PR DESCRIPTION
This adds custom event tracking for anchor links. The following information would be sent (the port :8000 on the eventLabel won't be there in production):

<img width="476" alt="event-labels" src="https://user-images.githubusercontent.com/353360/128089328-9772ed15-7e46-4824-9701-78ba75289f81.png">

