### PR TITLE
Tweaks to "Pending" logic on sparklines

### DIFF
--- a/pages/_data/casesSummaryData.js
+++ b/pages/_data/casesSummaryData.js
@@ -13,32 +13,35 @@ module.exports = function() {
     fetch(dataDomain+'confirmed-cases/california.json')
     .then(res => res.json())
     .then(json => {
-        const data = json;          
-        let sumCasesCount = 0;
-        const pending_date = json.data.latest.CONFIRMED_CASES.EPISODE_UNCERTAINTY_PERIOD;
-        const caseList = json.data.time_series.CONFIRMED_CASES_EPISODE_DATE.VALUES;
-        let parse_state = 0;
-        let summed_days = 0;
-        for (let i = 0; i < caseList.length; ++i) {
-            if (parse_state == 0) {
-                if (caseList[i].DATE == pending_date) {
-                    parse_state = 1;
-                }
-            } else {
-                sumCasesCount += caseList[i].VALUE;
-                summed_days += 1;
-            }
-            if (summed_days == 7) {
-                break;
-            }
-        }
-        // console.log("SUMMED CASES", sumCasesCount, summed_days);
-        let output = 
-            {
-                CASES_DAILY_AVERAGE: sumCasesCount / summed_days
-            }
-        ;
-        resolve(output);
+        // const data = json;          
+        // let sumCasesCount = 0;
+        // const pending_date = json.data.latest.CONFIRMED_CASES.EPISODE_UNCERTAINTY_PERIOD;
+        // const caseList = json.data.time_series.CONFIRMED_CASES_EPISODE_DATE.VALUES;
+        // let parse_state = 0;
+        // let summed_days = 0;
+        // for (let i = 0; i < caseList.length; ++i) {
+        //     if (parse_state == 0) {
+        //         if (caseList[i].DATE == pending_date) {
+        //             parse_state = 1;
+        //         }
+        //     } else {
+        //         sumCasesCount += caseList[i].VALUE;
+        //         summed_days += 1;
+        //     }
+        //     if (summed_days == 7) {
+        //         break;
+        //     }
+        // }
+        // // console.log("SUMMED CASES", sumCasesCount, summed_days);
+        // let output = 
+        //     {
+        //         CASES_DAILY_AVERAGE: sumCasesCount / summed_days
+        //     }
+        // ;
+
+        // console.log("CASE COMPARISON (dyn/pre): ",sumCasesCount / summed_days, json.data.latest.CONFIRMED_CASES.CASES_DAILY_AVERAGE);
+        // resolve(output);
+        resolve(json);
     });
   });
 };

--- a/pages/_data/deathsSummaryData.js
+++ b/pages/_data/deathsSummaryData.js
@@ -13,32 +13,34 @@ module.exports = function() {
     fetch(dataDomain+'confirmed-deaths/california.json')
     .then(res => res.json())
     .then(json => {
-        const data = json;          
-        let sumDeathsCount = 0;
-        const pending_date = json.data.latest.CONFIRMED_DEATHS.DEATH_UNCERTAINTY_PERIOD;
-        const deathsList = json.data.time_series.CONFIRMED_DEATHS_DEATH_DATE.VALUES;
-        let parse_state = 0;
-        let summed_days = 0;
-        for (let i = 0; i < deathsList.length; ++i) {
-            if (parse_state == 0) {
-                if (deathsList[i].DATE == pending_date) {
-                    parse_state = 1;
-                }
-            } else {
-                sumDeathsCount += deathsList[i].VALUE;
-                summed_days += 1;
-            }
-            if (summed_days == 7) {
-                break;
-            }
-        }
-        // console.log("SUMMED DEATHS", sumDeathsCount, summed_days);
-        let output = 
-            {
-                DEATHS_DAILY_AVERAGE: sumDeathsCount / summed_days
-            }
-        ;
-        resolve(output);
+        // const data = json;          
+        // let sumDeathsCount = 0;
+        // const pending_date = json.data.latest.CONFIRMED_DEATHS.DEATH_UNCERTAINTY_PERIOD;
+        // const deathsList = json.data.time_series.CONFIRMED_DEATHS_DEATH_DATE.VALUES;
+        // let parse_state = 0;
+        // let summed_days = 0;
+        // for (let i = 0; i < deathsList.length; ++i) {
+        //     if (parse_state == 0) {
+        //         if (deathsList[i].DATE == pending_date) {
+        //             parse_state = 1;
+        //         }
+        //     } else {
+        //         sumDeathsCount += deathsList[i].VALUE;
+        //         summed_days += 1;
+        //     }
+        //     if (summed_days == 7) {
+        //         break;
+        //     }
+        // }
+        // // console.log("SUMMED DEATHS", sumDeathsCount, summed_days);
+        // let output = 
+        //     {
+        //         DEATHS_DAILY_AVERAGE: sumDeathsCount / summed_days
+        //     }
+        // ;
+        // console.log("DEATH COMPARISON (dyn/pre): ",sumDeathsCount / summed_days, json.data.latest.CONFIRMED_DEATHS.DEATHS_DAILY_AVERAGE);
+        // resolve(output);
+        resolve(json);
     });
   });
 };

