### PR TITLE
Aria fixes for Equity and Variants page -- IN PROGRESS --

### DIFF
--- a/src/js/equity-dash/charts/data-completeness/draw.js
+++ b/src/js/equity-dash/charts/data-completeness/draw.js
@@ -72,7 +72,7 @@ function drawBars(svg, x, y, yAxis, stackedData, color, data, tooltip, translati
     .attr("height", "30px")
     .attr("fill", "transparent")  // use rgb(255,0,0,0.5) for debugging
     .attr("tabindex", "0")
-    .attr("aria-label", (d, i) => {
+    /* .attr("aria-label", (d, i) => {
       let percentNotMissing = d.data.NOT_MISSING
         ? parseFloat(d.data.NOT_MISSING * 100).toFixed(1) + "%"
         : 0;
@@ -100,7 +100,7 @@ function drawBars(svg, x, y, yAxis, stackedData, color, data, tooltip, translati
       caption = caption.replace( /\s+/g, ' ');
       caption = caption.trim();
       return caption;
-    })
+    }) */
 
     .on("mouseover focus", function(event, d) {
       d3.select(this).transition();

--- a/src/js/equity-dash/charts/relative-percentage-by-100k/draw-chart.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-100k/draw-chart.js
@@ -60,7 +60,7 @@ export default function drawBars(stackedData, data, statewideRatePer100k) {
     .attr("height", "30px")
     .attr("fill", "transparent")  // use rgb(255,0,0,0.5) for debugging
     .attr("tabindex", "0")
-    .attr("aria-label", (d, i) => {
+    /* .attr("aria-label", (d, i) => {
       let caption = component.toolTipCaption(
         d.data.DEMOGRAPHIC_SET_CATEGORY,
         d.data.METRIC_VALUE_PER_100K
@@ -81,7 +81,7 @@ export default function drawBars(stackedData, data, statewideRatePer100k) {
       caption = caption.trim();
       // console.log("Set 100k aria-label",caption);
       return caption;
-    })
+    }) */
     .on("mouseover focus", function (event, d) {
       d3.select(this).transition();
 

--- a/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart.js
@@ -42,9 +42,7 @@ export default function drawBars({
     .attr("y", (d) => y(d.data.DEMOGRAPHIC_SET_CATEGORY) + 20)
     .attr("width", (d) => x2(d[1]) - x2(d[0]))
     .attr("height", "10px")
-
     .attr("tabindex", "0")
-    .attr("aria-label", (d, i) => 'unused_caption1')
     ;
 
   // Yellow bars rendered second

--- a/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart.js
+++ b/src/js/equity-dash/charts/relative-percentage-by-pop/draw-chart.js
@@ -74,7 +74,7 @@ export default function drawBars({
     .attr("height", "40px")
     .attr("fill", "transparent")  // use rgb(255,0,0,0.5) for debugging
     .attr("tabindex", "0")
-    .attr("aria-label", (d, i) => {
+    /* .attr("aria-label", (d, i) => {
       let caption = component.getToolTipCaption1(d, selectedMetric);
       // remove tags and trim excess whitespace
       caption = caption.replace( /(<([^>]+)>)/ig, ' ');
@@ -82,7 +82,7 @@ export default function drawBars({
       caption = caption.trim();
       // console.log("Set pop aria label",caption);
       return caption;
-    })
+    }) */
     .on("mouseover focus", function (event, d) {
       d3.select(this).transition();
       // Rephrase as "X people make up XX% of cases statewide and XX% of California's population"

--- a/src/js/equity-dash/charts/social-determinants/draw.js
+++ b/src/js/equity-dash/charts/social-determinants/draw.js
@@ -108,7 +108,7 @@ function writeBars(component, svg, data, x, y, width, tooltip) {
       .attr("width", x.bandwidth())
       .attr("id", (d, i) => "barid-"+i)
       .attr("tabindex", "0")
-      .attr("aria-label", (d, i) => `${component.ariaLabel(d)}`)
+      // .attr("aria-label", (d, i) => `${component.ariaLabel(d)}`)
       .on("mouseover focus", function(event, d, i) {
         d3.select(this).style("fill", "#003D9D");
         // problem the svg is not the width in px in page as the viewbox width
@@ -141,7 +141,7 @@ function rewriteBars(component, svg, data, x, y) {
     .attr("x", (d, i) => x(i))
     .attr("y", d => y(d.CASE_RATE_PER_100K))
     .attr("height", d => y(0) - y(d.CASE_RATE_PER_100K))
-    .attr("aria-label", (d, i) => `${component.ariaLabel(d)}`)
+    // .attr("aria-label", (d, i) => `${component.ariaLabel(d)}`)
 }
 
 function writeBarLabels(component, svg, data, x, y, sparkline) {

--- a/src/js/vaccines/charts/cagov-chart-vaccines-hpi-by-dose/index.js
+++ b/src/js/vaccines/charts/cagov-chart-vaccines-hpi-by-dose/index.js
@@ -148,7 +148,8 @@ class CAGovVaccinesHPIDose extends window.HTMLElement {
             .attr("width", d => xScale.bandwidth())
             .attr("height", d => (yScale(0)-yScale(d.COMBINED_DOSES/totalDosesAllQuartiles)))
             .attr("tabindex", "0")
-            .attr("aria-label", (d, i) => `${this.ariaLabel(d, totalDosesAllQuartiles)}`);
+            // .attr("aria-label", (d, i) => `${this.ariaLabel(d, totalDosesAllQuartiles)}`)
+            ;
 
     groups
         .append("text")

--- a/src/js/vaccines/charts/cagov-chart-vaccines-hpi-by-people/index.js
+++ b/src/js/vaccines/charts/cagov-chart-vaccines-hpi-by-people/index.js
@@ -174,7 +174,8 @@ class CAGovVaccinesHPIPeople extends window.HTMLElement {
             .attr("width", d => xScaleInner.bandwidth())
             .attr("height", d => (yScale(0)-yScale(d.D[d.KEY])))
             .attr("tabindex", "0")
-            .attr("aria-label", (d, i) => `${this.ariaLabel(d)}`);
+            // .attr("aria-label", (d, i) => `${this.ariaLabel(d)}`)
+            ;
 
     let barcaps1 = groups
         .selectAll("g")

--- a/src/js/variants/charts/cagov-chart-dashboard-variant-chart/variantchart-template.js
+++ b/src/js/variants/charts/cagov-chart-dashboard-variant-chart/variantchart-template.js
@@ -21,14 +21,14 @@ import css from "./variantchart.scss";
     // Set 'selected' attribute based on current chart config.
     const optionAttribute = (optionValues[i] === configFilter || optionValues[i] === timerange) ? 'selected = "selected"' : '';
     // Contatenate options.
-    optionsMarkup += `<option role="option" ${optionAttribute} value="${optionValues[i]}">${label}</option>`;
+    optionsMarkup += `<option aria-label="${label}" ${optionAttribute} value="${optionValues[i]}">${label}</option>`;
     i += 1;
   });
 
   // @todo a11y: Each select should have a label with a for="" attribute.
   return `
     <cagov-chart-filter-select class="js-filter-${configKey}">
-      <select data-type="${selectType}">
+      <select aria-label="pull down menu" data-type="${selectType}">
         ${optionsMarkup}
       </select>
     </cagov-chart-filter-select>


### PR DESCRIPTION
This addresses all addressable AxeDev issues, improving the site score.  

However, work continues on making the bar charts accessible.  I need to find a better method of providing narrated captions for the bars -- the method we were using (aria-label on rects) is not valid.

* Removes invalid aria-labels from rects on bar charts.
* Removes invalid roles from pull-down menus.
