### PR TITLE
update page feedback

### DIFF
--- a/pages/_includes/footer.njk
+++ b/pages/_includes/footer.njk
@@ -14,7 +14,7 @@ ga('tracker3.send', 'pageview');
 
 <pagerating-section id="pagerating-section">
 	<cagov-pagefeedback 
-	data-endpoint-url="https://fa-go-alph-d-002.azurewebsites.net/WasHelpful"
+	data-endpoint-url="https://feedback.innovation.ca.gov/sendfeedback"
 	data-question="{{text.is_this_page_useful}}"
 	data-yes="{{text.answer_yes}}"
 	data-no="{{text.answer_no}}"


### PR DESCRIPTION
We have deployed new page feedback architecture running in AWS.

This new data store is now being consumed by the data team and powers the dashboards used by site reviewers

This update will change the covid site frontend to post to our new AWS endpoints