### PR TITLE
Autocomplete patch, eliminates use of mark, and fixes mark bug.

### DIFF
--- a/src/js/common/search/index.js
+++ b/src/js/common/search/index.js
@@ -73,25 +73,35 @@ class CAGovCountySearch extends window.HTMLElement {
     rtlOverride(this, 'div', 'ltr');
   }
 
-  setupAutoComp(fieldSelector, fieldName, aList) {
-    let component = this;
-    const awesompleteSettings = {
-      autoFirst: true,
-      filter: function (text, input) {
-        return Awesomplete.FILTER_CONTAINS(text, input.match(/[^,]*$/)[0]);
-      },
-      item: function (text, input) {
-        return Awesomplete.ITEM(text, input.match(/[^,]*$/)[0]);
-      },
-      replace: function (selectedSuggestion) {
-        let typedInValue = selectedSuggestion.value;
-        component.processCountySearchInput(typedInValue);
-      },
-      list: aList
-    };
 
-    const aplete = new Awesomplete(fieldSelector, awesompleteSettings)
+setupAutoComp(fieldSelector, fieldName, aList) {
+  let component = this;
+
+  // custom item handler, based on this suggestion
+  // https://github.com/LeaVerou/awesomplete/issues/16939
+  function myItem(text) {
+    var li = document.createElement('li')
+    li.setAttribute('aria-selected', 'false')
+    li.innerHTML = text
+    return li
   }
+
+  const awesompleteSettings = {
+    autoFirst: true,
+    filter: function (text, input) {
+      var res = Awesomplete.FILTER_CONTAINS(text, input.match(/[^,]*$/)[0]);
+      return res;
+    },
+    item: myItem,
+    replace: function (selectedSuggestion) {
+      let typedInValue = selectedSuggestion.value;
+      component.processCountySearchInput(typedInValue);
+    },
+    list: aList
+  };
+
+  const aplete = new Awesomplete(fieldSelector, awesompleteSettings)
+}
 
   emitCounty() {
     // jbum: If we get statewide: true, reset the dialog to as it appears on refresh


### PR DESCRIPTION
**NOTE: Before merging, let's test all instances of auto-complete.**

Prior to this patch, there were two issues with auto-complete on county-search.

1) A recently introduced bug (of undetermined cause) caused it fail on AWS hosted instances, returning a mark that contained angle brackets, like so:

<img width="184" alt="CleanShot 2022-05-18 at 14 26 10" src="https://user-images.githubusercontent.com/287977/169158545-65b0f9a9-9cf6-408e-96ae-55a755c278ef.png">

2) Even when working, the results looked wonky, since they inserted a space and highlighted region.

This work-around patch replaces the awesomplete.ITEM function with a simplified version which makes the results look better.

<img width="195" alt="CleanShot 2022-05-18 at 14 27 03" src="https://user-images.githubusercontent.com/287977/169158657-0a513857-8fde-49f0-867e-7d2ce01314d3.png">
