### PR TITLE
Remove 'Quick Answers' result from search

### DIFF
--- a/pages/_includes/search.njk
+++ b/pages/_includes/search.njk
@@ -44,8 +44,9 @@
   const query = decodeURIComponent(urlq.replace(/\+/g,' ').toLowerCase());
 	document.querySelectorAll('input[name=q]').forEach(x=>x.value=query);
 </script> 
-
+<!--
 <script>
+	/***
 	const myWebSearchStartingCallback = query => {
 		if(!query) return;
 
@@ -99,9 +100,11 @@
 				}
 			}
 		});
-	}
+
+	} 
 	myWebSearchStartingCallback(query)
-</script>
+	***/
+</script> -->
 <script>
 	String.prototype.hashCode = function() {
 		var hash = 0, i, chr;


### PR DESCRIPTION
The Azure QnA Maker service is being sunsetted.  This removes the 'Quick Answers' feature from search results, which relies on that feature.  The removal of the feature was approved by Josh Pocus.

Once this is merged, we can disable the fa-go-covid-answ-001 trigger on Azure, as well as take down our QnA Maker setup (I suggest waiting a week or two).

