### PR TITLE
Work-around for Safari 14.1 refresh issue with large-tab buttons.

### DIFF
--- a/src/css/_buttons.scss
+++ b/src/css/_buttons.scss
@@ -297,6 +297,8 @@ button.clear {
     flex-direction: row;
   }
   .large-tab {
+    pointer-events: unset !important; // work-around for Safari 14
+    cursor: pointer; // work-around for Safari 14
     text-decoration: none;
     font-family: Montserrat;
     font-style: normal;
@@ -328,8 +330,8 @@ button.clear {
     &.active,
     &[aria-expanded="true"],
     &.toggle-active {
-      color: $white;
       background-color: $darkblue;
+      color: $white;
       text-decoration: none;
       pointer-events: none;
       cursor: default;

--- a/src/js/equity-dash/charts/social-determinants/index.js
+++ b/src/js/equity-dash/charts/social-determinants/index.js
@@ -224,7 +224,7 @@ class CAGOVChartD3Bar extends window.HTMLElement {
           }
         });
         resetToggles();
-        tog.classList.add('active')
+        tog.classList.add('active');
       })
     })
 


### PR DESCRIPTION
There is a safari 14 bug which causes our big-blue (large-tab) buttons to not refresh properly, even though the styling is correct.

This work-around is based on a discussion here:

https://bugs.webkit.org/show_bug.cgi?id=225354

Tested to work in Safari 14.1.