### PR TITLE
Fixed y-axis scaling and tick issues for health equity chart.

### DIFF
--- a/src/js/equity-dash/charts/healthy-places-index/index.js
+++ b/src/js/equity-dash/charts/healthy-places-index/index.js
@@ -252,7 +252,6 @@ class CAGOVChartD3Lines extends window.HTMLElement {
       1,
       max_y_ab * 1.4
     );
-    console.log("Healthy places: max-y",max_y*100, max_y_1, max_y_2);
 
     let y = d3
       .scaleLinear()

--- a/src/js/equity-dash/charts/healthy-places-index/index.js
+++ b/src/js/equity-dash/charts/healthy-places-index/index.js
@@ -32,7 +32,7 @@ class CAGOVChartD3Lines extends window.HTMLElement {
       desktop: {
         width: 613,
         height: 355,
-        margin: { top: 30, right: 24, bottom: 40, left: 30 },
+        margin: { top: 30, right: 24, bottom: 40, left: 36 },
         legendPosition: {
           x: 300,
           y: 10
@@ -41,7 +41,7 @@ class CAGOVChartD3Lines extends window.HTMLElement {
       tablet: {
         width: 440,
         height: 355,
-        margin: { top: 30, right: 24, bottom: 40, left: 30 },
+        margin: { top: 30, right: 24, bottom: 40, left: 36 },
         legendPosition: {
           x: 160,
           y: 18
@@ -50,7 +50,7 @@ class CAGOVChartD3Lines extends window.HTMLElement {
       mobile: {
         width: 440,
         height: 600,
-        margin: { top: 30, right: 24, bottom: 40, left: 30 },
+        margin: { top: 30, right: 24, bottom: 40, left: 36 },
         legendPosition: {
           x: 160,
           y: 18
@@ -59,7 +59,7 @@ class CAGOVChartD3Lines extends window.HTMLElement {
       retina: {
         width: 320,
         height: 450,
-        margin: { top: 30, right: 24, bottom: 40, left: 30 },
+        margin: { top: 30, right: 24, bottom: 40, left: 36 },
         legendPosition: {
           x: 100,
           y: 18
@@ -244,10 +244,15 @@ class CAGOVChartD3Lines extends window.HTMLElement {
       .range([this.chartBreakpointValues.margin.left, this.chartBreakpointValues.width - this.chartBreakpointValues.margin.right]);
 
     // don't allow max_y to exceed 100%, since that would be silly
+    let max_y_1 =  d3.max(missing_eq_data ? data : data2, (d) => d.METRIC_VALUE);
+    let max_y_2 =  d3.max(data, (d) => d.METRIC_VALUE);
+    let max_y_ab = Math.max(max_y_1, max_y_2);
+
     let max_y = Math.min(
       1,
-      d3.max(missing_eq_data ? data : data2, (d) => d.METRIC_VALUE) * 1.4
+      max_y_ab * 1.4
     );
+    console.log("Healthy places: max-y",max_y*100, max_y_1, max_y_2);
 
     let y = d3
       .scaleLinear()
@@ -280,7 +285,8 @@ class CAGOVChartD3Lines extends window.HTMLElement {
         .call((g) => g.select(".domain").remove());
 
     let nbr_ticks = Math.min(10, 1 + Math.floor(max_y * 100));
-    let y_tick_fmt = d3.format(".0%");
+    nbr_ticks = Math.max(5,nbr_ticks);
+    let y_tick_fmt = d3.format(".1%");
 
     let yAxis = (g) =>
       g


### PR DESCRIPTION
Fixes a Y-axis scaling problem, and increases tick count / formatting for these low numbers we are currently seeing.

Before:
<img width="813" alt="CleanShot 2022-04-21 at 13 16 17" src="https://user-images.githubusercontent.com/287977/164545329-3c20c015-35c9-435b-9d1e-0da825466339.png">

After:
<img width="788" alt="CleanShot 2022-04-21 at 13 17 11" src="https://user-images.githubusercontent.com/287977/164545467-b8510c3a-b984-4e00-8bc7-3e8e0a80bc8b.png">
