### PR TITLE
More accurate update-dates on data-driven pages.

### DIFF
--- a/pages/_includes/page.njk
+++ b/pages/_includes/page.njk
@@ -49,11 +49,13 @@
               {%- if page | engSlug === "data-and-tools" -%}
                 {{ "today" | formatDate2(true,tags) }}
               {%- elseif (page | engSlug).includes("state-dashboard") -%}
-                {{ (stateDashboardUpdateTime.ROUNDED_PUBLISH_DATE) | formatDate2(true,tags,0) }}
+                {{ '' | latestDate(publishdate,stateDashboardUpdateTime.ROUNDED_PUBLISH_DATE) | formatDate2(true,tags,0) }}
               {%- elseif page | engSlug === "vaccination-progress-data" -%}
-                {{ (stateDashboardUpdateTime.ROUNDED_PUBLISH_DATE) | formatDate2(true,tags,0) }}
+                {{ '' | latestDate(publishdate,stateDashboardUpdateTime.ROUNDED_PUBLISH_DATE) | formatDate2(true,tags,0) }}
               {%- elseif page | engSlug === "equity" -%}
-                {{ (equityDashboardUpdateTime.ROUNDED_PUBLISH_DATE) | formatDate2(true,tags, 0) }}
+                {{ '' | latestDate(publishdate,equityDashboardUpdateTime.ROUNDED_PUBLISH_DATE) | formatDate2(true,tags, 0) }}
+              {%- elseif page | engSlug === "variants" -%}
+                {{ '' | latestDate(publishdate,variantsUpdateTime.ROUNDED_PUBLISH_DATE) | formatDate2(true,tags, 0) }}
               {%- else -%}
                 {{ publishdate | formatDate2(true,tags) }}
               {%- endif -%}


### PR DESCRIPTION
Prior to this fix, the update-date at the top of state-dashboard, equity, and vaccination-progress-data reflected the data-publish date (and not any wordpress update date, even if more recent).  The date at the top of the vaccines page showed the wordpress update date only.

This fix patches all four pages to show the _later_ of the two dates: data-publish-date and wordpress-publish-date.

Normally, with no editing going on, the date will reflect the data-publish date. But if a mid-day or mid-week wordpress edit happens, the date will reflect that (until the next pipeline data update).