### PR TITLE
Modified charts for 5+ vaccines datra.

### DIFF
--- a/src/js/vaccines/charts/cagov-chart-vaccination-groups-age/index.js
+++ b/src/js/vaccines/charts/cagov-chart-vaccination-groups-age/index.js
@@ -13,7 +13,7 @@ class CAGovVaccinationGroupsAge extends window.HTMLElement {
     this.translationsObj = getTranslations(this);
     this.innerHTML = template(this.translationsObj);
     // Settings and initial values
-    this.nbr_bars = 4;
+    this.nbr_bars = 5;
     let bar_vspace = 60;
 
     this.chartOptions = {
@@ -31,7 +31,7 @@ class CAGovVaccinationGroupsAge extends window.HTMLElement {
           top: 60,
           right: 80,
           bottom: 0,
-          left: 0,
+          left: 4,
         },
       },
       tablet: {
@@ -42,7 +42,7 @@ class CAGovVaccinationGroupsAge extends window.HTMLElement {
           top: 60,
           right: 80,
           bottom: 0,
-          left: 0,
+          left: 4,
         },
       },
       mobile: {
@@ -53,7 +53,7 @@ class CAGovVaccinationGroupsAge extends window.HTMLElement {
           top: 60,
           right: 80,
           bottom: 0,
-          left: 0,
+          left: 4,
         },
       },
       retina: {
@@ -64,7 +64,7 @@ class CAGovVaccinationGroupsAge extends window.HTMLElement {
           top: 60,
           right: 80,
           bottom: 0,
-          left: 0,
+          left: 4,
         },
       },
     };

--- a/src/js/vaccines/charts/cagov-chart-vaccination-groups-gender/index.js
+++ b/src/js/vaccines/charts/cagov-chart-vaccination-groups-gender/index.js
@@ -32,7 +32,7 @@ class CAGovVaccinationGroupsGender extends window.HTMLElement {
           top: 60,
           right: 80,
           bottom: 0,
-          left: 0,
+          left: 4,
         },
       },
       tablet: {
@@ -43,7 +43,7 @@ class CAGovVaccinationGroupsGender extends window.HTMLElement {
           top: 60,
           right: 80,
           bottom: 0,
-          left: 0,
+          left: 4,
         },
       },
       mobile: {
@@ -54,7 +54,7 @@ class CAGovVaccinationGroupsGender extends window.HTMLElement {
           top: 60,
           right: 80,
           bottom: 20,
-          left: 0,
+          left: 4,
         },
       },
       retina: {
@@ -65,7 +65,7 @@ class CAGovVaccinationGroupsGender extends window.HTMLElement {
           top: 60,
           right: 80,
           bottom: 20,
-          left: 0,
+          left: 4,
         },
       },
     };

--- a/src/js/vaccines/charts/cagov-chart-vaccination-groups-race-ethnicity/index.js
+++ b/src/js/vaccines/charts/cagov-chart-vaccination-groups-race-ethnicity/index.js
@@ -13,7 +13,7 @@ class CAGovVaccinationGroupsRaceEthnicity extends window.HTMLElement {
     this.translationsObj = getTranslations(this);
     this.innerHTML = template(this.translationsObj);
     // Settings and initial values
-    this.nbr_bars = 9;
+    this.nbr_bars = 10;
     this.bar_vspace = 60;
 
     this.chartOptions = {
@@ -34,7 +34,7 @@ class CAGovVaccinationGroupsRaceEthnicity extends window.HTMLElement {
           top: 60,
           right: 80,
           bottom: 20, // 20 added for divider
-          left: 0,
+          left: 4,
         },
       },
       tablet: {
@@ -45,7 +45,7 @@ class CAGovVaccinationGroupsRaceEthnicity extends window.HTMLElement {
           top: 60,
           right: 80,
           bottom: 20, // 20 added for divider
-          left: 0,
+          left: 4,
         },
       },
       mobile: {
@@ -56,7 +56,7 @@ class CAGovVaccinationGroupsRaceEthnicity extends window.HTMLElement {
           top: 60,
           right: 80,
           bottom: 20,
-          left: 0,
+          left: 4,
         },
       },
       retina: {
@@ -67,7 +67,7 @@ class CAGovVaccinationGroupsRaceEthnicity extends window.HTMLElement {
           top: 60,
           right: 80,
           bottom: 20,
-          left: 0,
+          left: 4,
         },
       },
     };

--- a/src/js/vaccines/rollup.config.js
+++ b/src/js/vaccines/rollup.config.js
@@ -4,14 +4,14 @@ import postcss from 'rollup-plugin-postcss';
 import { terser } from 'rollup-plugin-terser';
 
 const defaultConfig = {
-  equityChartsVEDataLoc: 'https://files.covid19.ca.gov/data/vaccine-equity/',
+  equityChartsVEDataLoc: 'https://files.covid19.ca.gov/data/vaccine-equity/v2/',
   chartsVHPIDataLocDoses: 'https://files.covid19.ca.gov/data/vaccine-hpi/v2/',
   chartsVHPIDataLocPeople: 'https://files.covid19.ca.gov/data/vaccine-hpi/v2/',
 }
 const stagingConfig =  {
-  equityChartsVEDataLoc: 'https://raw.githubusercontent.com/cagov/covid-static-data/7cf5fc39e0bfc91658c7f9bd5ac985178fee43f8/data/vaccine-equity/',
-  chartsVHPIDataLocDoses: 'https://raw.githubusercontent.com/cagov/covid-static/staging/data/vaccine-hpi//v2/',
-  chartsVHPIDataLocPeople: 'https://raw.githubusercontent.com/cagov/covid-static/staging/data/vaccine-hpi/v2/',
+  equityChartsVEDataLoc: 'https://files.covid19.ca.gov/data/vaccine-equity/v2/',
+  chartsVHPIDataLocDoses: 'https://files.covid19.ca.gov/data/vaccine-hpi/v2/',
+  chartsVHPIDataLocPeople: 'https://files.covid19.ca.gov/data/vaccine-hpi/v2/',
 }
 
 const devOutputPath = 'docs/js/vaccines.js';


### PR DESCRIPTION
_NOT TO BE MERGED until Wed Nov 10 around 9:30am._

* Modifies vaccine equity charts to use new /v2/ data from CovidVaccineEquityV2 cron job, which use a 5+ eligible population, and adds a bar to the age chart.  

* Also adds a small margin on these charts to prevent observed cropping of the statewide % indicator.
