### PR TITLE
Dropped width: 100vw from wp-block-separator

### DIFF
--- a/src/css/_general.scss
+++ b/src/css/_general.scss
@@ -1602,7 +1602,7 @@ li.active ul.nav.bd-sidenav {
 /* Wordpress Separator */
 
 .wp-block-separator {
-  border-top: 1px solid #000;
+  border-top: 1px solid $black;
   margin: 5rem calc(50% - 50vw);
 }
 

--- a/src/css/_general.scss
+++ b/src/css/_general.scss
@@ -1601,7 +1601,7 @@ li.active ul.nav.bd-sidenav {
 
 /* Wordpress Separator */
 .wp-block-separator {
-  width: 100vw;
+  // width: 100vw; // causes an unsightly gap on RTL languages and has no apparent effect on LTR pages.
   margin-left: calc(50% - 50vw);
   border-top: 1px solid $black;
   margin-top: 5rem;

--- a/src/css/_general.scss
+++ b/src/css/_general.scss
@@ -1600,13 +1600,12 @@ li.active ul.nav.bd-sidenav {
 }
 
 /* Wordpress Separator */
+
 .wp-block-separator {
-  // width: 100vw; // causes an unsightly gap on RTL languages and has no apparent effect on LTR pages.
-  margin-left: calc(50% - 50vw);
-  border-top: 1px solid $black;
-  margin-top: 5rem;
-  margin-bottom: 5rem;
+  border-top: 1px solid #000;
+  margin: 5rem calc(50% - 50vw);
 }
+
 .wp-block-separator.noborder {
   border:none;
   background-color:#FFF;


### PR DESCRIPTION
This removes an unsightly gap from Arabic (or any RTL language) pages. 

No apparent effect observed on LTR pages.

Thanks to @carterm for catching this and identifying the fix!