### PR TITLE
Equity data sources patch

### DIFF
--- a/src/js/equity-dash/charts/data-completeness/template.js
+++ b/src/js/equity-dash/charts/data-completeness/template.js
@@ -19,6 +19,10 @@ export default function template(translationsObj) {
         <div class="row">
           <div class="col-lg-9 col-md-9 col-sm-12 mx-auto px-0">
 
+          <div class="mt-2">
+            ${translationsObj["data-source"]}
+          </div>
+
             <div class="wp-block-cgb-block-chart-drawer js-qa-exclude"><cagov-accordion class="chart-drawer">
             <div class="card"><button class="card-header accordion-alpha" type="button" aria-expanded="false"><div class="plus-munus"><cagov-plus></cagov-plus><cagov-minus></cagov-minus></div>
             <div class="accordion-title js-qa-exclude">Chart information</div></button><div class="card-container" aria-hidden="true"><div class="card-body">
@@ -29,6 +33,7 @@ export default function template(translationsObj) {
   
           </div>
         </div>
+
 
         <div class="row" ${inhibitNote}>
           <div class="col-lg-9 col-md-9 col-sm-12 mx-auto px-0">

--- a/src/js/equity-dash/charts/data-completeness/template.js
+++ b/src/js/equity-dash/charts/data-completeness/template.js
@@ -4,6 +4,8 @@ export default function template(translationsObj) {
   // inhibit special note if it is missing (as it currently is for some translations)
   const inhibitNote = ('special-note' in translationsObj)? 
                       '' : 'style="display:none;"' ;
+  const dataSrc = ('data-source' in translationsObj)? translationsObj["data-source"] : "";
+
   return /*html*/`<div class="py-2">
     <div class="container">
       <div class="col-lg-12 bg-white py-4">
@@ -20,7 +22,7 @@ export default function template(translationsObj) {
           <div class="col-lg-9 col-md-9 col-sm-12 mx-auto px-0">
 
           <div class="mt-2">
-            ${translationsObj["data-source"]}
+            ${dataSrc}
           </div>
 
             <div class="wp-block-cgb-block-chart-drawer js-qa-exclude"><cagov-accordion class="chart-drawer">

--- a/src/js/equity-dash/charts/social-determinants/template.js
+++ b/src/js/equity-dash/charts/social-determinants/template.js
@@ -26,6 +26,10 @@ export default function template(translationsObj) {
         </div>
         <div class="row d-flex justify-content-md-center">
           <div class="col-lg-9 col-md-9 col-sm-12 mx-auto">
+
+            <div class="mt-4">
+            ${translationsObj["data-source"]}
+            </div>
   
             <div class="wp-block-cgb-block-chart-drawer js-qa-exclude"><cagov-accordion class="chart-drawer">
             <div class="card"><button class="card-header accordion-alpha" type="button" aria-expanded="false"><div class="plus-munus"><cagov-plus></cagov-plus><cagov-minus></cagov-minus></div>

--- a/src/js/equity-dash/charts/social-determinants/template.js
+++ b/src/js/equity-dash/charts/social-determinants/template.js
@@ -2,6 +2,7 @@
 import css from './index.scss';
 
 export default function template(translationsObj) {
+  let dataSrc = ('data-source' in translationsObj)? translationsObj["data-source"] : "";
   return /*html*/`<div class="py-2 bg-lightblue full-bleed px-4">
     <div class="container">
     <div class="row">
@@ -28,7 +29,7 @@ export default function template(translationsObj) {
           <div class="col-lg-9 col-md-9 col-sm-12 mx-auto">
 
             <div class="mt-4">
-            ${translationsObj["data-source"]}
+              ${dataSrc}
             </div>
   
             <div class="wp-block-cgb-block-chart-drawer js-qa-exclude"><cagov-accordion class="chart-drawer">


### PR DESCRIPTION
Inserting a data-sources reference into the templates for two charts.

These charts currently have a chart-drawer as part of the template. This inserts some needed markup between the bottom of the chart and the chart-drawer. If the data-source item has not yet been provided (as it won't be for translated pages at first), it is inhibited by using a empty string.

Currently in preview on staging.
