### PR TITLE
Support use of uppercase in branch names for PR previews.

### DIFF
--- a/.github/workflows/eleventy_build_pr.yml
+++ b/.github/workflows/eleventy_build_pr.yml
@@ -33,7 +33,7 @@ jobs:
         run: echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF})" >> $GITHUB_ENV
       - name: Escape branch name for URL
         shell: bash
-        run: echo "URLSAFE_BRANCH_NAME=$(echo ${BRANCH_NAME} | sed 's|[^A-Za-z0-9-]|-|g' | sed -E 's|-*([A-Za-z0-9]*.*[A-Za-z0-9]+)-*|\1|' | cut -c 1-63)" >> $GITHUB_ENV
+        run: echo "URLSAFE_BRANCH_NAME=$(echo ${BRANCH_NAME} | tr '[:upper:]' '[:lower:]' | sed 's|[^A-Za-z0-9-]|-|g' | sed -E 's|-*([A-Za-z0-9]*.*[A-Za-z0-9]+)-*|\1|' | cut -c 1-63)" >> $GITHUB_ENV
       - name: Report escaped branch name
         shell: bash
         run: echo ${URLSAFE_BRANCH_NAME}


### PR DESCRIPTION
Support use of uppercase in branch names for PR previews.

Prior to this fix, if a branch name contained any uppercase letters, the PR Preview feature would 404.