### PR TITLE
Implemented region fill for tests sparkline.

### DIFF
--- a/pages/wordpress-posts/state-dashboard-sparklines.html
+++ b/pages/wordpress-posts/state-dashboard-sparklines.html
@@ -15,13 +15,13 @@ addtositemap: false
 {%-set datadeaths = deathsSummaryData -%}
 -->
 
-
-
 <style>
+   /* this is a circular reference. and may cause issues */
    {% include "../../docs/img/generated/sparkline.css" %}
    div.chart-prev-div {
       width:440px;
       background-color: #003d9d;
+      padding: 0 10%;
    }
 </style>
 
@@ -37,23 +37,25 @@ Vaccines
   <cagov-chart-dashboard-sparkline class="chart" data-chart-config-filter="sparkline" data-chart-config-key="vaccines"></cagov-chart-dashboard-sparkline>
 </div>
 
-
+<br/>
 
 Cases
 <div class="chart-prev-div">
    <cagov-chart-dashboard-sparkline class="chart" data-chart-config-filter="sparkline" data-chart-config-key="cases"></cagov-chart-dashboard-sparkline>
 </div>
 
-
+<br/>
 
 Deaths
 <div class="chart-prev-div">
    <cagov-chart-dashboard-sparkline class="chart" data-chart-config-filter="sparkline" data-chart-config-key="deaths"></cagov-chart-dashboard-sparkline>
 </div>
 
-
+<br/>
 
 Tests
 <div class="chart-prev-div">
     <cagov-chart-dashboard-sparkline class="chart" data-chart-config-filter="sparkline" data-chart-config-key="tests"></cagov-chart-dashboard-sparkline>
 </div>
+
+<br/>

--- a/src/img/generated/sparkline.css
+++ b/src/img/generated/sparkline.css
@@ -10,7 +10,11 @@ g.fg-line path {
   stroke: #92c5de;
   stroke-width: 2px;
 }
-
+g.fg-region path {
+  fill: #00183f;
+  stroke: none;
+  opacity:0.5;
+}
 g.fg-line.second-line path {
   opacity: 0.5;
 }

