### PR TITLE
PREVIEW — Aligning averages on left/right axes for cases, deaths, total-tests.

### DIFF
--- a/src/js/dashboard/charts/common/cagov-dashboard-chart.js
+++ b/src/js/dashboard/charts/common/cagov-dashboard-chart.js
@@ -191,6 +191,7 @@ export default class CAGovDashboardChart extends window.HTMLElement {
 
     const renderOptions = this.setupRenderOptions();
     renderOptions.lineAndBarsSameScale = this.chartOptions.lineAndBarsSameScale;
+    renderOptions.alignAverages = this.chartOptions.alignAverages;
     renderOptions.month_modulo = this.chartConfigTimerange == 'all-time'? 3 : 1;
 
     renderChart.call(this, renderOptions);

--- a/src/js/dashboard/charts/common/histogram.js
+++ b/src/js/dashboard/charts/common/histogram.js
@@ -460,6 +460,7 @@ function drawLineLegend(svg, line_legend, line_data, xline, yline) {
     pending_legend = null,
     month_modulo = 3,
     lineAndBarsSameScale = false,
+    alignAverages = false,
     root_id = "barid" } )  {
 
     console.log("renderChart",root_id);
@@ -531,15 +532,26 @@ function drawLineLegend(svg, line_legend, line_data, xline, yline) {
         max_y_domain = 1;
       }
       // console.log("line range", root_id, min_y_domain, max_y_domain);
-      if (time_series_state_line && !lineAndBarsSameScale) {
-        max_y_domain = Math.max(max_y_domain, d3.max(time_series_state_line, d=> d.VALUE));
+      if (alignAverages) {
+        const avgBars = d3.mean(time_series_bars, d=> d.VALUE);
+        const avgLines = d3.mean(scale_series, d=> d.VALUE);
+        const scale = avgLines / avgBars;
+        max_y_domain = this.ybars.domain()[1] * scale;
+        console.log("Aligning averages scale=",scale,avgLines,avgBars,max_y_domain);
+        this.yline = d3
+          .scaleLinear()
+          .domain([0, max_y_domain])  // d3.max(data, d => d.METRIC_VALUE)]).nice()
+          .range([this.dimensions.height - this.dimensions.margin.bottom, this.dimensions.margin.top]);
+      } else {
+        if (time_series_state_line && !lineAndBarsSameScale) {
+          max_y_domain = Math.max(max_y_domain, d3.max(time_series_state_line, d=> d.VALUE));
+        }
+        // console.log("max_y_domain", max_y_domain);
+        this.yline = d3
+          .scaleLinear()
+          .domain([min_y_domain, max_y_domain]).nice()  // d3.max(data, d => d.METRIC_VALUE)]).nice()
+          .range([this.dimensions.height - this.dimensions.margin.bottom, this.dimensions.margin.top]);
       }
-      // console.log("max_y_domain", max_y_domain);
-      this.yline = d3
-        .scaleLinear()
-        .domain([min_y_domain, max_y_domain]).nice()  // d3.max(data, d => d.METRIC_VALUE)]).nice()
-        .range([this.dimensions.height - this.dimensions.margin.bottom, this.dimensions.margin.top]);
-
     }
 
 

--- a/src/js/dashboard/charts/common/line-chart-config.json
+++ b/src/js/dashboard/charts/common/line-chart-config.json
@@ -12,7 +12,8 @@
       "filterKeys": ["episode","reported"],
       "timeKeys": ["all-time","months-6","days-90"],
       "usesStateData": true,
-      "lineAndBarsSameScale":false
+      "lineAndBarsSameScale":false,
+      "alignAverages":true
     },
     "reported": {
       "chartName": "cagov-chart-dashboard-confirmed-cases",
@@ -25,7 +26,8 @@
       "filterKeys": ["episode","reported"],
       "timeKeys": ["all-time","months-6","days-90"],
       "usesStateData": true,
-      "lineAndBarsSameScale":false
+      "lineAndBarsSameScale":false,
+      "alignAverages":true
     }
   },
   "deaths": {
@@ -41,7 +43,8 @@
       "filterKeys": ["death","reported"],
       "timeKeys": ["all-time","months-6","days-90"],
       "usesStateData": true,
-      "lineAndBarsSameScale":false
+      "lineAndBarsSameScale":false,
+      "alignAverages":true
     },
     "reported": {
       "chartName": "cagov-chart-dashboard-confirmed-deaths",
@@ -54,7 +57,8 @@
       "filterKeys": ["death","reported"],
       "timeKeys": ["all-time","months-6","days-90"],
       "usesStateData": true,
-      "lineAndBarsSameScale":false
+      "lineAndBarsSameScale":false,
+      "alignAverages":true
     }
   },
   "tests": {
@@ -70,7 +74,8 @@
       "filterKeys": ["testing","reported"],
       "timeKeys": ["all-time","months-6","days-90"],
       "usesStateData": true,
-      "lineAndBarsSameScale":false
+      "lineAndBarsSameScale":false,
+      "alignAverages":true
     },
     "reported": {
       "chartName": "cagov-chart-dashboard-total-tests",
@@ -83,7 +88,8 @@
       "filterKeys": ["testing","reported"],
       "timeKeys": ["all-time","months-6","days-90"],
       "usesStateData": true,
-      "lineAndBarsSameScale":false
+      "lineAndBarsSameScale":false,
+      "alignAverages":true
     }
   },
   "positivity": {
@@ -99,7 +105,8 @@
       "timeKeys": ["all-time","months-6","days-90"],
       "usesStateData": true,
       "rightMarginOverride": 20,
-      "lineAndBarsSameScale":true
+      "lineAndBarsSameScale":true,
+      "alignAverages":false
     }
   },
   "patients": {
@@ -115,7 +122,8 @@
       "filterKeys": ["hospitalized","icu"],
       "timeKeys": ["all-time","months-6","days-90"],
       "rightMarginOverride": 20,
-      "lineAndBarsSameScale":true
+      "lineAndBarsSameScale":true,
+      "alignAverages":false
     },
     "icu": {
       "chartName": "cagov-chart-dashboard-patients",
@@ -128,7 +136,8 @@
       "filterKeys": ["hospitalized","icu"],
       "timeKeys": ["all-time","months-6","days-90"],
       "rightMarginOverride": 20,
-      "lineAndBarsSameScale":true
+      "lineAndBarsSameScale":true,
+      "alignAverages":false
     }
   },
   "icu-beds": {
@@ -143,7 +152,8 @@
       "rootId": "icu-beds",
       "timeKeys": ["all-time","months-6","days-90"],
       "rightMarginOverride": 20,
-      "lineAndBarsSameScale":true
+      "lineAndBarsSameScale":true,
+      "alignAverages":false
     }
   },
   "desktop": {


### PR DESCRIPTION
-- APPROVED FOR PRODUCTION --

Before this patch, the left-right axes on several charts operated independently and were not aligned. This computes the average for the data on each side (bars and lines) and scales the line-axis so that the averages align.

BEFORE
![image](https://user-images.githubusercontent.com/287977/153254366-8d8664b8-f0a0-43b3-ad6e-0a659d1a82e5.png)

AFTER
![image](https://user-images.githubusercontent.com/287977/153254424-30816688-1adc-43be-b003-e7b10ea7c18e.png)
