### PR TITLE
cagov/covid19#5635 Break sparklines to two columns on medium screens.

### DIFF
--- a/pages/_includes/main.njk
+++ b/pages/_includes/main.njk
@@ -143,7 +143,7 @@ formatNumber(tags,1)-%}
 					<!----- Begin Summary Boxes -->
 					<div class="row d-flex justify-content-md-center summary-boxes">
 						<!-- Blue Summary Box 1 -->						
-						<div class="col-md-3 px-10px">							
+						<div class="col-md-6 col-lg-3 px-10px">							
 							<div class="bg-blue bd-rounded-10 px-6px py-2 text-center mt-3 summary-box d-flex flex-column">
 								<div class="h5 text-uppercase color-white line-height-1-2 mt-1 mb-auto">{{ translatedLabels.varVaccinesAdministered }}</div>
 								<div id="total-vaccines-number" class="text-white font-size-1-2em mb-2"><strong>{{_varStatVaccines_}}</strong>
@@ -172,7 +172,7 @@ formatNumber(tags,1)-%}
 						</div>
 
 						<!-- Blue Summary Box 2 -->
-						<div class="col-md-3 px-10px">
+						<div class="col-md-6 col-lg-3 px-10px">							
 							<div class="bg-blue bd-rounded-10 px-6px py-2 text-center mt-3 summary-box d-flex flex-column">
 								<div class="h5 text-uppercase color-white line-height-1-2 mt-1 mb-auto">{{ translatedLabels.varTotalCases }}</div>
 
@@ -198,7 +198,7 @@ formatNumber(tags,1)-%}
 							</div>
 						</div>
 						<!-- Blue Summary Box 3 -->
-						<div class="col-md-3 px-10px">
+						<div class="col-md-6 col-lg-3 px-10px">							
 							<div class="bg-blue bd-rounded-10 px-6px py-2 text-center mt-3 summary-box d-flex flex-column">
 								<div class="h5 text-uppercase color-white line-height-1-2 mt-1 mb-auto">{{ translatedLabels.varTotalDeaths }}</div>
 
@@ -225,7 +225,7 @@ formatNumber(tags,1)-%}
 							</div>
 						</div>
 						<!-- Blue Summary Box 4 -->
-						<div class="col-md-3 px-10px">
+						<div class="col-md-6 col-lg-3 px-10px">							
 							<div class="bg-blue bd-rounded-10 px-6px py-2 text-center mt-3 summary-box d-flex flex-column">
 								<div class="h5 text-uppercase color-white line-height-1-2 mt-1 mb-auto">{{ translatedLabels.varTestsReported }}</div>
 								<div id="total-tests-number" class="text-white font-size-1-2em mb-2">


### PR DESCRIPTION
Fixes #5635 on homepage. 