--- a/src/js/dashboard/charts/cagov-chart-dashboard-sparkline/index.js
+++ b/src/js/dashboard/charts/cagov-chart-dashboard-sparkline/index.js
@@ -45,7 +45,7 @@ class CAGovDashboardSparkline extends window.HTMLElement {
 
     // Set default values for data and labels
     this.dataUrl = config.chartsStateDashTablesLocSparkline + this.chartOptions.dataUrl;
-    console.log("Loading sparkline json",this.dataset.chartConfigKey,this.dataUrl);
+    // console.log("Loading sparkline json",this.dataset.chartConfigKey,this.dataUrl);
     this.retrieveData(this.dataUrl);
 
     rtlOverride(this); // quick fix for arabic
@@ -65,10 +65,9 @@ class CAGovDashboardSparkline extends window.HTMLElement {
   }
 
   renderComponent() {
-    let addStateLine = false;
     this.statedata = this.chartdata;
 
-    console.log("Loading sparkline chart",this.dataset.chartConfigKey,this.chartdata);
+    // console.log("Loading sparkline chart",this.dataset.chartConfigKey,this.chartdata);
     this.innerHTML = template.call(this, this.chartOptions, this.translationsObj);
     let display_weeks = this.chartOptions.display_weeks;
     let uncertainty_days = this.chartOptions.uncertainty_days_override;
@@ -88,11 +87,9 @@ class CAGovDashboardSparkline extends window.HTMLElement {
       if (uncertainty_days > 28) {
         console.log("Problem calcuating uncertainty period",this.dataset.chartConfigKey,this.chartdata)
         uncertainty_days = 7;
-      } else {
-        console.log("Calculated uncertainty period",uncertainty_days,this.dataset.chartConfigKey,this.chartdata);
       }
     } else {
-      console.log("Overriding uncertainty_days",uncertainty_days,this.dataset.chartConfigKey,this.chartdata);
+      // console.log("Overriding uncertainty_days",uncertainty_days,this.dataset.chartConfigKey,this.chartdata);
     }
 
     let bar_series = this.chartdata.time_series[this.chartOptions.seriesField].VALUES;
@@ -128,12 +125,10 @@ class CAGovDashboardSparkline extends window.HTMLElement {
                           'time_series_bars':bar_series,
                           'time_series_line':line_series,
                           'left_y_fmt':'pct',
-                          'root_id':'pos-rate',
+                          'root_id':this.chartOptions.rootId,
                           'right_y_fmt':'integer',
                         };
-      if (addStateLine) {
-        renderOptions.time_series_state_line = this.statedata.time_series[this.chartOptions.seriesFieldAvg].VALUES;
-      }
+      console.log("RENDERING CHART",this.chartConfigFilter, this.chartConfigKey);
       renderChart.call(this, renderOptions);
   }
 

--- a/src/js/dashboard/charts/cagov-chart-dashboard-sparkline/sparkline-config.json
+++ b/src/js/dashboard/charts/cagov-chart-dashboard-sparkline/sparkline-config.json
@@ -31,7 +31,7 @@
     "tests": {
       "sparkline": {
         "chartName": "cagov-chart-dashboard-sparkline",
-        "chart_style": "solid",
+        "chart_style": "solid-region",
         "seriesField": "TEST_POSITIVITY_RATE_7_DAYS",
         "seriesFieldAvg": "TEST_POSITIVITY_RATE_7_DAYS",
         "dataUrl": "positivity-rate/california.json",

--- a/src/js/dashboard/charts/cagov-chart-dashboard-sparkline/sparkline.js
+++ b/src/js/dashboard/charts/cagov-chart-dashboard-sparkline/sparkline.js
@@ -16,6 +16,26 @@ function writeLine(svg, data, x, y, { root_id='barid', is_second_line=false, cro
           );
 }
 
+function writeRegion(svg, data, x, y, { root_id='barid', is_second_line=false, crop_floor=true }) {
+  let max_y_domain = y.domain()[1];
+  let max_x_domain = x.domain()[1];
+  let component = this;
+
+  let groups = svg.append("g")
+    .attr("class","fg-region")
+    // .attr('style','fill:none; stroke:#555555; stroke-width: 2.0px;'+(is_second_line? 'opacity:0.5;' : ''))
+    .append('path')
+    .datum(data)
+      .attr("class","area")
+      .attr("d", d3.area()
+        .x(function(d,i) { return x(i) })
+        .y0(y(0))
+        .y1(function(d) { return y(crop_floor? Math.max(0,d.VALUE) : d.VALUE) })
+      );
+      
+}
+
+
 function writeBars(svg, data, x, y, { root_id='barid', crop_floor=true,chart_style="normal" }) {
     if (!crop_floor) {
       console.log("NOT CROP FLOOR");
@@ -167,11 +187,8 @@ export default function renderChart({
   crop_floor = true,
   pending_date = null,
   month_modulo = 3,
-  root_id = "barid" } )  {
-
-  console.log("renderChart",root_id);
-  // d3.select(this.querySelector("svg g"))
-  //   .attr('style','font-family:sans-serif;font-size:16px;');
+  root_id = "barid" } )  
+{
 
   this.svg = d3
     .select(this.querySelector(".svg-holder"))
@@ -241,15 +258,20 @@ export default function renderChart({
     }
   }
 
-
   // let max_xdomain = d3.max(data, (d) => d3.max(d, (d) => d.METRIC_VALUE));
 
-  if (time_series_bars && chart_style != "no_bars") {
+  if (time_series_bars && chart_style != "no-bars" && chart_style != "solid-region") {
     writeBars.call(this, this.svg, time_series_bars, this.xbars, this.ybars, 
       { root_id:root_id, crop_floot:crop_floor, chart_style:chart_style});
     // bar legend on left
   }
   if (time_series_line) {
+    if (chart_style == "solid-region") {
+      writeRegion.call(this, this.svg, time_series_line, this.xline, this.ybars, 
+        { root_id:root_id, crop_floot:crop_floor});
+    }
+
+
     writeLine.call(this, this.svg, time_series_line, this.xline, this.ybars, 
       { root_id:root_id, crop_floot:crop_floor});
   }

--- a/src/js/dashboard/charts/cagov-chart-dashboard-sparkline/sparkline.scss
+++ b/src/js/dashboard/charts/cagov-chart-dashboard-sparkline/sparkline.scss
@@ -20,14 +20,22 @@ cagov-chart-dashboard-sparkline.chart {
         margin-left:10%;
         margin-right:10%;
     }
+    div.sparkline-tests g.fg-bars {
+      opacity: 0.7;
+    }
     .svg-holder {
       g.fg-bars {
-        fill: #1f2574;
+        fill: #00183f;
       }
       g.fg-line path {
         fill: none;
-        stroke: #96cce3;
+        stroke: #92c5de;
         stroke-width: 2px;
+      }
+      g.fg-region path {
+        fill: #00183f;
+        stroke: none;
+        opacity:0.5;
       }
       g.fg-line.second-line path {
         opacity: 0.5;

--- a/src/js/dashboard/charts/cagov-chart-dashboard-sparkline/sparklines-partial.scss
+++ b/src/js/dashboard/charts/cagov-chart-dashboard-sparkline/sparklines-partial.scss
@@ -1,10 +1,18 @@
 g.fg-bars {
-  fill: #1f2574;
+  fill: #00183f;
+}
+div.sparkline-tests g.fg-bars {
+  opacity: 0.7;
 }
 g.fg-line path {
   fill: none;
-  stroke: #96cce3;
+  stroke: #92c5de;
   stroke-width: 2px;
+}
+g.fg-region path {
+  fill: #00183f;
+  stroke: none;
+  opacity:0.5;
 }
 g.fg-line.second-line path {
   opacity: 0.5;

--- a/src/js/state-dashboard-sparklines/index.js
+++ b/src/js/state-dashboard-sparklines/index.js
@@ -1,3 +1,3 @@
 // sparklines
-console.log("HELLO");
+// console.log("HELLO");
 import "../dashboard/charts/cagov-chart-dashboard-sparkline/index.js"


### PR DESCRIPTION
Added styling on sparkline renderer (note: it currently includes a circular reference to generated css file)

Added custom testing chart mode "solid-region" which does a region fill using d3.area()

Copied some changes made manually to generated/sparklines.css into the permanent versions of these files, so we don't lose those changes (color changes, opacity).
