### PR TITLE
Updated Sass version to fix issue with local build.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "linkedom": "^0.14.25",
         "md5": "^2.3.0",
         "node-fetch": "^2.6.9",
-        "node-sass": "^8.0.0",
+        "node-sass": "^9.0.0",
         "npm-run-all": "^4.1.5",
         "onchange": "^7.1.0",
         "postcss-url": "^10.1.3",
@@ -13675,9 +13675,9 @@
       "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg=="
     },
     "node_modules/node-sass": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-8.0.0.tgz",
-      "integrity": "sha512-jPzqCF2/e6JXw6r3VxfIqYc8tKQdkj5Z/BDATYyG6FL6b/LuYBNFGFVhus0mthcWifHm/JzBpKAd+3eXsWeK/A==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-9.0.0.tgz",
+      "integrity": "sha512-yltEuuLrfH6M7Pq2gAj5B6Zm7m+gdZoG66wTqG6mIZV/zijq3M2OO2HswtT6oBspPyFhHDcaxWpsBm0fRNDHPg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -13700,7 +13700,7 @@
         "node-sass": "bin/node-sass"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/node-sass/node_modules/@npmcli/fs": {
@@ -33893,9 +33893,9 @@
       "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg=="
     },
     "node-sass": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-8.0.0.tgz",
-      "integrity": "sha512-jPzqCF2/e6JXw6r3VxfIqYc8tKQdkj5Z/BDATYyG6FL6b/LuYBNFGFVhus0mthcWifHm/JzBpKAd+3eXsWeK/A==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-9.0.0.tgz",
+      "integrity": "sha512-yltEuuLrfH6M7Pq2gAj5B6Zm7m+gdZoG66wTqG6mIZV/zijq3M2OO2HswtT6oBspPyFhHDcaxWpsBm0fRNDHPg==",
       "dev": true,
       "requires": {
         "async-foreach": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "linkedom": "^0.14.25",
     "md5": "^2.3.0",
     "node-fetch": "^2.6.9",
-    "node-sass": "^8.0.0",
+    "node-sass": "^9.0.0",
     "npm-run-all": "^4.1.5",
     "onchange": "^7.1.0",
     "postcss-url": "^10.1.3",


### PR DESCRIPTION
I was seeing an error message on my arm64 Macintosh when attempting to run the site locally with a more recent version of node.  Upgrading Sass from 8 -> 9 fixed it.

![image](https://github.com/cagov/covid19/assets/287977/791b7fec-8649-4133-887e-9fc32dac13c2)