--- a/pages/wordpress-posts/v5-state-dashboard.html
+++ b/pages/wordpress-posts/v5-state-dashboard.html
@@ -25,21 +25,21 @@ addtositemap: false
 {# {%-set data = tableauCovidMetrics[0] -%}  #}
 {%-set data2 = dailyStatsV2.data -%}
 {%-set datavax = vaccineSparkData.data -%}
-{%-set datacases = casesSummaryData -%}
-{%-set datadeaths = deathsSummaryData -%}
+{%-set datacases = casesSummaryData.data -%}
+{%-set datadeaths = deathsSummaryData.data -%}
 
 {%-set _varStatDate_ = dailyStatsV2.meta.PUBLISHED_DATE | formatDate2(false, tags, 0)-%}
 {%-set _varStatDateNoYear_ = _varStatDate_ | replace(", 2021", "")-%}
 {%-set _varStatTotalCases_ = data2.cases.LATEST_TOTAL_CONFIRMED_CASES | formatNumber(tags)-%}
 {%-set _varStatTotalCasesToday_ = data2.cases.NEWLY_REPORTED_CASES | formatNumber(tags)-%}
 {%-set _varStatNewCasesPer100k_ = (data2.cases.LATEST_CONFIDENT_AVG_CASE_RATE_PER_100K_7_DAYS) | formatNumberFixed(tags,1)-%}
-{%-set _varCasesDailyAverage_ = datacases.CASES_DAILY_AVERAGE | formatNumber(tags,0)-%}
+{%-set _varCasesDailyAverage_ = datacases.latest.CONFIRMED_CASES.CASES_DAILY_AVERAGE | formatNumber(tags,0)-%}
 
 {%-set _varStatTotalDeaths_ = data2.deaths.LATEST_TOTAL_CONFIRMED_DEATHS | formatNumber(tags)-%}
 {%-set _varStatTotalDeathsToday_ = data2.deaths.NEWLY_REPORTED_DEATHS | formatNumber(tags)-%}
 {%-set _varStatNewDeathsPer100k_ = (data2.deaths.LATEST_CONFIDENT_AVG_DEATH_RATE_PER_100K_7_DAYS) |
 formatNumberFixed(tags,2)-%}
-{%-set _varDeathsDailyAverage_ = datadeaths.DEATHS_DAILY_AVERAGE | formatNumber(tags,0)-%}
+{%-set _varDeathsDailyAverage_ = datadeaths.latest.CONFIRMED_DEATHS.DEATHS_DAILY_AVERAGE | formatNumber(tags,0)-%}
 
 {%-set _varStatTested_ = data2.tests.LATEST_TOTAL_TESTS_PERFORMED | formatNumber(tags)-%}
 {%-set _varStatTestedDaily_ = data2.tests.NEWLY_REPORTED_TESTS | formatNumber(tags)-%}

--- a/src/js/dashboard/charts/cagov-chart-dashboard-sparkline/index.js
+++ b/src/js/dashboard/charts/cagov-chart-dashboard-sparkline/index.js
@@ -104,13 +104,18 @@ class CAGovDashboardSparkline extends window.HTMLElement {
 
     // COMPUTE MANUAL AVERAGE
     let line_series = [];
-    bar_series.forEach((rec,i) => {
-        let sum = 0;
-        for (let j = i; j < i+7; ++j) {
-          sum += j < bar_series.length? bar_series[j].VALUE : 0;
-        }
-        line_series.push({DATE:rec.DATE,VALUE:sum/7.0});
-    });
+    if (('no_average' in this.chartOptions) && this.chartOptions.no_average) {
+      console.log("Skipping averaging for ",this.dataset.chartConfigKey);
+      line_series = JSON.parse(JSON.stringify(bar_series));
+    } else {
+      bar_series.forEach((rec,i) => {
+          let sum = 0;
+          for (let j = i; j < i+7; ++j) {
+            sum += j < bar_series.length? bar_series[j].VALUE : 0;
+          }
+          line_series.push({DATE:rec.DATE,VALUE:sum/7.0});
+      });
+    }
   
     bar_series = bar_series.splice(uncertainty_days, display_weeks*7);
     line_series = line_series.splice(uncertainty_days, display_weeks*7);

--- a/src/js/dashboard/charts/cagov-chart-dashboard-sparkline/sparkline-config.json
+++ b/src/js/dashboard/charts/cagov-chart-dashboard-sparkline/sparkline-config.json
@@ -8,7 +8,9 @@
         "dataUrl": "confirmed-cases/california.json",
         "rootId": "cases-ep",
         "display_weeks": 8,
-        "uncertainty_weeks": 1  
+        "uncertainty_days_override": 0,
+        "uncertainty_latest_field": "CONFIRMED_CASES",
+        "uncertainty_date_field": "EPISODE_UNCERTAINTY_PERIOD"
       }
     },
     "deaths": {
@@ -19,7 +21,9 @@
         "dataUrl": "confirmed-deaths/california.json",
         "rootId": "death-date",
         "display_weeks": 8,
-        "uncertainty_weeks": 3      
+        "uncertainty_days_override": 0,
+        "uncertainty_latest_field": "CONFIRMED_DEATHS",
+        "uncertainty_date_field": "DEATH_UNCERTAINTY_PERIOD"
       }
     },
     "tests": {
@@ -30,7 +34,9 @@
         "dataUrl": "total-tests/california.json",
         "rootId": "tests-tests",
         "display_weeks": 8,
-        "uncertainty_weeks": 1
+        "uncertainty_days_override": 0,
+        "uncertainty_latest_field": "TOTAL_TESTS",
+        "uncertainty_date_field": "TESTING_UNCERTAINTY_PERIOD"
       }
     },
     "vaccines": {
@@ -42,8 +48,10 @@
           "dataUrl": "vaccines/sparkline.json",
           "rootId": "tests-vaccines",
           "display_weeks": 8,
-          "uncertainty_weeks": 1
-        }
+          "uncertainty_days_override": 7,
+          "uncertainty_latest_field": "",
+          "uncertainty_date_field": ""
+          }
     },
     "desktop": {
       "fontSize": 14,

--- a/src/js/dashboard/charts/cagov-chart-dashboard-sparkline/sparkline-config.json
+++ b/src/js/dashboard/charts/cagov-chart-dashboard-sparkline/sparkline-config.json
@@ -29,14 +29,15 @@
     "tests": {
       "sparkline": {
         "chartName": "cagov-chart-dashboard-sparkline",
-        "seriesField": "TOTAL_TESTS",
-        "seriesFieldAvg": "AVG_TEST_RATE_PER_100K_7_DAYS",
-        "dataUrl": "total-tests/california.json",
+        "seriesField": "TEST_POSITIVITY_RATE_7_DAYS",
+        "seriesFieldAvg": "TEST_POSITIVITY_RATE_7_DAYS",
+        "dataUrl": "positivity-rate/california.json",
         "rootId": "tests-tests",
         "display_weeks": 8,
         "uncertainty_days_override": 0,
-        "uncertainty_latest_field": "TOTAL_TESTS",
-        "uncertainty_date_field": "TESTING_UNCERTAINTY_PERIOD"
+        "uncertainty_latest_field": "POSITIVITY_RATE",
+        "uncertainty_date_field": "TESTING_UNCERTAINTY_PERIOD",
+        "no_average":true
       }
     },
     "vaccines": {


### PR DESCRIPTION
Using "UNCERTAINTY_PERIOD" fields for computing pending days (to remove) from sparklines, when available (rather than forcing a fixed 1 or 3 weeks).  This way the sparklines match the underlying charts better.

Added an override for this feature, used on the vaccines sparkline, for which no such data is available.

Switched from weeks to days for the units.

Changed tests sparkline to show posivitiy rate instead of #4566 

Swicthed from dynamic to precomputed values for cases/deaths