### PR TITLE
Ignoring major node-fetch updates to do a known issue with dependabot.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,7 @@ updates:
     schedule: 
       interval: "daily"
     target-branch: "dependabotprs"
+    ignore:
+      - dependency-name: "node-fetch"
+        update-types: ["version-update:semver-major"]
+


### PR DESCRIPTION
We have a long-standing irreconcilable issue with being able to update to node-fetch 3.0. (and a Stale PR that is cause by this). 

This patch adds "major updates to node-fetch" to the list of things dependabot should ignore, so we can prevent it from reporting issues with it.

related:

https://stackoverflow.com/questions/69041454/error-require-of-es-modules-is-not-supported-when-importing-node-fetch

