### PR TITLE
Increased hover area on tooltips.

### DIFF
--- a/src/js/dashboard/charts/common/histogram.js
+++ b/src/js/dashboard/charts/common/histogram.js
@@ -350,15 +350,7 @@ function getDataIndexByX(data, xScale, yScale, bardata, yLine, linedata, xy)
     let ydi = yScale.invert(y);
     if (ydi >= 0 && ydi <= yScale.domain()[1] ) {
       let idi = Math.round(xdi);
-      let yp = yScale(bardata[idi].VALUE);
-      if (y >= yp-2) {
-        return idi;
-      }
-      let yp2 = yLine(linedata[idi].VALUE);
-      let yd = Math.abs(yp2-y);
-      if (yd < 6) {
-        return idi;
-      }
+      return idi;
     }
   }
   return null;


### PR DESCRIPTION
Currently, on the state-dashboard, tool-tips appear when you hover certain parts of the histogram charts (cases, deaths, tests, hospitalizations).  These tool-tips show specific values for the data in the charts for the date you are hovering over.  Like so:

<img width="419" alt="CleanShot 2022-04-18 at 15 00 01" src="https://user-images.githubusercontent.com/287977/163884397-ef76f195-23a2-4e40-aa16-b80a524dfc80.png">

At the moment, the site is programmed so that these tool-tips only appear when you mouse over specific graphic elements (bars and lines).  

For some of the charts, this is too restrictive, especially when the bars and lines are low.  This patch deletes several lines of code and modifies the "hover area" to include the entire chart area.   This makes it easier to discover and use the tool-tip feature.

The change in the "hover area" is as shown:

![image](https://user-images.githubusercontent.com/287977/163884434-64aee595-1ff2-49df-94ad-accd917319e7.png)
