### PR TITLE
Added support for displaying 1 or 2 additional decimal places to displayed counts in equity 100k chart.

### DIFF
--- a/src/js/common/value-formatters.js
+++ b/src/js/common/value-formatters.js
@@ -61,8 +61,12 @@ export default function formatValue(v, {format='number',min_decimals=1})
             return float2Formatter.format(v);
         } else if (min_decimals == 0) {
             return intFormatter.format(v);
-        } else {
+        } else if (min_decimals == 1) {
             return float1Formatter.format(v);
+        } else if (min_decimals == 2) {
+            return float2Formatter.format(v);
+        } else {
+            return float3Formatter.format(v);
         }
     }
 }

--- a/src/js/equity-dash/charts/healthy-places-index/tooltip.js
+++ b/src/js/equity-dash/charts/healthy-places-index/tooltip.js
@@ -3,7 +3,7 @@ import { parseSnowflakeDate } from "../../../common/readable-date.js";
 export default class Tooltip {
   constructor(needs_anno, yScale) {
     let yRange = yScale.range();
-    console.log("Range",yRange);
+    // console.log("Range",yRange);
     this.needs_anno = needs_anno;
     // this.legend = legend; // no longer using this param
     this.node = document.createElementNS("http://www.w3.org/2000/svg","g")

--- a/src/js/equity-dash/charts/relative-percentage-by-100k/draw-chart.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-100k/draw-chart.js
@@ -178,7 +178,7 @@ export default function drawBars(stackedData, data, statewideRatePer100k) {
             d.METRIC_VALUE_PER_100K !== null
           ) {
             return d.METRIC_VALUE_PER_100K
-              ? formatValue(d.METRIC_VALUE_PER_100K,{format:'integer'})
+              ? formatValue(d.METRIC_VALUE_PER_100K,{format:'number',min_decimals:this.decimal_display_places})
               : 0;
           } else {
             if (d.APPLIED_SUPPRESSION === "Total") {

--- a/src/js/equity-dash/charts/relative-percentage-by-100k/index.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-100k/index.js
@@ -141,7 +141,7 @@ class CAGOVEquityRE100K extends window.HTMLElement {
       let templateStr = this.translationsObj["chartToolTip-caption"];
       let caption = templateStr
         .replace("placeholderDEMO_CAT", a)
-        .replace("placeholderMETRIC_100K", formatValue(b,{format:'integer'}))
+        .replace("placeholderMETRIC_100K", formatValue(b,{format:'number',min_decimals:this.decimal_display_places}))
         .replace("placeholderFilterScope", c);
       return caption;
     };
@@ -358,6 +358,7 @@ class CAGOVEquityRE100K extends window.HTMLElement {
       // console.log("max xd",max_xdomain, statewideRatePer100k);
       max_xdomain = Math.max(max_xdomain, statewideRatePer100k)
     }
+    this.decimal_display_places = max_xdomain >= 20? 0 : max_xdomain >= 2? 1 : 2;
 
     let barGap = this.dimensions.is_single_col? 60 : 40;
     this.x = d3


### PR DESCRIPTION
This adds a decimal place to chart values and tooltip display if the max value falls below 20. It adds a second decimal place if the max value falls below 2.  Currently affects the statewide deaths chart only, by adding a decimal place, since the max value is currently at 10.  May also affect some county-wide charts (although extremely low numbers tend to cause data hiding in these charts, and I haven't found any affected counties yet).

![image](https://user-images.githubusercontent.com/287977/131395651-4f4aea94-f08b-45da-aa93-94a2601cef3f.png)
