### PR TITLE
Added pagesectionincludes shortcode to simplify handling of multiple pages with similar names.

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -343,6 +343,13 @@ module.exports = function(eleventyConfig) {
     return "";
   }
 
+  const contentfrompageincludes = (content, page, slug) => {
+    if(page.fileSlug && slug && page.fileSlug.toLocaleLowerCase().includes(slug.toLocaleLowerCase())) {
+      return content;
+    }
+    return "";
+  }
+
   const getTranslatedValue = (pageObj, tags, field) => {
     
     let langTag = getLangRecord(tags);
@@ -366,6 +373,7 @@ module.exports = function(eleventyConfig) {
   
   // show or hide content based on page
   eleventyConfig.addPairedShortcode("pagesection", contentfrompage);
+  eleventyConfig.addPairedShortcode("pagesectionincludes", contentfrompageincludes);
 
   let processedPostMap = new Map();
   htmlmap.forEach(pair => {

--- a/pages/_includes/footer.njk
+++ b/pages/_includes/footer.njk
@@ -145,22 +145,10 @@ ga('tracker3.send', 'pageview');
 	{{ macros.includeJavascriptByEnv('roadmap', env.dev) }}
 {% endpagesection -%} #}
 
-{%- pagesection page, "v3-state-dashboard" %}
+{%- pagesectionincludes page, "state-dashboard" %}
 	<script type="module" src="https://d3js.org/d3.v6.min.js"></script><!-- had some trouble importing this, error circular dependencies after npm install so including here -->
 	{{ macros.includeJavascriptByEnv('dashboard-v3', env.dev) }}
-{% endpagesection -%}
-{%- pagesection page, "v4-state-dashboard" %}
-	<script type="module" src="https://d3js.org/d3.v6.min.js"></script><!-- had some trouble importing this, error circular dependencies after npm install so including here -->
-	{{ macros.includeJavascriptByEnv('dashboard-v3', env.dev) }}
-{% endpagesection -%}
-{%- pagesection page, "v5-state-dashboard" %}
-	<script type="module" src="https://d3js.org/d3.v6.min.js"></script><!-- had some trouble importing this, error circular dependencies after npm install so including here -->
-	{{ macros.includeJavascriptByEnv('dashboard-v3', env.dev) }}
-{% endpagesection -%}
-{%- pagesection page, "state-dashboard" %}
-	<script type="module" src="https://d3js.org/d3.v6.min.js"></script><!-- had some trouble importing this, error circular dependencies after npm install so including here -->
-	{{ macros.includeJavascriptByEnv('dashboard-v3', env.dev) }}
-{% endpagesection -%}
+{% endpagesectionincludes -%}
 
 {%- pagesection page, "equity" %}
 	<script type="module" src="https://d3js.org/d3.v6.min.js"></script><!-- had some trouble importing this, error circular dependencies after npm install so including here -->

--- a/pages/_includes/page.njk
+++ b/pages/_includes/page.njk
@@ -42,11 +42,7 @@
             <p class="small-text">{{text.last_updated}}&nbsp;
               {%- if page | engSlug === "data-and-tools" -%}
                 {{ "today" | formatDate2(true,tags) }}
-              {%- elseif page | engSlug === "state-dashboard" -%}
-                {{ (dailyStatsV2.meta.PUBLISHED_DATE + "T17:00:00Z") | formatDate2(true,tags,0) }}
-              {%- elseif page | engSlug === "v4-state-dashboard" -%}
-                {{ (dailyStatsV2.meta.PUBLISHED_DATE + "T17:00:00Z") | formatDate2(true,tags,0) }}
-              {%- elseif page | engSlug === "v5-state-dashboard" -%}
+              {%- elseif (page | engSlug).includes("state-dashboard") -%}
                 {{ (dailyStatsV2.meta.PUBLISHED_DATE + "T17:00:00Z") | formatDate2(true,tags,0) }}
               {%- elseif page | engSlug === "vaccination-progress-data" -%}
                 {{ (dailyStatsV2.meta.PUBLISHED_DATE + "T17:00:00Z") | formatDate2(true,tags,0) }}
@@ -62,7 +58,7 @@
     </div>
   </div>
 
-  <div class="container{%- pagesection page, 'state-dashboard' %} blue-bottom{%- endpagesection %}{%- pagesection page, 'v4-state-dashboard' %} blue-bottom{%- endpagesection %}{%- pagesection page, 'v5-state-dashboard' %} blue-bottom{%- endpagesection %}">
+  <div class="container {%- pagesectionincludes page, 'state-dashboard' %} blue-bottom{%- endpagesectionincludes %}">
     <div class="row">
       <div class="col-lg-10 mx-auto">
         {{ content | safe  }}


### PR DESCRIPTION
Removed some redundant substitution handling for v#-state-dashboard variant versions in nunjucks templates.  

Thank you to Aaron for pointing me to the thing that needed changing.

