### PR TITLE
Rename remaining references to static.covid19 -> data.covid19

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -69,7 +69,6 @@ module.exports = function (eleventyConfig) {
       replaceContent(item, /"https:\/\/covid19.ca.gov\/img\//g, `"https://files.covid19.ca.gov/img/`);
 
       //retrieve files newly hosted on S3
-      replaceContent(item, /"https:\/\/files.ca.gov\/img\//g, `"https://static.covid19.ca.gov/img/`);
       replaceContent(item, /"https:\/\/files.ca.gov\/data\//g, `"https://data.covid19.ca.gov/data/`);
 
       if (item.inputPath.includes(FolderName)) {

--- a/pages/_includes/main.njk
+++ b/pages/_includes/main.njk
@@ -293,7 +293,7 @@ formatNumber(tags,1)-%}
 </div>
 </hero-stats>
 <script>
-let svg_path = 'https://static.covid19.ca.gov/img/generated/sparklines/';
+let svg_path = 'https://data.covid19.ca.gov/img/generated/sparklines/';
 function getSVG(file,selector) {
   fetch(svg_path + file).then(function(response) {
     return response.text().then(function(text) {

--- a/src/js/dashboard/index.js
+++ b/src/js/dashboard/index.js
@@ -27,7 +27,7 @@ import "./charts/cagov-chart-dashboard-icu-beds/index.js"
 import "./charts/cagov-chart-dashboard-postvax-chart/index.js"
 
 // load sparklines
-let svg_path = 'https://static.covid19.ca.gov/img/generated/sparklines/';
+let svg_path = 'https://data.covid19.ca.gov/img/generated/sparklines/';
 function getSVG(file,selector) {
   fetch(svg_path + file).then(function(response) {
     return response.text().then(function(text) {


### PR DESCRIPTION
Now that files.covid19 is pointing to cloudfront, we can use it across the board. Currently we have been loading images from static.covid19 to avoid migration issues.  This patch goes back to using files.covid19.ca.gov for in the various spots where we were using static.  

After this is merged, I can begin to phase out writing to the static buckets.