### PR TITLE
Added workflow support for auto-building staging on Tuesdays at 1:40pm

### DIFF
--- a/.github/workflows/azure-static-web-apps-wonderful-ground-0c34d501e.yml
+++ b/.github/workflows/azure-static-web-apps-wonderful-ground-0c34d501e.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - staging
 
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+  # Allows you to call this workflow from another workflow -- see equity_deploy_staging.yml
+  workflow_call:
+
 jobs:
   build_and_deploy_job:
     runs-on: ubuntu-latest

--- a/.github/workflows/equity_deploy_staging.yml
+++ b/.github/workflows/equity_deploy_staging.yml
@@ -1,0 +1,15 @@
+name: auto-equity-staging-build
+
+on:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # intended to run around 1:40pm on Wednesday
+    - cron:  '40 21 * * Wed'
+
+# Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+
+jobs:
+  rebuild-equity:
+    uses: ca-gov/covid19/.github/workflows/azure-static-web-apps-wonderful-ground-0c34d501e.yml

--- a/.github/workflows/equity_deploy_staging.yml
+++ b/.github/workflows/equity_deploy_staging.yml
@@ -3,8 +3,8 @@ name: auto-equity-staging-build
 on:
   schedule:
     # * is a special character in YAML so you have to quote this string
-    # intended to run around 1:40pm on Wednesday
-    - cron:  '40 21 * * Wed'
+    # intended to run around 1:40pm on Tuesday
+    - cron:  '40 21 * * Tue'
 
 # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/equity_deploy_staging.yml
+++ b/.github/workflows/equity_deploy_staging.yml
@@ -12,4 +12,4 @@ on:
 
 jobs:
   rebuild-equity:
-    uses: ca-gov/covid19/.github/workflows/azure-static-web-apps-wonderful-ground-0c34d501e.yml
+    uses: ca-gov/covid19/.github/workflows/azure-static-web-apps-wonderful-ground-0c34d501e.yml@master


### PR DESCRIPTION
This very simple patch is intended to autobuild staging at 1:40pm on Tuesdays for equity preview purposes.

This works by reusing the 'staging env build and deploy' workflow, aka

azure-static-web-apps-wonderful-ground-0c34d501e.yml

I added a workflow_call trigger so it can be called from another workflow, and then a separate workflow which triggers it like a Cron job.

* Note that if/when Staging gets moved to S3, any other staging builds will also need to be triggered in the same way.

* If this works, I may remove the morning auto builder system and do a similar trigger when Covid-static-data does a merge on the dashboard file.

