### PR TITLE
Using static.covid19 for images.

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -68,8 +68,8 @@ module.exports = function (eleventyConfig) {
       replaceContent(item, /"https:\/\/covid19.ca.gov\/pdf\//g, `"https://files.covid19.ca.gov/pdf/`);
       replaceContent(item, /"https:\/\/covid19.ca.gov\/img\//g, `"https://files.covid19.ca.gov/img/`);
 
-      //retrieve files newly hosted at data.covid19.ca.gov
-      replaceContent(item, /"https:\/\/files.ca.gov\/img\//g, `"https://data.covid19.ca.gov/img/`);
+      //retrieve files newly hosted on S3
+      replaceContent(item, /"https:\/\/files.ca.gov\/img\//g, `"https://static.covid19.ca.gov/img/`);
       replaceContent(item, /"https:\/\/files.ca.gov\/data\//g, `"https://data.covid19.ca.gov/data/`);
 
       if (item.inputPath.includes(FolderName)) {

--- a/pages/_includes/main.njk
+++ b/pages/_includes/main.njk
@@ -293,7 +293,7 @@ formatNumber(tags,1)-%}
 </div>
 </hero-stats>
 <script>
-let svg_path = 'https://data.covid19.ca.gov/img/generated/sparklines/';
+let svg_path = 'https://static.covid19.ca.gov/img/generated/sparklines/';
 function getSVG(file,selector) {
   fetch(svg_path + file).then(function(response) {
     return response.text().then(function(text) {

--- a/src/css/_general.scss
+++ b/src/css/_general.scss
@@ -2567,7 +2567,7 @@ ul.small-text {
     margin: 12px 0 10px 0;
     line-height: 1.5;
     li {
-      background: url('https://data.covid19.ca.gov/img/noun-reminder.svg') no-repeat 1px 15px transparent;
+      background: url('https://files.covid19.ca.gov/img/noun-reminder.svg') no-repeat 1px 15px transparent;
       padding: 1rem .5rem 1rem 2.5rem;
       margin: 0;
       border-bottom: 1px solid $black;

--- a/src/js/dashboard/index.js
+++ b/src/js/dashboard/index.js
@@ -27,7 +27,7 @@ import "./charts/cagov-chart-dashboard-icu-beds/index.js"
 import "./charts/cagov-chart-dashboard-postvax-chart/index.js"
 
 // load sparklines
-let svg_path = 'https://data.covid19.ca.gov/img/generated/sparklines/';
+let svg_path = 'https://static.covid19.ca.gov/img/generated/sparklines/';
 function getSVG(file,selector) {
   fetch(svg_path + file).then(function(response) {
     return response.text().then(function(text) {


### PR DESCRIPTION
Temporarily using static.covid19.ca.gov for images, by way of an 11ty replacement, and for the sparklines.

This will be reverted back to using data next week, after we get the domain name repointed.

Currently in preview on preproduction.