### PR TITLE
Including OTHER in variants chart.

### DIFF
--- a/src/js/variants/charts/cagov-chart-dashboard-variant-chart/variantchart-config.json
+++ b/src/js/variants/charts/cagov-chart-dashboard-variant-chart/variantchart-config.json
@@ -18,7 +18,8 @@
           "Epsilon",
           "Lambda",
           "Mu",
-          "Omicron"
+          "Omicron",
+          "Other"
         ],
         "labels":"         alpha    beta       gamma     delta    epsilon   lambda     mu       omicron   other", 
         "series_colors8_old2":["#1F2574","#72267C","#DC4567","#C23371",          "#F96E55","#FFCF44","#32CC14","#888888"],
@@ -31,7 +32,7 @@
         "skip_zeros": true,
         "timeKeys": ["all-time","months-6","days-90"],
         "pending_days": 0,
-        "omit_other": true,
+        "omit_other": false,
         "normalize": true
       }
     },

--- a/src/js/variants/charts/cagov-chart-dashboard-variant-chart/variantchart-config.json
+++ b/src/js/variants/charts/cagov-chart-dashboard-variant-chart/variantchart-config.json
@@ -33,7 +33,7 @@
         "timeKeys": ["all-time","months-6","days-90"],
         "pending_days": 0,
         "omit_other": false,
-        "normalize": true
+        "normalize": false
       }
     },
     "desktop": {


### PR DESCRIPTION
Prior to this patch, the Other category was not displayed in the Variants chart (and data was renormalized to fix it).

Due to the coming omicron-mutation, there is renewed interest in displaying this field. So the JSON options have been changed to include it again, and turn off the re-normalization feature.

Intent is to merge this in Thursday Feb 17 at 9:20 to coincide with data rollout.


