### PR TITLE
install this amp package so es5 build works

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "covid19",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
@@ -26,6 +27,7 @@
       },
       "devDependencies": {
         "@11ty/eleventy": "^1.0.0-beta.2",
+        "@ampproject/remapping": "^2.1.2",
         "@babel/core": "^7.17.0",
         "@babel/preset-env": "^7.16.11",
         "@cagov/11ty-serverless-preview-mode": "^1.0.12",
@@ -155,6 +157,17 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.0.tgz",
       "integrity": "sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg==",
       "dev": true
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
+      "integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.16.7",
@@ -21870,9 +21883,9 @@
       }
     },
     "@ampproject/remapping": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.1.tgz",
-      "integrity": "sha512-Aolwjd7HSC2PyY0fDj/wA/EimQT4HfEnFYNp5s9CQlrdhyvWTtvZ5YzrUPu6R6/1jKiUlxu8bUhkdSnKHNAHMA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
+      "integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
       "requires": {
         "@jridgewell/trace-mapping": "^0.3.0"
       }

--- a/package.json
+++ b/package.json
@@ -55,10 +55,11 @@
     "whatwg-fetch": "^3.6.2"
   },
   "devDependencies": {
-    "@cagov/11ty-serverless-preview-mode": "^1.0.12",
     "@11ty/eleventy": "^1.0.0-beta.2",
+    "@ampproject/remapping": "^2.1.2",
     "@babel/core": "^7.17.0",
     "@babel/preset-env": "^7.16.11",
+    "@cagov/11ty-serverless-preview-mode": "^1.0.12",
     "@fullhuman/postcss-purgecss": "^4.1.3",
     "@playwright/test": "^1.19.1",
     "@rollup/plugin-babel": "^5.3.0",


### PR DESCRIPTION
The build was broken complaining about this package while trying to do the transpiled version. This was required for multiple packages so I installed it locally and errors went away.

Long term solution is to stop transpiling and make sure the site is still navigable without javascript on any device.

Short term fix is to obey the transpiler and deliver tons of additional dependencies to the rarer, least powerful user agents