### PR TITLE
fix offsite link tracking bug that was ignoring desired subdomains

### DIFF
--- a/src/js/tracking-you/index.js
+++ b/src/js/tracking-you/index.js
@@ -13,8 +13,8 @@ export default function setupAnalytics() {
   });
 
   document.querySelectorAll('a').forEach((a) => {
-    // look for and track offsite and pdf links
-    if(a.href.indexOf(window.location.hostname) > -1 || a.href.indexOf('covid19.ca.gov') > -1) {
+    // look for and track anchor and pdf links
+    if(a.href.indexOf(window.location.hostname) > -1 || a.href.indexOf('covid19.ca.gov') > -1) { // do this because pdfs are on linked subdomains
       if(a.href.indexOf('.pdf') > -1) {
         a.addEventListener('click',function() {
           reportGA('pdf', this.href.split(window.location.hostname)[1])
@@ -25,11 +25,16 @@ export default function setupAnalytics() {
           reportGA('anchor', this.href.split(window.location.hostname)[1])
         });    
       }
-    } else {
-      // console.log("Adding offsite link handler:",window.location.hostname,a.href);
-      a.addEventListener('click',function() {
-        reportGA('offsite', this.href)
-      })
+    }
+    // look for offsite links
+    if(a.href.indexOf(window.location.origin) === -1 && a.href.indexOf('http') > -1) { // we are looking at a different protocol + hostname, ignoring tel: links
+      if(a.href.indexOf('.pdf') === -1) {
+        // we want to track links to subdomains like toolkit.covid19.ca.gov
+        // but we don't want to record clicks to files.covid19.ca.gov/my.pdf as offsite links because we record those as pdf clicks above
+        a.addEventListener('click',function() {
+          reportGA('offsite', this.href)
+        })          
+      }
     }
   });
 


### PR DESCRIPTION
Ticket: https://github.com/cagov/covid19/issues/5107

Bug:
We expected links on covid19 to toolkit.covid19.ca.gov to generate an offsite link click event since they were going to a domain that had its own set of GA tags. 
This wasn't happening, no events on links to pages on 4th level subdomains under covid19.ca.gov were generating click events.

This code change fixes that without duplicating pdf link tracking events because those are hosted on files.covid19.ca.gov