### PR TITLE
Using original directory for vaccine equity jsons.

### DIFF
--- a/src/js/vaccines/rollup.config.js
+++ b/src/js/vaccines/rollup.config.js
@@ -4,14 +4,14 @@ import postcss from 'rollup-plugin-postcss';
 import { terser } from 'rollup-plugin-terser';
 
 const defaultConfig = {
-  equityChartsVEDataLoc: 'https://files.covid19.ca.gov/data/vaccine-equity/v2/',
-  chartsVHPIDataLocDoses: 'https://files.covid19.ca.gov/data/vaccine-hpi/v2/',
-  chartsVHPIDataLocPeople: 'https://files.covid19.ca.gov/data/vaccine-hpi/v2/',
+  equityChartsVEDataLoc: 'https://files.covid19.ca.gov/data/vaccine-equity/',
+  chartsVHPIDataLocDoses: 'https://files.covid19.ca.gov/data/vaccine-hpi/',
+  chartsVHPIDataLocPeople: 'https://files.covid19.ca.gov/data/vaccine-hpi/',
 }
 const stagingConfig =  {
-  equityChartsVEDataLoc: 'https://files.covid19.ca.gov/data/vaccine-equity/v2/',
-  chartsVHPIDataLocDoses: 'https://files.covid19.ca.gov/data/vaccine-hpi/v2/',
-  chartsVHPIDataLocPeople: 'https://files.covid19.ca.gov/data/vaccine-hpi/v2/',
+  equityChartsVEDataLoc: 'https://files.covid19.ca.gov/data/vaccine-equity/',
+  chartsVHPIDataLocDoses: 'https://files.covid19.ca.gov/data/vaccine-hpi/',
+  chartsVHPIDataLocPeople: 'https://files.covid19.ca.gov/data/vaccine-hpi/',
 }
 
 const devOutputPath = 'docs/js/vaccines.js';


### PR DESCRIPTION
Part of a general effort affecting /covid19/ /Cron/ and /covid-static-data/ to consolidate vaccine equity code.

When we switched the eligible vaccine population to 5+, I created a V2 version of the CovidVaccineEquity job to run in parallel to the original. I've now removed original (v1) and gone to a single version of the job using the v2 code.

The /v2/ files have been copied to their original location (the parent directory), and the cron now writes to the original location.

This patch modifies the chart renderer to retrieve those json files from the original (parent) directory, instead of /v2/.
