### PR TITLE
fix accordions on search and update event tracking

### DIFF
--- a/pages/_includes/search.njk
+++ b/pages/_includes/search.njk
@@ -65,7 +65,7 @@
 
 			let answers = [...data[0].answers];
 			if(answers[0].questions.length > 0) {
-				let html = `<h4>Quick answers</h4>
+				let html = `<h3>Quick answers</h3>
 					${answers.map(function(a) {
 						if(a.answer.indexOf('platform.twitter.com/widgets') > -1) {
 							let newScript = document.createElement("script");
@@ -74,15 +74,12 @@
 						}
 						if(a.questions.length > 0) {
 							return `<cagov-accordion>
-								<div class="card"><button class="card-header accordion-alpha" type="button" aria-expanded="false">
-										<div class="accordion-title">${a.questions.join(' ')}</div>
-									</button>
-									<div class="card-container collapsed">
-										<div class="card-body">
-											<p>${a.answer}</p>
-										</div>
+								<details>
+									<summary><h4>${a.questions.join(' ')}</h4></summary>
+									<div class="accordion-body">
+										${a.answer}
 									</div>
-								</div>
+								</details>
 							</cagov-accordion>`;
 						} else {
 							return '';

--- a/src/js/anchor-events/src/index.js
+++ b/src/js/anchor-events/src/index.js
@@ -14,8 +14,8 @@
 class CAGOVAnchorsToEvents extends window.HTMLElement {
   connectedCallback() {
     this.selector = this.dataset.selector ? this.dataset.selector : 'cagov-accordion';
-    this.cancelSelector = this.dataset.cancelSelector ? this.dataset.cancelSelector : 'button[aria-expanded="true"]';
-    this.eventTargetSelector = this.dataset.eventTargetSelector ? this.dataset.eventTargetSelector  : 'button.card-header.accordion-alpha';
+    this.cancelSelector = this.dataset.cancelSelector ? this.dataset.cancelSelector : 'cagov-accordion details[open] summary';
+    this.eventTargetSelector = this.dataset.eventTargetSelector ? this.dataset.eventTargetSelector  : 'cagov-accordion details summary';
     this.eventType = this.dataset.eventType ? this.dataset.eventType : 'click';
     this.runConditions();
     this.reviewPageLinks()

--- a/src/js/anchor-events/test/index.test.js
+++ b/src/js/anchor-events/test/index.test.js
@@ -27,20 +27,14 @@ describe('accordion exists', () => {
 
       <a id="clicktest" href="#communications">auto anchor link</a>
 
-      <cagov-accordion class="prog-enhanced">
-      <div class="card">
-        <button class="card-header accordion-alpha" type="button" aria-expanded="false">
-          <div class="accordion-title">
-          <h4 id="communications"><span class="ca-gov-icon-mobile"></span> Communications infrastructure</h4>
-          </div></div>
-        </button>
-        <div class="card-container" aria-hidden="true">
-          <div class="card-body">
-            <p style="height: 500px;">some text which takes up a lot of space</p>
+      <cagov-accordion>
+        <details>
+          <summary>Accordion title</summary>
+          <div class="accordion-body">
+            accordion content
           </div>
-        </div>
-      </div>
-    </cagov-accordion>
+        </details>
+      </cagov-accordion>
     <cagov-anchor-events />
     </div>`);
 

--- a/src/js/tracking-you/index.js
+++ b/src/js/tracking-you/index.js
@@ -6,8 +6,8 @@ export default function setupAnalytics() {
 
   document.querySelectorAll('cagov-accordion').forEach((acc) => {
     acc.addEventListener('click',function() {
-      if(this.querySelector('.accordion-title')) {
-        reportGA('accordion', this.querySelector('.accordion-title').textContent.trim())
+      if(this.querySelector('summary')) {
+        reportGA('accordion', this.querySelector('summary').textContent.trim())
       }
     });
   });


### PR DESCRIPTION
This fixes some bugs introduced with the accordion upgrades;

- Accordions used for quick answers in search results started defaulting to open. This is the failure state and is caused by a js error looking for new markup while search results pages uses old accordions. This is a friendly way to fail but not desired because they take up tons of space above basic search results.
- Accordion open tracking code wasn't updated to look for new selector pattern
- Automated E2E tests need to use new accordion pattern