### PR TITLE
Support image urls in both files and static locations.

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -629,7 +629,7 @@ module.exports = function (eleventyConfig) {
       const lang = langData.languages.filter(x => x.enabled && x.hreflang === htmllang).concat(langData.languages[0])[0].id;
 
       //Scan the DOM for a files.covid19.ca.gov links
-      const domTargets = Array.from(html.matchAll(/"(?<URL>https:\/\/files\.covid19\.ca\.gov\/[^"]*)"/gm))
+      const domTargets = Array.from(html.matchAll(/"(?<URL>https:\/\/(files|static)\.covid19\.ca\.gov\/[^"]*)"/gm))
         .map(r => r.groups.URL);
 
       if (filesSiteData.length === 0) {


### PR DESCRIPTION
Fixes findlinkstolocalize() to support images in either files.covid19 or static.covid19 locations, so that translated images show up as designed.

Temporary fix until we get files.covid19 domain repointed.

