### PR TITLE
Writing and parsing additional date info into pre-rendered SVGs.

### DIFF
--- a/pages/_includes/main.njk
+++ b/pages/_includes/main.njk
@@ -322,7 +322,12 @@ let svg_path = 'https://files.covid19.ca.gov/img/generated/sparklines/';
 function getSVG(file,selector) {
   fetch(svg_path + file).then(function(response) {
     return response.text().then(function(text) {
-      document.querySelector(selector).innerHTML = text;
+      let targetEl = document.querySelector(selector);
+      if(targetEl) {
+        targetEl.innerHTML = text;
+        let svg_about = targetEl.querySelector('svg').getAttribute('about');
+        console.log("SVG ABOUT: ",svg_about);
+      }
     });
   });
 }

--- a/pages/manual-content/chart-tester.html
+++ b/pages/manual-content/chart-tester.html
@@ -36,7 +36,12 @@
 function getSVG(file,selector) {
   fetch(file).then(function(response) {
     return response.text().then(function(text) {
-      document.querySelector(selector).innerHTML = text;
+      let targetEl = document.querySelector(selector);
+      if(targetEl) {
+        targetEl.innerHTML = text;
+        let svg_about = targetEl.querySelector('svg').getAttribute('about');
+        console.log("SVG ABOUT: ",svg_about);
+      }
     });
   });
 }

--- a/src/js/chart-renderer/charts/cagov-chart-dashboard-sparkline/index.js
+++ b/src/js/chart-renderer/charts/cagov-chart-dashboard-sparkline/index.js
@@ -122,6 +122,8 @@ class CAGovDashboardSparkline extends window.HTMLElement {
                           'right_y_fmt':'integer',
                           'published_date': this.metadata.PUBLISHED_DATE,
                           'render_date': getSnowflakeStyleDate(0),
+                          'last_date': bar_series[0].DATE,
+                          'first_date': bar_series[bar_series.length-1].DATE,
                           'chart_options': this.chartOptions,
                         };
       console.log("RENDERING CHART",this.chartConfigFilter, this.chartConfigKey);

--- a/src/js/chart-renderer/charts/cagov-chart-dashboard-sparkline/sparkline.js
+++ b/src/js/chart-renderer/charts/cagov-chart-dashboard-sparkline/sparkline.js
@@ -113,6 +113,8 @@ export default function renderChart({
   crop_floor = true,
   published_date = "YYYY-MM-DD",
   render_date = "YYYY-MM-DD",
+  first_date = "YYYY-MM-DD",
+  last_date = "YYYY-MM-DD",
   root_id = "barid",
   chart_options = {bar_color:'#FF0000',line_color:'#00FF00',stroke_width:10},
  } )  
@@ -122,7 +124,7 @@ export default function renderChart({
     .select(this.querySelector(".svg-holder"))
     .append("svg");
 
-  this.svg.attr("about","DATA_PUBLISHED_DATE:" + published_date + ",RENDER_DATE:" + render_date)
+  this.svg.attr("about","DATA_PUBLISHED_DATE:" + published_date + ",RENDER_DATE:" + render_date+ ",FIRST_DATE:" + first_date+ ",LAST_DATE:" + last_date)
           .attr('xmlns','http://www.w3.org/2000/svg');
 
   // this.svg.selectAll("g").remove();

--- a/src/js/dashboard/index.js
+++ b/src/js/dashboard/index.js
@@ -35,6 +35,8 @@ function getSVG(file,selector) {
       let targetEl = document.querySelector(selector);
       if(targetEl) {
         targetEl.innerHTML = text;
+        let svg_about = targetEl.querySelector('svg').getAttribute('about');
+        console.log("SVG ABOUT: ",svg_about);
       }
     });
   });


### PR DESCRIPTION
This is writing the rendered date range into the "about" field of pre-rendered sparkline SVGs.

The plan is to start displaying these dates in the tracker boxes, next week.  

After evaluating several ways to store and retrieve this information (including computing them dynamically from available sources), I've found this to be a good place to store it, since it will help insure the preloaded SVGs and the displayed dates stay in sync, and shouldn't incur a network penalty. It also keeps the date logic in one place, rather than duplicating it across multiple scripts.

Most other methods run the risk of the dates and the displayed charts being temporarily out of sync during morning updates, due to our use of pre-rendered SVGs.