### PR TITLE
Forcing staging build for staging workflow. 

### DIFF
--- a/.github/workflows/staging_aws.yml
+++ b/.github/workflows/staging_aws.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Build 11ty
         run: |
           npm install
-          npm run build
+          npm run build:staging
 
       # Push built site files to S3 production bucket    
       - name: Configure AWS Credentials


### PR DESCRIPTION
Oddly, our staging build's NODE_ENV environment variable has stopped registering as 'staging' or 'developemnt' -- it is coming up as 'undefined' which is causing staging-specific logic to be skipped.  A symptom of this is the staging.covid19 equity page is loading the production data.  In the below snapshot, the pathname of the json should be on the 'to-review' path, not 'reviewed'.

Evidence:
<img width="649" alt="CleanShot 2022-06-15 at 10 07 38" src="https://user-images.githubusercontent.com/287977/173885368-8c157cfa-17d9-4997-bcdd-e078424a4b9c.png">

This patch forces a staging build.  After merging, I'll apply this to the staging branch as well.