### PR TITLE
Preloading of cases postvax chart via embedded <img> tag.

### DIFF
--- a/pages/wordpress-posts/state-dashboard.html
+++ b/pages/wordpress-posts/state-dashboard.html
@@ -257,6 +257,7 @@ data2.icu.ICU_SUSPECTED_COVID_PATIENTS_DAILY) | formatNumber(tags)-%}
       Vaccinated cases per 100K: <b>{VCOUNT}</b><br>
     </li>  
   </ul>
+  <img class="postvax-chart" src="https://files.covid19.ca.gov/img/generated/postvax/postvax-cases.svg">
 </cagov-chart-dashboard-postvax-chart>
 
 

--- a/src/js/dashboard/charts/cagov-chart-dashboard-postvax-chart/postvax-chart.scss
+++ b/src/js/dashboard/charts/cagov-chart-dashboard-postvax-chart/postvax-chart.scss
@@ -158,3 +158,4 @@ cagov-chart-dashboard-postvax-chart {
 .d-hide {
   display: none;
 }
+img.postvax-chart { max-width: 615px; }

--- a/src/js/dashboard/charts/ie11.scss
+++ b/src/js/dashboard/charts/ie11.scss
@@ -7,7 +7,7 @@ cagov-chart-dashboard-confirmed-cases, cagov-chart-dashboard-confirmed-deaths, c
 
 cagov-chart-dashboard-postvax-chart  {
   .svg-holder svg {
-    width: 615px;
-		height: 400px;
+    width: 400px;
+		height: 300px;
   }
 }


### PR DESCRIPTION
Candidate solution for making postvax chart visible in IE11, prerenders the chart as an embedded <img>.

Styling isn't quite there yet. And the HTML elements rendered by template are missing (legends).

Fwiw, I still don't understand why ALL the other dynamic svgs work...  Would love to fix dynamic rendering first...