### PR TITLE
Adjustments for coming out of Daylight Savings.

### DIFF
--- a/pages/_includes/main.njk
+++ b/pages/_includes/main.njk
@@ -138,7 +138,7 @@ formatNumber(tags,1)-%}
 				<div class="hero-stats" role="region" aria-labelledby="tracking-covid">
 					<h2 class="color-orange text-center m-0 pb-2 pt-3" id="tracking-covid">{{translatedLabels.varStatsHeader}}</h2>
 					<div class="text-sm text-center text-300">
-						{{- translatedLabels.varUpdateText | replace("[UpdatedDate]", (dailyStatsV2.meta.PUBLISHED_DATE + "T17:00:00Z") | formatDate2(false,tags,0)) | replace("[DataDate]",dailyStatsV2.meta.PUBLISHED_DATE | formatDate2(false,tags,-1)) -}}
+						{{- translatedLabels.varUpdateText | replace("[UpdatedDate]", (dailyStatsV2.meta.PUBLISHED_DATE + "T18:00:00Z") | formatDate2(false,tags,0)) | replace("[DataDate]",dailyStatsV2.meta.PUBLISHED_DATE | formatDate2(false,tags,-1)) -}}
 					</div>
 					<!----- Begin Summary Boxes -->
 					<div class="row d-flex justify-content-md-center summary-boxes">

--- a/pages/_includes/page.njk
+++ b/pages/_includes/page.njk
@@ -43,11 +43,11 @@
               {%- if page | engSlug === "data-and-tools" -%}
                 {{ "today" | formatDate2(true,tags) }}
               {%- elseif (page | engSlug).includes("state-dashboard") -%}
-                {{ (dailyStatsV2.meta.PUBLISHED_DATE + "T17:00:00Z") | formatDate2(true,tags,0) }}
+                {{ (dailyStatsV2.meta.PUBLISHED_DATE + "T18:00:00Z") | formatDate2(true,tags,0) }}
               {%- elseif page | engSlug === "vaccination-progress-data" -%}
-                {{ (dailyStatsV2.meta.PUBLISHED_DATE + "T17:00:00Z") | formatDate2(true,tags,0) }}
+                {{ (dailyStatsV2.meta.PUBLISHED_DATE + "T18:00:00Z") | formatDate2(true,tags,0) }}
               {%- elseif page | engSlug === "equity" -%}
-                {{ (equityTopBoxes[0].publish_date + "T17:00:00Z") | formatDate2(true,tags, 0) }}
+                {{ (equityTopBoxes[0].publish_date + "T18:00:00Z") | formatDate2(true,tags, 0) }}
               {%- else -%}
                 {{ publishdate | formatDate2(true,tags) }}
               {%- endif -%}


### PR DESCRIPTION
_Not to be merged_ until Sunday Evening, Nov 7. (Jim'll take care of it).

This patch advances some displayed times which are expressed in GMT by one hour, to account for the increased offset between Pacific Time and GMT after DST is no longer in effect.